### PR TITLE
[codex] Add reusable emulator image workflow and admin bypass rule

### DIFF
--- a/scripts/ci/github_ruleset_payload.json
+++ b/scripts/ci/github_ruleset_payload.json
@@ -12,6 +12,13 @@
       "exclude": []
     }
   },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
   "rules": [
     {
       "type": "pull_request",


### PR DESCRIPTION
## What changed
- add a dedicated `emulator-image-prepare` workflow and reusable emulator image preparation scripts
- separate emulator image preparation from `emulator-smoke` consumption and add stage-based diagnostics
- update CI/runtime budget handling and supporting documentation for the reusable image path
- allow repository admins to bypass the protected-branch ruleset when merging through pull requests

## Why
The CI emulator path was rebuilding inline during smoke runs, which made failures slower and harder to diagnose. This change moves image preparation into a dedicated path, reuses prepared images in smoke runs, and records stage-specific diagnostics. It also updates the ruleset source-of-truth so admin merge bypass behavior matches the requested repository policy.

## Impact
- `emulator-smoke` can consume a prepared image instead of rebuilding inline
- maintainers get clearer diagnostics for image resolution, startup, and readiness timing
- ruleset behavior is documented and reproducible from the repository payload

## Root cause
The previous CI flow coupled image build and smoke execution in the same path, which made runner-time failures and performance regressions difficult to isolate.

## Validation
- `bash -n scripts/lib/vocastock_env.sh scripts/lib/vocastock_ci_helpers.sh scripts/ci/prepare_emulator_image.sh scripts/ci/resolve_emulator_image_ref.sh scripts/ci/run_emulator_smoke.sh scripts/firebase/start_emulators.sh scripts/firebase/stop_emulators.sh scripts/firebase/smoke_local_stack.sh scripts/firebase/measure_emulator_ready_time.sh scripts/ci/check_ci_runtime_budget.sh scripts/ci/run_local_stack_smoke.sh`
- `VOCAS_IMAGE_PREPARE_ALLOW_PUBLISH=0 VOCAS_IMAGE_PREPARE_EXPORT_ARTIFACT=1 bash scripts/ci/prepare_emulator_image.sh`
- `bash scripts/ci/run_local_stack_smoke.sh`
- `bash scripts/firebase/measure_emulator_ready_time.sh`
- `bash scripts/ci/check_ci_runtime_budget.sh .artifacts`
- `actrun workflow run .github/workflows/emulator-image-prepare.yml --local --include-dirty --trust`
- `actrun workflow run .github/workflows/ci.yml --local --include-dirty --trust`
- `bash scripts/ci/apply_github_ruleset.sh lihs-ie/vocastock 15155215`
