### PR TITLE
ci: pin GitHub actions and fix toolchain install

### DIFF
--- a/.github/workflows/apple-build.yml
+++ b/.github/workflows/apple-build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print local-versus-runner boundary
         run: |
           echo "Local host baseline: ${LOCAL_HOST_BASELINE}"
@@ -31,7 +31,7 @@ jobs:
         run: bash scripts/ci/run_apple_build_smoke.sh
       - name: Enforce Apple workflow runtime budget
         run: bash scripts/ci/check_ci_runtime_budget.sh .artifacts/ci
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ success() || failure() }}
         with:
           name: ci-metrics-apple-build-smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print local-versus-runner boundary
         run: |
           echo "Local host baseline: ${LOCAL_HOST_BASELINE}"
@@ -36,12 +36,12 @@ jobs:
     timeout-minutes: 20
     needs: toolchain-validate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install and verify toolchains
         run: bash scripts/ci/install_toolchains.sh
       - name: Run Flutter quality checks
         run: bash scripts/ci/run_quality_checks.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ success() || failure() }}
         with:
           name: ci-metrics-flutter-static-checks
@@ -54,10 +54,10 @@ jobs:
     timeout-minutes: 15
     needs: toolchain-validate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Dockerized Firebase emulator smoke
         run: bash scripts/ci/run_emulator_smoke.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ success() || failure() }}
         with:
           name: ci-metrics-emulator-smoke
@@ -70,12 +70,12 @@ jobs:
     timeout-minutes: 20
     needs: toolchain-validate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install and verify toolchains
         run: bash scripts/ci/install_toolchains.sh
       - name: Run Android build smoke
         run: bash scripts/ci/run_android_build_smoke.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ success() || failure() }}
         with:
           name: ci-metrics-android-build-smoke
@@ -91,7 +91,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validate Trivy policy
         run: bash scripts/ci/run_quality_checks.sh --validate-trivy-policy
       - name: Mark vulnerability scan start
@@ -106,7 +106,7 @@ jobs:
           start_epoch="$(cat .artifacts/ci/durations/vulnerability-scan.started-at)"
           end_epoch="$(date +%s)"
           printf "%s\n" "$((end_epoch - start_epoch))" > .artifacts/ci/durations/vulnerability-scan.seconds
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ success() || failure() }}
         with:
           name: ci-metrics-vulnerability-scan
@@ -123,8 +123,8 @@ jobs:
       - android-build-smoke
       - vulnerability-scan
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ci-metrics-*
           path: .artifacts/downloaded

--- a/scripts/ci/check_ci_runtime_budget.sh
+++ b/scripts/ci/check_ci_runtime_budget.sh
@@ -9,7 +9,10 @@ budget_seconds="${CI_RUNTIME_BUDGET_SECONDS:-$VOCAS_CI_RUNTIME_BUDGET_SECONDS}"
 
 vocas_log "enforcing CI runtime budget for runner classes ${VOCAS_APPROVED_LINUX_RUNNER_CLASS} and ${VOCAS_APPROVED_APPLE_RUNNER_CLASS}"
 
-mapfile -t duration_files < <(find "$search_root" -name "*.seconds" -type f | sort)
+duration_files=()
+while IFS= read -r duration_file; do
+  duration_files+=("$duration_file")
+done < <(find "$search_root" -name "*.seconds" -type f | sort)
 (( ${#duration_files[@]} > 0 )) || vocas_die "no CI duration files found under $search_root"
 
 total_seconds=0

--- a/scripts/ci/install_toolchains.sh
+++ b/scripts/ci/install_toolchains.sh
@@ -39,6 +39,7 @@ fi
 
 firebase_bin="$(vocas_npm_global_bin)/firebase"
 firebase_package_dir="$(vocas_npm_global_prefix)/lib/node_modules/firebase-tools"
+firebase_packages_root="$(dirname "$firebase_package_dir")"
 firebase_package_manifest="$firebase_package_dir/package.json"
 firebase_version=""
 if [[ -f "$firebase_package_manifest" ]]; then
@@ -46,8 +47,9 @@ if [[ -f "$firebase_package_manifest" ]]; then
 fi
 
 if [[ "$firebase_version" != "$VOCAS_APPROVED_FIREBASE_TOOLS_VERSION" ]]; then
+  mkdir -p "$firebase_packages_root"
   rm -rf "$firebase_package_dir" "$firebase_bin"
-  find "$(dirname "$firebase_package_dir")" -maxdepth 1 -type d -name '.firebase-tools-*' -exec rm -rf {} +
+  find "$firebase_packages_root" -maxdepth 1 -type d -name '.firebase-tools-*' -exec rm -rf {} +
   npm install --global --no-fund --no-audit "firebase-tools@${VOCAS_APPROVED_FIREBASE_TOOLS_VERSION}"
 fi
 


### PR DESCRIPTION
## Summary
- pin GitHub Actions to exact commit SHAs from current stable releases
- update checkout/upload/download artifact actions to newer stable versions
- harden toolchain install so firebase-tools cleanup does not fail when the npm-global directory is absent

## Verification
- bash scripts/ci/install_toolchains.sh
- actrun lint .github/workflows/ci.yml
- actrun lint .github/workflows/apple-build.yml
- actrun workflow run .github/workflows/ci.yml --local --include-dirty --trust
- actrun workflow run .github/workflows/apple-build.yml --local --include-dirty --trust