### PR TITLE
docs: add domain modeling and auth design specs

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/008-auth-session-design"
+  "feature_directory": "specs/005-domain-modeling"
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/002-flutter-dev-env"
+  "feature_directory": "specs/008-auth-session-design"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # vocastock Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-16
+Auto-generated from all feature plans. Last updated: 2026-04-17
 
 ## Active Technologies
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/development/*.md` (003-architecture-design)
@@ -12,6 +12,12 @@ Auto-generated from all feature plans. Last updated: 2026-04-16
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/` (005-domain-modeling)
 - Flutter 3.41.5 (stable), Dart SDK bundled with Flutter 3.41.5, shell scripts, YAML, GitHub Actions YAML + Flutter SDK 3.41.5, Xcode 26.4, Android Studio 2025.3, CocoaPods 1.16.2, Temurin JDK 21.0.10+7 LTS, Node.js 24.14.1 LTS, Firebase CLI 15.2.1, Docker Desktop 4.69.0, GitHub-hosted runners, Trivy Action 0.33.1 (005-domain-modeling)
 - Git-managed repository files, Docker volumes for emulator data, GitHub Actions artifacts for CI reports (005-domain-modeling)
+- Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/005-domain-modeling/` (007-backend-command-design)
+- Git-managed repository files、設計上で参照する抽象的な command-side persistence、workflow state store、identity reference store (007-backend-command-design)
+- Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/` (008-auth-session-design)
+- Git-managed repository files、設計上で参照する抽象的な auth account store、external identity link store、session store、actor resolution store (008-auth-session-design)
+- Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend (008-auth-session-design)
+- Git-managed repository files、設計上で参照する抽象的な auth account store、external identity link store、session store、actor / learner resolution store、Firebase Authentication user records (008-auth-session-design)
 
 - Markdown 1.x, YAML, JSON + Spec Kit workflow, existing domain documents, requirements memo, ADR memo (001-complete-domain-model)
 
@@ -54,12 +60,10 @@ an aggregate's own identifier field must be `identifier`, and related identifier
 fields must use concept names such as `bank`, `entry`, or `image`.
 
 ## Recent Changes
-- 005-domain-modeling: Added Flutter 3.41.5 (stable), Dart SDK bundled with Flutter 3.41.5, shell scripts, YAML, GitHub Actions YAML + Flutter SDK 3.41.5, Xcode 26.4, Android Studio 2025.3, CocoaPods 1.16.2, Temurin JDK 21.0.10+7 LTS, Node.js 24.14.1 LTS, Firebase CLI 15.2.1, Docker Desktop 4.69.0, GitHub-hosted runners, Trivy Action 0.33.1
-- 005-domain-modeling: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
-- 005-domain-modeling: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
+- 008-auth-session-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend
+- 008-auth-session-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
+- 007-backend-command-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/005-domain-modeling/`
 
 
 <!-- MANUAL ADDITIONS START -->
-- 002-flutter-dev-env: ローカル host baseline は `macOS 26.4.1 / Flutter 3.41.5 / Xcode 26.4 / Android Studio 2025.3 / Docker Desktop 4.69.0`
-- 002-flutter-dev-env: 検証コマンドは `bash scripts/bootstrap/verify_macos_toolchain.sh`、`bash scripts/bootstrap/validate_local_setup.sh`、`bash scripts/firebase/measure_emulator_ready_time.sh`
 <!-- MANUAL ADDITIONS END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-17
 - Git-managed repository files、設計上で参照する抽象的な auth account store、external identity link store、session store、actor resolution store (008-auth-session-design)
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend (008-auth-session-design)
 - Git-managed repository files、設計上で参照する抽象的な auth account store、external identity link store、session store、actor / learner resolution store、Firebase Authentication user records (008-auth-session-design)
+- Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/` (009-sense-modeling)
 
 - Markdown 1.x, YAML, JSON + Spec Kit workflow, existing domain documents, requirements memo, ADR memo (001-complete-domain-model)
 
@@ -60,9 +61,9 @@ an aggregate's own identifier field must be `identifier`, and related identifier
 fields must use concept names such as `bank`, `entry`, or `image`.
 
 ## Recent Changes
+- 009-sense-modeling: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
 - 008-auth-session-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend
 - 008-auth-session-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
-- 007-backend-command-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/005-domain-modeling/`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/external/adr.md
+++ b/docs/external/adr.md
@@ -3,26 +3,50 @@
 ## UI
 
 - ユーザーが直に触れる部分
+- `VocabularyExpression` の登録、完了済み `Explanation` の閲覧、完了済み `VisualImage` の閲覧を扱う
+- 生成中または失敗中は状態のみを表示し、中間生成物は表示しない
 
-## 英単語存在チェック
+## Learner identity resolution
 
-- 登録される英単語が本当に存在するのかを判定する
-- すでに登録済みの英単語か判定する
+- 外部 identity を `Learner` へ解決する
+- 認証そのものは扱わず、domain には学習者解決結果だけを渡す
 
-## 解説生成
+## VocabularyExpression validation
 
-- 英単語から解説を生成する
-- 生成には指定のAIサービスを利用する
+- 登録対象の英語表現が本当に存在するのかを判定する
+- `VocabularyExpressionText` を `NormalizedVocabularyExpressionText` へ正規化する
 
-## 解説リーダー
+## Registration lookup
 
-- 生成された解説を取得する
+- 同一学習者内で、すでに登録済みの `VocabularyExpression` かを判定する
 
-## 画像生成
+## Explanation generation
 
-- 解説から英単語を視覚的に理解できる画像を生成する
-- 生成した画像は何らかのストレージサービスに永続化し、ストレージ上で画像を一意に識別する情報を返す
+- `VocabularyExpression` から解説を生成する
+- 生成には指定の AI サービスを利用する
+- 完了時のみ解説 payload を返す
 
-## 画像存在確認
+## Explanation reader
 
-- 英単語がすでに画像が生成されているかを判定する
+- `VocabularyExpression.currentExplanation` に対応する完了済み解説を取得する
+- 必要に応じて解説履歴を取得する
+
+## Image generation
+
+- 完了済み `Explanation` から英語表現を視覚的に理解できる画像を生成する
+- 完了時のみ画像 payload を返す
+
+## Asset storage
+
+- 生成した画像を何らかのストレージサービスに永続化する
+- ストレージ上で画像を一意に識別する情報と再取得参照を返す
+
+## Pronunciation media
+
+- 発音サンプルを参照可能な形で返す
+
+## Deferred Scope
+
+- 認証、account lifecycle、session 管理は auth/session 設計で扱う
+- command 受理、retry / regenerate の dispatch、workflow orchestration は backend command 設計で扱う
+- query model、永続化実装、ベンダー固有 adapter はこの ADR の対象外とする

--- a/docs/external/adr.md
+++ b/docs/external/adr.md
@@ -3,8 +3,9 @@
 ## UI
 
 - ユーザーが直に触れる部分
-- `VocabularyExpression` の登録、完了済み `Explanation` の閲覧、完了済み `VisualImage` の閲覧を扱う
+- `VocabularyExpression` の登録、`Sense` で整理された完了済み `Explanation` の閲覧、完了済み `VisualImage` の閲覧を扱う
 - 生成中または失敗中は状態のみを表示し、中間生成物は表示しない
+- 画像表示は `Explanation.currentImage` の単一参照に従い、複数 current image を同時公開しない
 
 ## Learner identity resolution
 
@@ -23,6 +24,7 @@
 ## Explanation generation
 
 - `VocabularyExpression` から解説を生成する
+- 完了時は `Explanation` とその配下の `Sense` を返す
 - 生成には指定の AI サービスを利用する
 - 完了時のみ解説 payload を返す
 
@@ -34,12 +36,15 @@
 ## Image generation
 
 - 完了済み `Explanation` から英語表現を視覚的に理解できる画像を生成する
+- 必要に応じて特定の `Sense` を描写対象として受け付ける
 - 完了時のみ画像 payload を返す
+- `Explanation.currentImage` は単一参照のまま維持し、複数 current image は後続 scope とする
 
 ## Asset storage
 
 - 生成した画像を何らかのストレージサービスに永続化する
 - ストレージ上で画像を一意に識別する情報と再取得参照を返す
+- 必要に応じて explanation 全体画像か `Sense` 対応画像かを metadata で区別できる
 
 ## Pronunciation media
 
@@ -50,3 +55,4 @@
 - 認証、account lifecycle、session 管理は auth/session 設計で扱う
 - command 受理、retry / regenerate の dispatch、workflow orchestration は backend command 設計で扱う
 - query model、永続化実装、ベンダー固有 adapter はこの ADR の対象外とする
+- 複数 current image の同時公開、meaning gallery、`Explanation` 直下の裸画像配列は follow-on scope とする

--- a/docs/external/requirements.md
+++ b/docs/external/requirements.md
@@ -2,22 +2,32 @@
 
 ## ユーザー
 
-- ユーザーが英単語・連なる英単語を登録する
-- すでに登録済みでなければ解説生成を行う
+- ユーザーが自分の `VocabularyExpression` を登録する
+  - `VocabularyExpression` は単語と連語を同一概念として扱う
+  - 重複登録判定は同一学習者内の `NormalizedVocabularyExpressionText` で行う
+- 未登録であれば、登録した `VocabularyExpression` に対して解説生成を行う
   - 時間がかかるため非同期で行う
-- ユーザーは生成された解説から英単語の視覚的なイメージ画像を生成できる
+- ユーザーは完了済み `Explanation` から視覚的イメージ画像を生成できる
   - 時間がかかるため非同期で行う
   - 生成された画像は何らかのストレージサービスに永続化される
 - ユーザーには解説と画像の完全な生成結果のみを表示する
   - 生成中または失敗中は状態のみを表示し、中間生成結果は表示しない
-- 画像が生成されている解説は画像を表示に反映する
+- 画像が生成されている解説は `currentImage` を表示に反映する
 
 ## 要件
 
-- 英単語は生成時にネイティブスピーカーがよく使うか頻出度別にレベル分けを行う
-- 品種都度別に登録した英単語を管理することができる
-- 英単語はどれだけ自分に定着したかをレベル分けで管理する
-  - 頻出度レベルとは異なる
+- `Explanation` は生成時にネイティブスピーカーがよく使うかを `Frequency` としてレベル分けする
+- `Explanation` は語彙の知的・語彙的な難度を `Sophistication` として管理する
+- `Learner` は自分が所有する `VocabularyExpression` を管理できる
+- 学習者ごとの定着度は `LearningState.proficiency` として管理する
+  - `Frequency` や `Sophistication` とは異なる概念として扱う
+- `RegistrationStatus`、`ExplanationGenerationStatus`、`ImageGenerationStatus` は別概念として管理する
+
+## Deferred Scope
+
+- 認証、credential、session 管理は auth/session 設計で扱う
+- command 受理、workflow orchestration、dispatch failure は backend command 設計で扱う
+- query model、永続化実装、外部 vendor adapter 実装は別 feature とする
 
 ## 開発基盤メモ
 

--- a/docs/external/requirements.md
+++ b/docs/external/requirements.md
@@ -7,12 +7,15 @@
   - 重複登録判定は同一学習者内の `NormalizedVocabularyExpressionText` で行う
 - 未登録であれば、登録した `VocabularyExpression` に対して解説生成を行う
   - 時間がかかるため非同期で行う
+- 完了済み `Explanation` は 1 件以上の `Sense` を持ち、多義語でも意味単位ごとに説明できる
+  - 例文とコロケーションは explanation 全体ではなく対応する `Sense` に属する
 - ユーザーは完了済み `Explanation` から視覚的イメージ画像を生成できる
   - 時間がかかるため非同期で行う
   - 生成された画像は何らかのストレージサービスに永続化される
+  - 画像は explanation 全体を代表してもよく、必要に応じて特定の `Sense` に対応してもよい
 - ユーザーには解説と画像の完全な生成結果のみを表示する
   - 生成中または失敗中は状態のみを表示し、中間生成結果は表示しない
-- 画像が生成されている解説は `currentImage` を表示に反映する
+- 画像が生成されている解説は単一の `currentImage` を表示に反映する
 
 ## 要件
 
@@ -22,12 +25,16 @@
 - 学習者ごとの定着度は `LearningState.proficiency` として管理する
   - `Frequency` や `Sophistication` とは異なる概念として扱う
 - `RegistrationStatus`、`ExplanationGenerationStatus`、`ImageGenerationStatus` は別概念として管理する
+- `Sense` は `Explanation` が所有する意味単位として管理し、`Meaning.values` を正本概念として再利用しない
+- `VisualImage` は独立集約のまま維持しつつ、必要に応じてどの `Sense` を描写する画像かを示せる
+- `Explanation.currentImage` は `Sense` の数にかかわらず単一参照のままとする
 
 ## Deferred Scope
 
 - 認証、credential、session 管理は auth/session 設計で扱う
 - command 受理、workflow orchestration、dispatch failure は backend command 設計で扱う
 - query model、永続化実装、外部 vendor adapter 実装は別 feature とする
+- 複数 current image の同時公開や meaning gallery は後続 feature で扱う
 
 ## 開発基盤メモ
 

--- a/docs/internal/domain/common.md
+++ b/docs/internal/domain/common.md
@@ -7,9 +7,17 @@
 | [learner.md](./learner.md) | `Learner`、`AuthenticationSubject` | 学習者の所有境界と外部 identity 境界 |
 | [vocabulary-expression.md](./vocabulary-expression.md) | `VocabularyExpression`、`VocabularyExpressionText`、`NormalizedVocabularyExpressionText` | 学習者が所有する登録対象と解説生成状態 |
 | [learning-state.md](./learning-state.md) | `LearningState`、`Proficiency` | 学習進捗と習熟度 |
-| [explanation.md](./explanation.md) | `Explanation`、`Frequency`、`Sophistication` | 解説本文と画像生成状態 |
-| [visual.md](./visual.md) | `VisualImage`、`StorageReference` | 画像アセットと履歴 |
+| [explanation.md](./explanation.md) | `Explanation`、`Sense`、`Frequency`、`Sophistication` | 解説本文、意味単位、画像生成状態 |
+| [visual.md](./visual.md) | `VisualImage`、`StorageReference` | 画像アセット、意味対応、履歴 |
 | [service.md](./service.md) | external port catalog | 外部責務の境界 |
+
+## Sense 導入レビューアンカー
+
+- `Sense` は `Explanation` が所有する内部エンティティである
+- `Sense` は多義語の意味単位を表し、`Meaning` は移行メモ上の旧表現としてのみ残す
+- `VisualImage` は独立集約のまま維持し、必要に応じて `sense` で意味単位を指せる
+- `Explanation.currentImage` は `Sense` 導入後も 0..1 件の単一 current 参照を維持する
+- 複数 current image の同時公開は follow-on scope とし、この文書群では扱わない
 
 ## 集約関係の概要
 
@@ -18,21 +26,25 @@ classDiagram
     class Learner
     class VocabularyExpression
     class Explanation
+    class Sense
     class VisualImage
     class LearningState
 
     Learner --> VocabularyExpression : owns
     Learner --> LearningState : tracks
     VocabularyExpression --> Explanation : currentExplanation
+    Explanation --> Sense : contains
     Explanation --> VisualImage : currentImage
+    VisualImage --> Sense : depicts
     VisualImage --> VisualImage : previousImage
     LearningState --> VocabularyExpression : vocabularyExpression
 ```
 
 - `Learner` は所有境界であり、認証方式そのものは保持しない
 - `VocabularyExpression` は学習者が所有する登録対象で、単語と連語を同一概念で扱う
-- `Explanation` は `VocabularyExpression` の完了済み解説結果を表す
-- `VisualImage` は `Explanation` に属する独立集約で、履歴を保持する
+- `Explanation` は `VocabularyExpression` の完了済み解説結果を表し、1 件以上の `Sense` を持つ
+- `Sense` は意味、状況、ニュアンス、例文、コロケーションを束ねる `Explanation` 配下の意味単位である
+- `VisualImage` は `Explanation` に属する独立集約で、必要に応じて特定の `Sense` を描写しつつ履歴を保持する
 - `LearningState` は `Learner` と `VocabularyExpression` の関係上にある習熟度専用集約である
 
 ## 正規用語と移行メモ
@@ -43,9 +55,12 @@ classDiagram
 | `LearningState` | `EntryLearningState` | 学習進捗の正規名称 |
 | `VocabularyExpressionText` | `EntryExpressionText` | 登録時の文字列表現 |
 | `NormalizedVocabularyExpressionText` | `NormalizedEntryExpressionText` | 重複判定用の正規化表現 |
+| `Sense` | `Meaning`, `Meaning.values` | `Explanation` 所有の意味単位として再編した正規名称 |
 
 - 旧称はこの移行メモ以外では使わない
 - 外部向け説明で日本語を併記する場合も、英語の正規名称は上表に合わせる
+- `Meaning` は正本概念としては維持せず、`Explanation.senses` へ置き換える
+- explanation 全体を代表する画像は `VisualImage.sense = null` で表し、意味対応のある画像だけ `sense` を持つ
 
 ## 命名規約
 
@@ -54,11 +69,13 @@ classDiagram
 - 他集約や他概念への参照フィールドは `learner`、`vocabularyExpression`、`currentExplanation`、`currentImage` のように概念名そのものを使う
 - 派生命名は `VocabularyExpression*` / `LearningState*` に統一する
 - 文字列表現の値オブジェクト名は `VocabularyExpressionText` と `NormalizedVocabularyExpressionText` を採用する
+- `Sense` の識別子は `SenseIdentifier` とし、関連参照フィールド名は `sense` を使う
 
 ## 概念分離
 
 | 概念 | 所有者 | 混同してはならない対象 |
 |---|---|---|
+| `Sense` | `Explanation` | `Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態 |
 | `Frequency` | `Explanation` | `Sophistication`、`Proficiency`、生成状態 |
 | `Sophistication` | `Explanation` | `Frequency`、`Proficiency`、登録状態 |
 | `Proficiency` | `LearningState` | `Frequency`、`Sophistication`、生成状態 |
@@ -72,10 +89,14 @@ classDiagram
 - regenerate 開始時に `currentExplanation` / `currentImage` を消してはならない
 - 新しい解説または画像が `succeeded` になった時だけ current 参照を切り替える
 - 生成中または失敗中は状態表示だけを行い、不完全な生成物は表示しない
+- `Explanation` が複数の `Sense` を持っていても、表示対象の `currentImage` は常に 0..1 件である
+- `currentImage` が `sense` を持つ場合、その `sense` は同じ `Explanation` に属する意味単位でなければならない
+- explanation 全体を代表する画像は `sense` を持たず、意味ごとの画像と同じ表示ルールに従う
 
 ## Deferred Scope / Follow-on Boundaries
 
 - credential 管理、session 管理、provider ごとの認証導線は auth/session 設計で扱う
 - command 受理、dispatch failure、workflow orchestration は backend command 設計で扱う
 - query model、永続化マッピング、adapter 実装、ベンダー固有 SDK はこの文書群の対象外とする
+- 複数 current image の同時公開、meaning gallery、`Explanation` 直下の裸画像配列は後続 feature で扱う
 - この文書群は project-wide domain language の正本であり、後続 feature はここで固定した概念境界を前提にする

--- a/docs/internal/domain/common.md
+++ b/docs/internal/domain/common.md
@@ -1,12 +1,81 @@
 # 共通ドメインモデル
 
-## タイムライン（Timeline）
+## Source-of-Truth Index
 
-|フィールド名 | 種別 |保持数 | 備考|
-|-|-|-|-|
-| createdAt | 日時 | 1 | 作成日時 |
-| updatedAt | 日時 | 1 | 更新日時 |
+| 文書 | 正本となる概念 | 役割 |
+|---|---|---|
+| [learner.md](./learner.md) | `Learner`、`AuthenticationSubject` | 学習者の所有境界と外部 identity 境界 |
+| [vocabulary-expression.md](./vocabulary-expression.md) | `VocabularyExpression`、`VocabularyExpressionText`、`NormalizedVocabularyExpressionText` | 学習者が所有する登録対象と解説生成状態 |
+| [learning-state.md](./learning-state.md) | `LearningState`、`Proficiency` | 学習進捗と習熟度 |
+| [explanation.md](./explanation.md) | `Explanation`、`Frequency`、`Sophistication` | 解説本文と画像生成状態 |
+| [visual.md](./visual.md) | `VisualImage`、`StorageReference` | 画像アセットと履歴 |
+| [service.md](./service.md) | external port catalog | 外部責務の境界 |
 
-## 不変条件
+## 集約関係の概要
 
-- 作成日時は更新日時と同じ日時か前の日時でなければならない
+```mermaid
+classDiagram
+    class Learner
+    class VocabularyExpression
+    class Explanation
+    class VisualImage
+    class LearningState
+
+    Learner --> VocabularyExpression : owns
+    Learner --> LearningState : tracks
+    VocabularyExpression --> Explanation : currentExplanation
+    Explanation --> VisualImage : currentImage
+    VisualImage --> VisualImage : previousImage
+    LearningState --> VocabularyExpression : vocabularyExpression
+```
+
+- `Learner` は所有境界であり、認証方式そのものは保持しない
+- `VocabularyExpression` は学習者が所有する登録対象で、単語と連語を同一概念で扱う
+- `Explanation` は `VocabularyExpression` の完了済み解説結果を表す
+- `VisualImage` は `Explanation` に属する独立集約で、履歴を保持する
+- `LearningState` は `Learner` と `VocabularyExpression` の関係上にある習熟度専用集約である
+
+## 正規用語と移行メモ
+
+| 正規用語 | 非推奨 / 旧称 | 補足 |
+|---|---|---|
+| `VocabularyExpression` | `Entry` | 学習者が所有する登録対象の正規名称 |
+| `LearningState` | `EntryLearningState` | 学習進捗の正規名称 |
+| `VocabularyExpressionText` | `EntryExpressionText` | 登録時の文字列表現 |
+| `NormalizedVocabularyExpressionText` | `NormalizedEntryExpressionText` | 重複判定用の正規化表現 |
+
+- 旧称はこの移行メモ以外では使わない
+- 外部向け説明で日本語を併記する場合も、英語の正規名称は上表に合わせる
+
+## 命名規約
+
+- 識別子型は必ず `XxxIdentifier` 形式にする
+- 集約自身の識別子フィールド名は常に `identifier` にする
+- 他集約や他概念への参照フィールドは `learner`、`vocabularyExpression`、`currentExplanation`、`currentImage` のように概念名そのものを使う
+- 派生命名は `VocabularyExpression*` / `LearningState*` に統一する
+- 文字列表現の値オブジェクト名は `VocabularyExpressionText` と `NormalizedVocabularyExpressionText` を採用する
+
+## 概念分離
+
+| 概念 | 所有者 | 混同してはならない対象 |
+|---|---|---|
+| `Frequency` | `Explanation` | `Sophistication`、`Proficiency`、生成状態 |
+| `Sophistication` | `Explanation` | `Frequency`、`Proficiency`、登録状態 |
+| `Proficiency` | `LearningState` | `Frequency`、`Sophistication`、生成状態 |
+| `RegistrationStatus` | `VocabularyExpression` | 解説生成状態、画像生成状態 |
+| `ExplanationGenerationStatus` | `VocabularyExpression` | `ImageGenerationStatus`、`RegistrationStatus` |
+| `ImageGenerationStatus` | `Explanation` | `ExplanationGenerationStatus`、`Proficiency` |
+
+## 非同期表示の共通ルール
+
+- ユーザーへ見せてよい生成物は完了済みの `currentExplanation` と `currentImage` だけである
+- regenerate 開始時に `currentExplanation` / `currentImage` を消してはならない
+- 新しい解説または画像が `succeeded` になった時だけ current 参照を切り替える
+- 生成中または失敗中は状態表示だけを行い、不完全な生成物は表示しない
+
+## Deferred Scope / Follow-on Boundaries
+
+- credential 管理、session 管理、provider ごとの認証導線は auth/session 設計で扱う
+- command 受理、dispatch failure、workflow orchestration は backend command 設計で扱う
+- query model、永続化マッピング、adapter 実装、ベンダー固有 SDK はこの文書群の対象外とする
+- この文書群は project-wide domain language の正本であり、後続 feature はここで固定した概念境界を前提にする

--- a/docs/internal/domain/explanation.md
+++ b/docs/internal/domain/explanation.md
@@ -1,203 +1,193 @@
-# 解説ドメインモデル
+# Explanation ドメインモデル
 
-# 値オブジェクト
+## この文書の役割
 
-## 解説識別子
+- `Explanation` を `VocabularyExpression` に紐づく知識集約として定義する
+- `Frequency` と `Sophistication` の所有者を `Explanation` に固定する
+- `currentImage` と `imageGeneration` の責務を明確化する
 
-- 英単語解説を一意に識別する値オブジェクト
-- 英単語そのものを表す
+## 関連文書
 
-### 不変条件
+- [common.md](./common.md)
+- [vocabulary-expression.md](./vocabulary-expression.md)
+- [visual.md](./visual.md)
+- [service.md](./service.md)
 
-- 1文字以上
+## 値オブジェクト
 
-## 頻出レベル (FrequencyLevel)
+### ExplanationIdentifier
 
-- 以下の値を列挙する
-  - よく使う（often）
-  - 使う（sometimes）
-  - あまり使わない（rarely）
-  - 全然使わない（hardlyEver）
+- 解説を一意に識別する値オブジェクト
+- 英語表現そのものではなく、生成済み解説結果を識別する
 
-## 頻出度（Frequency）
+### FrequencyLevel
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-|level | 頻出レベル| 1 | |
-| reason | 理由 | 1 | |
+- `often`
+- `sometimes`
+- `rarely`
+- `hardlyEver`
 
-### 不変条件
+### Frequency
 
-- 理由は1文字以上255文字以下
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| level | FrequencyLevel | 1 | 頻出度レベル |
+| reason | 文字列 | 1 | 判定理由 |
 
-## 知的レベル（SophisticationLevel）
+不変条件:
 
-- 以下の値を列挙する
-  - かなり知的（advanced）
-  - 知的（intermediate）
-  - 少し知的（basic）
-  - あまり知的ではない（veryBasic）
+- `reason` は 1 文字以上 255 文字以下
 
-## 知的度（Sophistication）
+### SophisticationLevel
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| level | 知的レベル| 1 | |
-| reason | 理由 | 1 | |
+- `advanced`
+- `intermediate`
+- `basic`
+- `veryBasic`
 
-## 習熟度（Proficiency）
+### Sophistication
 
-- 話せる（Fluent）
-- 定着（Internalized）
-- インプット済み（Learned）
-- インプット中（Learning）
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| level | SophisticationLevel | 1 | 知的度レベル |
+| reason | 文字列 | 1 | 判定理由 |
 
-## 意味（meaning）
+不変条件:
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| values | 単語の意味のリスト | 1..n| |
-| situation | 使用する状況 | 1 | |
-| nuance | ニュアンス | 1 | |
+- `reason` は 1 文字以上 255 文字以下
 
-### 不変条件
+### Meaning
 
-- 使用する状況は1文字以上255文字以下
-- ニュアンスは1文字以上255文字以下
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| values | 意味の一覧 | 1..n | 主要な意味の列挙 |
+| situation | 文字列 | 1 | 使用する状況 |
+| nuance | 文字列 | 1 | ニュアンス |
 
-## 発音記号（PhoneticSymbols）
+不変条件:
 
-- 米国の発音記号を表す
+- `values` は 1 件以上
+- `situation` は 1 文字以上 255 文字以下
+- `nuance` は 1 文字以上 255 文字以下
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| weak | 弱形 | 1| |
-| strong | 強形 | 1 | |
+### PhoneticSymbols
 
-### 不変条件
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| weak | 文字列 | 1 | 弱形 |
+| strong | 文字列 | 1 | 強形 |
 
-- 弱形は1文字以上255文字以下
-- 強形は1文字以上255文字以下
+不変条件:
 
-## 発音（Pronunciation）
+- `weak` は 1 文字以上 255 文字以下
+- `strong` は 1 文字以上 255 文字以下
 
-- 米国の発音を表す
+### Pronunciation
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| symbols | 発音記号 | 1| |
-| sample | URL | 1 | 外部リソースの発音動画のリンク |
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| symbols | PhoneticSymbols | 1 | 発音記号 |
+| sample | 参照 | 0..1 | 外部メディア参照 |
 
-## コロケーション（Collocation）
+### Collocation
 
-- 英単語のコロケーションを表す
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| value | 文字列 | 1 | コロケーション |
+| meaning | 文字列 | 1 | 意味 |
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| value | コロケーション内容 | 1| |
-| meaning | コロケーションの意味 | 1 | |
+不変条件:
 
-### 不変条件
+- `value` は 1 文字以上 255 文字以下
+- `meaning` は 1 文字以上 255 文字以下
 
-- コロケーション内容は1文字以上255文字以下
-- 意味は1文字以上255文字以下
+### ExampleSentence
 
-## 例文（ExampleSentence）
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| value | 文字列 | 1 | 例文 |
+| meaning | 文字列 | 1 | 日本語説明 |
+| pronunciation | 文字列 | 1 | 例文の発音 |
 
-- 英単語を使った例文を表す
+不変条件:
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| value | 例文の値 | 1| |
-| meaning | 例文の意味 | 1 | |
-| pronunciation | 例文の発音（全て弱形） | 1 | |
+- `value` は 1 文字以上 255 文字以下
+- `meaning` は 1 文字以上 255 文字以下
 
-### 不変条件
+### SimilarExpression
 
-- 例文の値は1文字以上255文字以下
-- 意味は1文字以上255文字以下
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| value | 文字列 | 1 | 類似表現 |
+| meaning | 文字列 | 1 | 意味・ニュアンス |
+| comparison | 文字列 | 1 | 元の `VocabularyExpression` との比較 |
 
-## イメージ（Image）
+不変条件:
 
-- 英単語を視覚的に表現する画像を表す
-- 値はURLである
+- `value`、`meaning`、`comparison` は 1 文字以上 255 文字以下
 
-## 類似表現（SimilarExpression）
+### Etymology
 
-- 生成元の英単語の類似表現を表す
+- 1 文字以上 255 文字以下の文字列
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| value | 類似表現の値 | 1| |
-| meaning | 類似表現の意味・ニュアンス | 1 | |
-| comparison | 生成元の英単語との比較 | 1 | |
+### ImageGenerationStatus
 
-### 不変条件
+- `pending`
+- `running`
+- `succeeded`
+- `failed`
 
-- 値は1文字以上255文字以下
-- 意味は1文字以上255文字以下
-- 比較は1文字以上255文字以下
+## 集約
 
+### Explanation
 
-## 語源（Etymology）
+- `VocabularyExpression` に紐づく生成済み解説を表す知識集約
+- ユーザーへ表示する本文と、画像生成の current 参照を保持する
 
-- 1文字以上255文字以下の文字列
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| identifier | ExplanationIdentifier | 1 | 解説識別子 |
+| vocabularyExpression | VocabularyExpressionIdentifier | 1 | 元の登録対象 |
+| meaning | Meaning | 1 | 意味のまとまり |
+| pronunciation | Pronunciation | 1 | 発音情報 |
+| frequency | Frequency | 1 | 頻出度 |
+| sophistication | Sophistication | 1 | 知的度 |
+| collocations | Collocation の一覧 | 1..10 | コロケーション |
+| examples | ExampleSentence の一覧 | 1..3 | 例文 |
+| etymology | Etymology | 1 | 語源 |
+| similarities | SimilarExpression の一覧 | 1..5 | 類似表現 |
+| imageGeneration | ImageGenerationStatus | 1 | 画像生成状態 |
+| currentImage | VisualImageIdentifier | 0..1 | 現在表示中の完了済み画像 |
+| timeline | Timeline | 1 | 作成・更新日時 |
 
-# 集約
+不変条件:
 
-## 解説（Explanation）
+- `vocabularyExpression` は常に 1 つの `VocabularyExpression` を参照する
+- `frequency` と `sophistication` は `Explanation` が所有する
+- `Proficiency` を持ってはならない
+- `currentImage` は同じ `Explanation` に属する完了済み `VisualImage` だけを参照できる
+- `currentImage` が未設定でも、`imageGeneration` は状態を保持できる
 
-- 英単語の解説を表す集約
+## 画像生成ライフサイクル
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| identifier | 解説識別子 | 1| |
-| meaning | 意味 | 1 | |
-| image | 視覚的イメージ | 0..1 | |
-| pronunciation   | 発音 | 1 | |
-| frequency |頻出度 | 1  | |
-| sophistication | 知的度 | 1  | |
-| collocations| コロケーションのリスト | 1..10  | |
-| examples | 例文のリスト | 1..3  | |
-| etymology| 語源 | 1 | |
-| similarities | 類似表現のリスト | 1..5 | |
-| timeline | タイムライン | 1 | |
+- `pending -> running -> succeeded | failed`
+- `failed -> pending` は retry として許可する
+- `succeeded -> running` は regenerate として許可する
+- regenerate 開始時に `currentImage` を消してはならない
+- 新しい画像が `succeeded` になった時だけ `currentImage` を切り替える
+- `failed` 時は、直前の完了済み `currentImage` があれば継続表示してよい
 
-### 振る舞い
+## 表示ルール
 
-- 画像を生成する（GenerateImage）
-  - 画像生成イベントを発行する
-  - すでに画像を持つ場合は例外を発する
+- ユーザーへ表示してよい画像は完了済みの `currentImage` のみ
+- 画像生成中または失敗中は状態だけを表示できる
+- 未完了画像、不完全 payload、中間結果は表示してはならない
 
-- 画像を再生成する（RegenerateImage）
-  - 画像再生成イベントを発行する
-  - 画像を持たない場合は例外を発する
+## リポジトリ
 
-### リポジトリ
+### ExplanationRepository
 
-解説リポジトリ（ExplanationRepository）
-
-- 識別子で集約を単一取得する（find）
-- 検索条件に合致する集約の一覧を取得する（search）
-- 識別子を指定して集約を破棄する（terminate）
-- 集約を永続化する（persist）
-
-# ドメインイベント
-
-## 画像生成イベント（GeneratedImage）
-
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| identifier | 解説識別子 | 1| |
-| image | 視覚的表現画像識別子 | 1 |
-| occurredAt | 発生日時 | 1 | |
-
-## 画像再生成イベント（RegeneratedImage）
-
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| identifier | 解説識別子 | 1| |
-| before | 視覚的表現画像識別子 | 1 |
-| after | 視覚的表現画像識別子 | 1 |
-| occurredAt | 発生日時 | 1 | |
-
+- `find(identifier)`
+- `findCurrentByVocabularyExpression(vocabularyExpression)`
+- `listByVocabularyExpression(vocabularyExpression)`
+- `persist(explanation)`

--- a/docs/internal/domain/explanation.md
+++ b/docs/internal/domain/explanation.md
@@ -3,15 +3,17 @@
 ## この文書の役割
 
 - `Explanation` を `VocabularyExpression` に紐づく知識集約として定義する
+- `Sense` を `Explanation` 所有の意味単位として定義する
 - `Frequency` と `Sophistication` の所有者を `Explanation` に固定する
 - `currentImage` と `imageGeneration` の責務を明確化する
+- meaning-to-image mapping の正本を [visual.md](./visual.md) と分担して固定する
 
 ## 関連文書
 
-- [common.md](./common.md)
+- [common.md](./common.md) - project-wide 用語、`Meaning` から `Sense` への移行メモ、単一 `currentImage` ルール
 - [vocabulary-expression.md](./vocabulary-expression.md)
-- [visual.md](./visual.md)
-- [service.md](./service.md)
+- [visual.md](./visual.md) - `VisualImage.sense`、履歴、current handoff 条件
+- [service.md](./service.md) - sense-aware image generation を扱う外部ポート
 
 ## 値オブジェクト
 
@@ -19,6 +21,11 @@
 
 - 解説を一意に識別する値オブジェクト
 - 英語表現そのものではなく、生成済み解説結果を識別する
+
+### SenseIdentifier
+
+- 同一 `Explanation` 内の意味単位を識別する値オブジェクト
+- related-field 命名は `sense` に統一し、`senseId` や `senseIdentifier` を使わない
 
 ### FrequencyLevel
 
@@ -55,20 +62,6 @@
 不変条件:
 
 - `reason` は 1 文字以上 255 文字以下
-
-### Meaning
-
-| フィールド名 | 種別 | 保持数 | 備考 |
-|---|---|---:|---|
-| values | 意味の一覧 | 1..n | 主要な意味の列挙 |
-| situation | 文字列 | 1 | 使用する状況 |
-| nuance | 文字列 | 1 | ニュアンス |
-
-不変条件:
-
-- `values` は 1 件以上
-- `situation` は 1 文字以上 255 文字以下
-- `nuance` は 1 文字以上 255 文字以下
 
 ### PhoneticSymbols
 
@@ -137,23 +130,47 @@
 - `succeeded`
 - `failed`
 
+## エンティティ
+
+### Sense
+
+- `Explanation` が所有する意味単位の内部エンティティ
+- explanation 全体の粗い `Meaning` ではなく、意味、状況、ニュアンス、例文、コロケーションを意味単位で束ねる
+
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| identifier | SenseIdentifier | 1 | 同一 `Explanation` 内での意味識別子 |
+| label | 文字列 | 1 | 意味を短く表す代表ラベル |
+| situation | 文字列 | 1 | 使われる状況 |
+| nuance | 文字列 | 1 | ニュアンス |
+| order | 正の整数 | 1 | 表示順序 |
+| collocations | Collocation の一覧 | 0..5 | その意味に結びつくコロケーション |
+| examples | ExampleSentence の一覧 | 0..3 | その意味に結びつく例文 |
+
+不変条件:
+
+- `label` は 1 文字以上 255 文字以下
+- `situation` は 1 文字以上 255 文字以下
+- `nuance` は 1 文字以上 255 文字以下
+- `order` は 1 以上の整数
+- `identifier` と `order` は同一 `Explanation` 内で重複してはならない
+- `collocations` と `examples` は explanation 全体ではなく、その `Sense` の意味に対応していなければならない
+
 ## 集約
 
 ### Explanation
 
 - `VocabularyExpression` に紐づく生成済み解説を表す知識集約
-- ユーザーへ表示する本文と、画像生成の current 参照を保持する
+- 1 件以上の `Sense` を持ち、ユーザーへ表示する本文と画像生成の current 参照を保持する
 
 | フィールド名 | 種別 | 保持数 | 備考 |
 |---|---|---:|---|
 | identifier | ExplanationIdentifier | 1 | 解説識別子 |
 | vocabularyExpression | VocabularyExpressionIdentifier | 1 | 元の登録対象 |
-| meaning | Meaning | 1 | 意味のまとまり |
+| senses | Sense の一覧 | 1..5 | 意味単位の一覧 |
 | pronunciation | Pronunciation | 1 | 発音情報 |
 | frequency | Frequency | 1 | 頻出度 |
 | sophistication | Sophistication | 1 | 知的度 |
-| collocations | Collocation の一覧 | 1..10 | コロケーション |
-| examples | ExampleSentence の一覧 | 1..3 | 例文 |
 | etymology | Etymology | 1 | 語源 |
 | similarities | SimilarExpression の一覧 | 1..5 | 類似表現 |
 | imageGeneration | ImageGenerationStatus | 1 | 画像生成状態 |
@@ -163,10 +180,14 @@
 不変条件:
 
 - `vocabularyExpression` は常に 1 つの `VocabularyExpression` を参照する
+- `senses` は 1 件以上 5 件以下でなければならない
+- `senses` の `identifier` と `order` は同一 `Explanation` 内で一意でなければならない
 - `frequency` と `sophistication` は `Explanation` が所有する
 - `Proficiency` を持ってはならない
 - `currentImage` は同じ `Explanation` に属する完了済み `VisualImage` だけを参照できる
+- `currentImage` が `sense` を持つ画像を指す場合、その `sense` は同じ `Explanation.senses` のいずれかでなければならない
 - `currentImage` が未設定でも、`imageGeneration` は状態を保持できる
+- explanation 全体を代表する画像を current にする場合、`VisualImage.sense` は未設定でよい
 
 ## 画像生成ライフサイクル
 
@@ -176,12 +197,14 @@
 - regenerate 開始時に `currentImage` を消してはならない
 - 新しい画像が `succeeded` になった時だけ `currentImage` を切り替える
 - `failed` 時は、直前の完了済み `currentImage` があれば継続表示してよい
+- 画像生成リクエストは explanation 全体または特定 `Sense` を対象にできるが、current 参照は常に 1 件だけである
 
 ## 表示ルール
 
 - ユーザーへ表示してよい画像は完了済みの `currentImage` のみ
 - 画像生成中または失敗中は状態だけを表示できる
 - 未完了画像、不完全 payload、中間結果は表示してはならない
+- `Explanation` が複数の `Sense` を持っていても、`currentImage` を配列化して複数同時表示してはならない
 
 ## リポジトリ
 

--- a/docs/internal/domain/learner.md
+++ b/docs/internal/domain/learner.md
@@ -1,0 +1,69 @@
+# Learner ドメインモデル
+
+## この文書の役割
+
+- `Learner` を学習者本人の所有境界として定義する
+- `VocabularyExpression` と `LearningState` の起点となる責務を固定する
+- 認証そのものを domain 外へ留めつつ、外部 identity 境界を明確にする
+
+## 関連文書
+
+- [common.md](./common.md)
+- [vocabulary-expression.md](./vocabulary-expression.md)
+- [learning-state.md](./learning-state.md)
+- [service.md](./service.md)
+
+## 値オブジェクト
+
+### LearnerIdentifier
+
+- 学習者を一意に識別する値オブジェクト
+
+### AuthenticationSubject
+
+- 外部 identity を参照する安定した subject
+- 認証方式や credential そのものではなく、外部責務と結びつく参照だけを持つ
+
+不変条件:
+
+- 同一 `AuthenticationSubject` は同一 `Learner` を指す
+- credential、password、provider session を保持してはならない
+
+## 集約
+
+### Learner
+
+- 学習者本人を表す独立集約
+- 自身が所有する `VocabularyExpression` と `LearningState` の起点となる
+
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| identifier | LearnerIdentifier | 1 | 学習者識別子 |
+| authenticationSubject | AuthenticationSubject | 1 | 外部 identity 参照 |
+| timeline | Timeline | 1 | 作成・更新日時 |
+
+不変条件:
+
+- `authenticationSubject` は stable で一意でなければならない
+- `Learner` は credential や session を保持しない
+
+## 所有境界
+
+- `Learner` は 0..n 件の `VocabularyExpression` を所有する
+- `Learner` は 0..n 件の `LearningState` を持つ
+- `VocabularyExpression` の重複判定は同一 `Learner` 境界の内側で行う
+- `LearningState` は `Learner` と `VocabularyExpression` の関係上でのみ存在できる
+
+## 外部 identity 境界
+
+- 認証方式、provider 実装、session 管理は domain 外の責務である
+- domain には `AuthenticationSubject` と `LearnerIdentityPort` の結果だけを持ち込む
+- `Learner` は auth provider の種類に依存しない
+
+## リポジトリ
+
+### LearnerRepository
+
+- `find(identifier)`
+- `findByAuthenticationSubject(authenticationSubject)`
+- `persist(learner)`

--- a/docs/internal/domain/learning-state.md
+++ b/docs/internal/domain/learning-state.md
@@ -1,0 +1,60 @@
+# LearningState ドメインモデル
+
+## この文書の役割
+
+- `LearningState` を学習進捗の正本として定義する
+- `Proficiency` を `VocabularyExpression` や `Explanation` から分離して固定する
+
+## 関連文書
+
+- [common.md](./common.md)
+- [learner.md](./learner.md)
+- [vocabulary-expression.md](./vocabulary-expression.md)
+
+## 値オブジェクト
+
+### LearningStateIdentifier
+
+- 学習状態を一意に識別する値オブジェクト
+
+### Proficiency
+
+- `Learning`
+- `Learned`
+- `Internalized`
+- `Fluent`
+
+## 集約
+
+### LearningState
+
+- 学習者ごとの習熟状態を表す集約
+- `Learner` と `VocabularyExpression` の関係上でのみ存在する
+
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| identifier | LearningStateIdentifier | 1 | 学習状態識別子 |
+| learner | LearnerIdentifier | 1 | 対象学習者 |
+| vocabularyExpression | VocabularyExpressionIdentifier | 1 | 対象登録表現 |
+| proficiency | Proficiency | 1 | 習熟度 |
+| timeline | Timeline | 1 | 作成・更新日時 |
+
+不変条件:
+
+- `learner + vocabularyExpression` は一意でなければならない
+- `vocabularyExpression` は同じ `learner` が所有する `VocabularyExpression` でなければならない
+- `proficiency` は `Learning`、`Learned`、`Internalized`、`Fluent` のいずれか
+- `Frequency` と `Sophistication` を持ってはならない
+
+## 責務
+
+- 学習者ごとの主観的な定着状態だけを扱う
+- 登録状態、解説生成状態、画像生成状態を代替してはならない
+- 学習進捗の更新は `LearningState` だけで完結させる
+
+## リポジトリ
+
+### LearningStateRepository
+
+- `findByLearnerAndVocabularyExpression(learner, vocabularyExpression)`
+- `persist(state)`

--- a/docs/internal/domain/service.md
+++ b/docs/internal/domain/service.md
@@ -63,7 +63,7 @@
 
 | 入力 | 出力 | 保証 |
 |---|---|---|
-| `explanation`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | 完了時のみ画像成果物を返し、retry / regenerate も同じ契約で扱う |
+| `explanation`, `sense?`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | `sense` を指定する場合は同じ `Explanation` に属する意味単位だけを受け付け、完了時のみ画像成果物を返し、retry / regenerate も同じ契約で扱う |
 
 ### AssetStoragePort
 
@@ -73,7 +73,7 @@
 
 | 入力 | 出力 | 保証 |
 |---|---|---|
-| `binaryOrAssetPayload`, `metadata` | `image`, `storageReference` | 返却された参照で再取得でき、識別子は一意である |
+| `binaryOrAssetPayload`, `metadata(explanation, sense?)` | `image`, `storageReference` | 返却された参照で再取得でき、識別子は一意であり、必要に応じて explanation 全体画像か特定 `Sense` 画像かを後続で追跡できる |
 
 ### PronunciationMediaPort
 
@@ -90,3 +90,4 @@
 - domain は vendor 名、SDK 型、transport 形式を知らない
 - auth provider の credential / session 管理は外部責務であり、この文書では扱わない
 - generator や storage の実装差し替えは port 契約を崩さずに行える必要がある
+- domain は完了済み結果だけを表示対象とし、中間画像 payload の公開可否は `status` と `Explanation.currentImage` で判断する

--- a/docs/internal/domain/service.md
+++ b/docs/internal/domain/service.md
@@ -1,18 +1,92 @@
-# ドメインサービス
+# ドメインサービス / 外部ポート
 
-## 英単語バリデーションサービス
+## この文書の役割
 
-### 振る舞い
+- ドメインが外部へ依存する責務を port として整理する
+- 認証実装、AI vendor、ストレージ SDK などの実装詳細を domain language に持ち込まない
 
-- 英単語が存在するか判定する（exist）
-  - 入力
-    - 解説識別子
-  - 出力
-    - 真偽地
+## 関連文書
 
-- 英単語がすでに登録済みか判定する（registered）
-  - 入力
-    - 解説識別子
-  - 出力
-    - 真偽地
+- [common.md](./common.md)
+- [learner.md](./learner.md)
+- [vocabulary-expression.md](./vocabulary-expression.md)
+- [explanation.md](./explanation.md)
+- [visual.md](./visual.md)
 
+## ポート一覧
+
+### LearnerIdentityPort
+
+目的:
+
+- 外部 identity を `Learner` 境界へ結びつける
+
+| 入力 | 出力 | 保証 |
+|---|---|---|
+| `authenticationSubject` | `learner?`, `found` | credential や session の実装詳細を返さず、`Learner` 解決に必要な結果だけを返す |
+
+### WordValidationPort
+
+目的:
+
+- 登録対象の英語表現が有効かを判定し、必要なら正規化結果を返す
+
+| 入力 | 出力 | 保証 |
+|---|---|---|
+| `text`, `kind` | `exists`, `normalizedVocabularyExpressionText`, `rejectionReason?` | 同じ入力に対して一貫した判定を返し、登録や生成の副作用を持たない |
+
+### RegistrationLookupPort
+
+目的:
+
+- 同一学習者内で既存登録済みの `VocabularyExpression` があるかを確認する
+
+| 入力 | 出力 | 保証 |
+|---|---|---|
+| `learner`, `normalizedVocabularyExpressionText`, `kind` | `registered`, `vocabularyExpression?` | 重複登録判定は同一学習者境界の内側だけで行い、生成副作用を持たない |
+
+### ExplanationGenerationPort
+
+目的:
+
+- `VocabularyExpression` に対する解説生成を依頼し、状態更新に必要な結果を返す
+
+| 入力 | 出力 | 保証 |
+|---|---|---|
+| `vocabularyExpression`, `normalizedVocabularyExpressionText` | `requestIdentifier`, `status`, `explanationPayload?`, `failureReason?` | 完了時のみ解説本文を返し、未完了時は状態だけを返す |
+
+### ImageGenerationPort
+
+目的:
+
+- 完了済み `Explanation` に基づく画像生成を依頼し、画像生成状態を返す
+
+| 入力 | 出力 | 保証 |
+|---|---|---|
+| `explanation`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | 完了時のみ画像成果物を返し、retry / regenerate も同じ契約で扱う |
+
+### AssetStoragePort
+
+目的:
+
+- 画像成果物を永続化し、安定した識別子と取得参照を返す
+
+| 入力 | 出力 | 保証 |
+|---|---|---|
+| `binaryOrAssetPayload`, `metadata` | `image`, `storageReference` | 返却された参照で再取得でき、識別子は一意である |
+
+### PronunciationMediaPort
+
+目的:
+
+- 発音サンプルを参照可能な形で取得する
+
+| 入力 | 出力 | 保証 |
+|---|---|---|
+| `text` | `sampleReference?` | 取得不能時は失敗理由または空結果を返し、解説本文の生成責務と混同しない |
+
+## ポート分離ルール
+
+- domain は vendor 名、SDK 型、transport 形式を知らない
+- auth provider の credential / session 管理は外部責務であり、この文書では扱わない
+- generator や storage の実装差し替えは port 契約を崩さずに行える必要がある

--- a/docs/internal/domain/visual.md
+++ b/docs/internal/domain/visual.md
@@ -3,6 +3,7 @@
 ## この文書の役割
 
 - `VisualImage` を `Explanation` から独立した画像集約として定義する
+- `VisualImage.sense` による meaning-to-image mapping を定義する
 - `previousImage` による履歴保持と `currentImage` への handoff 条件を固定する
 
 ## 関連文書
@@ -41,14 +42,18 @@
 |---|---|---:|---|
 | identifier | VisualImageIdentifier | 1 | 画像識別子 |
 | explanation | ExplanationIdentifier | 1 | 生成元解説 |
+| sense | SenseIdentifier | 0..1 | 描写する意味単位 |
 | previousImage | VisualImageIdentifier | 0..1 | 同一解説内の直前画像 |
 | storageReference | StorageReference | 1 | 永続化先参照 |
 | timeline | Timeline | 1 | 作成・更新日時 |
 
 不変条件:
 
+- `sense` を持つ場合、その `Sense` は同じ `Explanation` に属していなければならない
 - `previousImage` を持つ場合、その画像は同じ `Explanation` に属していなければならない
 - `previousImage` の循環参照を作ってはならない
+- `previousImage` と現在画像の両方が `sense` を持つ場合、両者は同じ `Sense` を指していなければならない
+- explanation 全体を代表する画像は `sense` を持たなくてよい
 - `VisualImage` 自体は current か history かを持たず、current 判定は `Explanation.currentImage` 側の責務とする
 
 ## currentImage handoff
@@ -56,6 +61,9 @@
 - 新しい `VisualImage` が `succeeded` 相当の完了状態として保存された時だけ `Explanation.currentImage` に採用できる
 - regenerate 中は、直前の完了済み `VisualImage` を `Explanation.currentImage` のまま維持する
 - 以前の画像は `previousImage` を通じて履歴として保持する
+- `Explanation.currentImage` は `Sense` の数にかかわらず 0..1 件であり、複数 current image を同時に採用してはならない
+- 特定 `Sense` の再生成では、`previousImage` は同じ `sense` を持つ履歴へ接続しなければならない
+- explanation 全体の代表画像を再生成する場合は、`sense = null` のまま履歴を接続する
 
 ## リポジトリ
 

--- a/docs/internal/domain/visual.md
+++ b/docs/internal/domain/visual.md
@@ -1,30 +1,67 @@
-# 視覚的表現画像
+# VisualImage ドメインモデル
+
+## この文書の役割
+
+- `VisualImage` を `Explanation` から独立した画像集約として定義する
+- `previousImage` による履歴保持と `currentImage` への handoff 条件を固定する
+
+## 関連文書
+
+- [common.md](./common.md)
+- [explanation.md](./explanation.md)
+- [service.md](./service.md)
 
 ## 値オブジェクト
 
-### 視覚的表現画像識別子（VisualImageIdentifier）
+### VisualImageIdentifier
 
-- 文字列
+- 画像を一意に識別する値オブジェクト
 
-#### 不変条件
+不変条件:
 
-- 1文字以上255文字以下
+- 1 文字以上 255 文字以下
+
+### StorageReference
+
+- 画像アセットを再取得するための安定した参照
+
+不変条件:
+
+- 同一 `VisualImageIdentifier` は 1 つの `StorageReference` だけを指す
+- 参照は再取得可能でなければならない
 
 ## 集約
 
-### 視覚的表現画像（VisualImage）
+### VisualImage
 
-- 英単語を視覚的に表現した画像
+- `Explanation` に基づく視覚的表現画像
+- 現在表示中画像と履歴画像の両方を表す独立集約
 
-|フィールド名 |種別 |保持数 | 備考|
-|-|-|-|-|
-| identifier | 識別子 | 1 | |
-| explanation | 解説識別子 | 1 | | 
-| timeline | タイムライン | 1 | |
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| identifier | VisualImageIdentifier | 1 | 画像識別子 |
+| explanation | ExplanationIdentifier | 1 | 生成元解説 |
+| previousImage | VisualImageIdentifier | 0..1 | 同一解説内の直前画像 |
+| storageReference | StorageReference | 1 | 永続化先参照 |
+| timeline | Timeline | 1 | 作成・更新日時 |
 
-#### リポジトリ
+不変条件:
 
-- 識別子で集約を単一取得する（find）
-- 解説識別子で集約を単一取得する（findByExplanation）
-- 識別子を指定して集約を破棄する（terminate）
-- 集約を永続化する（persist）
+- `previousImage` を持つ場合、その画像は同じ `Explanation` に属していなければならない
+- `previousImage` の循環参照を作ってはならない
+- `VisualImage` 自体は current か history かを持たず、current 判定は `Explanation.currentImage` 側の責務とする
+
+## currentImage handoff
+
+- 新しい `VisualImage` が `succeeded` 相当の完了状態として保存された時だけ `Explanation.currentImage` に採用できる
+- regenerate 中は、直前の完了済み `VisualImage` を `Explanation.currentImage` のまま維持する
+- 以前の画像は `previousImage` を通じて履歴として保持する
+
+## リポジトリ
+
+### VisualImageRepository
+
+- `find(identifier)`
+- `findCurrentByExplanation(explanation)`
+- `listByExplanation(explanation)`
+- `persist(image)`

--- a/docs/internal/domain/vocabulary-expression.md
+++ b/docs/internal/domain/vocabulary-expression.md
@@ -1,0 +1,110 @@
+# VocabularyExpression ドメインモデル
+
+## この文書の役割
+
+- `VocabularyExpression` を学習者が所有する登録対象の正本として定義する
+- `VocabularyExpressionText` と `NormalizedVocabularyExpressionText` を固定する
+- 解説生成状態、retry / regenerate、`currentExplanation` の表示ルールを明文化する
+
+## 関連文書
+
+- [common.md](./common.md)
+- [learner.md](./learner.md)
+- [learning-state.md](./learning-state.md)
+- [explanation.md](./explanation.md)
+- [service.md](./service.md)
+
+## 値オブジェクト
+
+### VocabularyExpressionIdentifier
+
+- 登録対象を一意に識別する値オブジェクト
+
+### VocabularyExpressionText
+
+- ユーザーが登録した英語表現
+
+不変条件:
+
+- 1 文字以上
+
+### NormalizedVocabularyExpressionText
+
+- 重複判定に使う正規化済み英語表現
+
+不変条件:
+
+- 同一学習者内で一意でなければならない
+
+### VocabularyExpressionKind
+
+- `word`
+- `phrase`
+
+### RegistrationStatus
+
+- `active`
+- `archived`
+
+### ExplanationGenerationStatus
+
+- `pending`
+- `running`
+- `succeeded`
+- `failed`
+
+## 集約
+
+### VocabularyExpression
+
+- 学習者が所有する登録対象となる英語表現
+- 単語と連語を同一概念で扱う
+
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| identifier | VocabularyExpressionIdentifier | 1 | 登録対象識別子 |
+| learner | LearnerIdentifier | 1 | 所有学習者 |
+| text | VocabularyExpressionText | 1 | 登録された表現 |
+| normalizedText | NormalizedVocabularyExpressionText | 1 | 重複判定用表現 |
+| kind | VocabularyExpressionKind | 1 | 単語か連語か |
+| registrationStatus | RegistrationStatus | 1 | 登録状態 |
+| explanationGeneration | ExplanationGenerationStatus | 1 | 解説生成状態 |
+| currentExplanation | ExplanationIdentifier | 0..1 | 現在表示中の完了済み解説 |
+| timeline | Timeline | 1 | 作成・更新日時 |
+
+不変条件:
+
+- `learner + normalizedText` は同一学習者内で一意でなければならない
+- `kind` は `word` または `phrase`
+- `currentExplanation` は同じ `VocabularyExpression` に属する完了済み `Explanation` だけを参照できる
+- `registrationStatus` と `explanationGeneration` を混同してはならない
+
+## 解説生成ライフサイクル
+
+- `pending -> running -> succeeded | failed`
+- `failed -> pending` は retry として許可する
+- `succeeded -> running` は regenerate として許可する
+- regenerate 開始時に `currentExplanation` を消してはならない
+- 新しい解説が `succeeded` になった時だけ `currentExplanation` を切り替える
+- regenerate 失敗時は、直前の完了済み `currentExplanation` があれば維持してよい
+
+## 表示ルール
+
+- ユーザーへ見せてよい本文は完了済み `currentExplanation` のみ
+- `pending` / `running` / `failed` では状態のみを表示できる
+- 未完了解説や部分生成結果を表示してはならない
+
+## LearningState との関係
+
+- `VocabularyExpression` 自体は `Proficiency` を持たない
+- 習熟度は [learning-state.md](./learning-state.md) の `LearningState` が扱う
+
+## リポジトリ
+
+### VocabularyExpressionRepository
+
+- `find(identifier)`
+- `findByLearnerAndNormalizedText(learner, normalizedText)`
+- `listByLearner(learner)`
+- `persist(vocabularyExpression)`
+- `archive(identifier)`

--- a/specs/005-domain-modeling/checklists/requirements.md
+++ b/specs/005-domain-modeling/checklists/requirements.md
@@ -1,7 +1,7 @@
-# Specification Quality Checklist: ドメインモデリング
+# Specification Quality Checklist: ドメインモデリング - Sense導入差分
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning  
-**Created**: 2026-04-15  
+**Created**: 2026-04-17  
 **Feature**: [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md)
 
 ## Content Quality
@@ -31,7 +31,7 @@
 
 ## Notes
 
-- 2026-04-16 に clarification を反映し、project-wide scope、`Entry` 概念、`VisualImage` 独立集約を確定した
-- 2026-04-16 に `Domain Models Affected` を更新し、`learner.md`、`vocabulary-expression.md`、`learning-state.md` を対象文書へ追加して `plan.md` / `tasks.md` と整合させた
-- planning に進める状態である
+- 2026-04-17 に `005-domain-modeling` を `Sense` 導入差分へ更新し、`plan.md` / `tasks.md` と scope を整合させた
+- `Sense` は `Explanation` 所有の意味単位、`VisualImage` は独立集約維持、`currentImage` は単一参照維持を前提にした
+- 複数 current image の同時公開は後続 feature scope として明記した
 - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/005-domain-modeling/contracts/async-visibility-contract.md
+++ b/specs/005-domain-modeling/contracts/async-visibility-contract.md
@@ -18,6 +18,13 @@
 | `succeeded` | 生成完了 | `currentImage` を表示してよい |
 | `failed` | 生成失敗 | `currentImage` があれば直前の完了済み画像を維持してよく、未存在なら画像は表示しない |
 
+## Sense-aware Visibility Rules
+
+- `Explanation` が複数の `Sense` を持っていても、この phase でユーザーへ見せてよい current image は単一の `currentImage` のみ
+- `currentImage` が `sense` を持つ場合、その画像がどの意味を補助するかは説明できなければならない
+- 画像生成中または失敗中でも、未完了の sense-specific image は表示してはならない
+- `Sense` の導入は current image の単一参照ルールを破ってはならない
+
 ## Retry and Regeneration Rules
 
 - `failed -> pending` は explanation / image の retry として許可する
@@ -32,4 +39,4 @@
 
 - ユーザーへ見せてよい生成物は、常に完了済みの `currentExplanation` / `currentImage` のみ
 - 生成中または失敗中は状態表示のみ可能であり、新規の未完了生成物は見せない
-- 冪等 retry により同じ依頼が再送されても、ユーザーへ不完全結果を見せない
+- `Sense` が増えても、冪等 retry により不完全結果を見せない保証は維持される

--- a/specs/005-domain-modeling/contracts/concept-separation-contract.md
+++ b/specs/005-domain-modeling/contracts/concept-separation-contract.md
@@ -4,10 +4,11 @@
 
 | Concept | Meaning | Must Not Be Mixed With |
 |--------|---------|------------------------|
-| `Frequency` | 英語表現がどの程度よく使われるか | `Proficiency`, `Sophistication`, generation status |
-| `Sophistication` | 英語表現の知的・語彙的な難度 | `Frequency`, `Proficiency`, registration status |
-| `Proficiency` | 学習者がどれだけ定着したか | `Frequency`, `Sophistication`, generation status |
-| `RegistrationStatus` | 学習者がその表現を追跡中かどうか | explanation / image generation status |
+| `Sense` | `Explanation` 内の意味単位 | `VocabularyExpression`, `LearningState`, generation status |
+| `Frequency` | 英語表現がどの程度よく使われるか | `Proficiency`, `Sophistication`, `Sense`, generation status |
+| `Sophistication` | 英語表現の知的・語彙的な難度 | `Frequency`, `Proficiency`, `Sense`, registration status |
+| `Proficiency` | 学習者がどれだけ定着したか | `Frequency`, `Sophistication`, `Sense`, generation status |
+| `RegistrationStatus` | 学習者がその表現を追跡中かどうか | explanation / image generation status, `Sense` |
 | `ExplanationGenerationStatus` | 解説生成の進行状態 | image generation status, registration status |
 | `ImageGenerationStatus` | 画像生成の進行状態 | explanation generation status, proficiency |
 
@@ -15,6 +16,7 @@
 
 | Concept | Owner |
 |--------|-------|
+| `Sense` | `Explanation` |
 | `Frequency` | `Explanation` |
 | `Sophistication` | `Explanation` |
 | `Proficiency` | `LearningState` |
@@ -24,8 +26,8 @@
 
 ## Guarantees
 
-- 語彙自体の属性と学習進捗を同一フィールド群へ統合しない
-- `Explanation` は `Proficiency` を持たない
-- `LearningState` は `Frequency` と `Sophistication` を持たない
-- `VocabularyExpression` は `ImageGenerationStatus` を持たず、画像生成の current / history は `Explanation` と `VisualImage` の責務で扱う
+- 語彙自体の属性、意味単位、学習進捗を同一フィールド群へ統合しない
+- `Explanation` は `Sense` を持つが、`Proficiency` は持たない
+- `LearningState` は `Frequency`、`Sophistication`、`Sense` を持たない
+- `VocabularyExpression` は `Sense` を直接持たず、意味の構造化は `Explanation` の責務で扱う
 - `ExplanationGenerationStatus` と `ImageGenerationStatus` は同じ語彙を使っても別状態として扱う

--- a/specs/005-domain-modeling/contracts/domain-port-catalog.md
+++ b/specs/005-domain-modeling/contracts/domain-port-catalog.md
@@ -34,11 +34,11 @@
 
 ## ImageGenerationPort
 
-**Purpose**: 完了済み `Explanation` に基づく画像生成を依頼し、画像生成状態を返す。
+**Purpose**: 完了済み `Explanation` と必要に応じて対象 `Sense` に基づく画像生成を依頼し、画像生成状態を返す。
 
 | Input | Output | Guarantees |
 |-------|--------|------------|
-| `explanation`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | 完了時のみ画像成果物を返し、再生成も同じ契約で扱う |
+| `explanation`, `sense?`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | 完了時のみ画像成果物を返し、意味単位を指定する場合は同一 `Explanation` 配下の `Sense` だけを受理し、再生成も同じ契約で扱う |
 
 ## AssetStoragePort
 

--- a/specs/005-domain-modeling/contracts/sense-image-mapping-contract.md
+++ b/specs/005-domain-modeling/contracts/sense-image-mapping-contract.md
@@ -1,0 +1,34 @@
+# Contract: Sense Image Mapping
+
+## Sense Ownership
+
+| Concept | Rule |
+|--------|------|
+| `Sense` | `Explanation` が所有する内部エンティティである |
+| `VisualImage.sense` | 指定する場合は、同じ `Explanation` に属する `Sense` だけを参照できる |
+| `Explanation.currentImage` | 常に完了済み `VisualImage` を 0..1 件だけ参照する |
+
+## Meaning-to-Image Mapping
+
+| Case | Allowed | Notes |
+|------|---------|-------|
+| `VisualImage.sense = null` | Yes | explanation 全体を代表する画像として扱える |
+| `VisualImage.sense = SenseIdentifier` | Yes | 特定の意味単位を描写する画像として扱える |
+| `VisualImage.sense` が他 explanation の `Sense` を指す | No | ownership boundary を壊すため禁止 |
+| 1 explanation に意味対応なしの裸画像を複数 current として並べる | No | この phase の scope 外 |
+
+## Example and Collocation Ownership
+
+| Artifact | Owner |
+|---------|-------|
+| `ExampleSentence` | `Sense` |
+| `Collocation` | `Sense` |
+| `Pronunciation` | `Explanation` |
+| `Frequency` | `Explanation` |
+| `Sophistication` | `Explanation` |
+
+## Guarantees
+
+- 画像枚数より先に意味単位と画像単位の対応関係を明示する
+- `Sense` を導入しても `Explanation.currentImage` の単一 current 参照は維持する
+- 多義語の画像化は、少なくとも domain 上では「どの意味の画像か」を説明できる

--- a/specs/005-domain-modeling/contracts/vocabulary-expression-identity-contract.md
+++ b/specs/005-domain-modeling/contracts/vocabulary-expression-identity-contract.md
@@ -6,8 +6,9 @@
 |--------|------|------------|-------|
 | `Learner` | 学習者 identity 境界、所有関係 | `VocabularyExpression`, `LearningState` | 認証そのものは持たず、外部 identity を参照する |
 | `VocabularyExpression` | 登録対象の識別、登録状態、解説生成状態 | `Learner`, `currentExplanation` | 単語と連語を同一概念で扱う学習者所有集約 |
-| `Explanation` | 解説本文、頻出度、知的度、画像 generation 状態 | `VocabularyExpression`, `currentImage` | current な表示結果を指す知識集約 |
-| `VisualImage` | 画像アセット参照、履歴 | `Explanation`, `previousImage` | `Explanation` から独立した集約 |
+| `Explanation` | 解説本文、意味単位、頻出度、知的度、画像 generation 状態 | `VocabularyExpression`, `currentImage` | current な表示結果を指す知識集約 |
+| `Sense` | 意味単位、意味別の例文とコロケーション | `Explanation` | `Explanation` が所有する内部エンティティ |
+| `VisualImage` | 画像アセット参照、履歴 | `Explanation`, `sense`, `previousImage` | `Explanation` から独立した集約 |
 | `LearningState` | 習熟度 | `Learner`, `VocabularyExpression` | 学習進捗だけを扱う |
 
 ## Identifier Rules
@@ -17,7 +18,8 @@
 | `Learner` | `LearnerIdentifier` | `identifier` | none |
 | `VocabularyExpression` | `VocabularyExpressionIdentifier` | `identifier` | `learner`, `currentExplanation` |
 | `Explanation` | `ExplanationIdentifier` | `identifier` | `vocabularyExpression`, `currentImage` |
-| `VisualImage` | `VisualImageIdentifier` | `identifier` | `explanation`, `previousImage` |
+| `Sense` | `SenseIdentifier` | `identifier` | none |
+| `VisualImage` | `VisualImageIdentifier` | `identifier` | `explanation`, `sense`, `previousImage` |
 | `LearningState` | `LearningStateIdentifier` | `identifier` | `learner`, `vocabularyExpression` |
 
 ## VocabularyExpression Kind
@@ -32,12 +34,14 @@
 | Scope | Uniqueness Rule | Notes |
 |------|------------------|-------|
 | Same `Learner` | `normalizedVocabularyExpressionText` は一意 | 重複登録は拒否または更新判断の対象になる |
+| Same `Explanation` | `Sense.identifier` と `Sense.order` は一意 | 意味単位は explanation 内だけで識別する |
 | Different `Learner` | 同じ表現でも共存可能 | 学習者間で `VocabularyExpression` を共有しない |
 
 ## Guarantees
 
 - `VocabularyExpression` は単語と連語を統一した学習者所有の登録対象概念である
 - 同じ英語表現の重複判定は同一学習者内でのみ行う
+- `Sense` は `VocabularyExpression` や `LearningState` の代替概念ではなく、`Explanation` の意味単位である
 - `ExplanationIdentifier` や `VisualImageIdentifier` を登録対象の識別子として使わない
 - `VisualImage` は `Explanation` の内部値ではなく独立集約として扱う
 - `LearningState` は `Frequency` や `Sophistication` を持たず、習熟度のみを扱う

--- a/specs/005-domain-modeling/data-model.md
+++ b/specs/005-domain-modeling/data-model.md
@@ -28,19 +28,33 @@ classDiagram
         <<Aggregate>>
         +ExplanationIdentifier identifier
         +VocabularyExpressionIdentifier vocabularyExpression
-        +Meaning meaning
+        +Sense[] senses
         +Pronunciation pronunciation
         +Frequency frequency
         +Sophistication sophistication
+        +Etymology etymology
+        +SimilarExpression[] similarities
         +ImageGenerationStatus imageGeneration
         +VisualImageIdentifier currentImage
         +Timeline timeline
+    }
+
+    class Sense {
+        <<Entity>>
+        +SenseIdentifier identifier
+        +string label
+        +string situation
+        +string nuance
+        +int order
+        +Collocation[] collocations
+        +ExampleSentence[] examples
     }
 
     class VisualImage {
         <<Aggregate>>
         +VisualImageIdentifier identifier
         +ExplanationIdentifier explanation
+        +SenseIdentifier sense
         +VisualImageIdentifier previousImage
         +StorageReference storageReference
         +Timeline timeline
@@ -95,8 +109,10 @@ classDiagram
     Learner "1" --> "0..*" LearningState : tracks
     VocabularyExpression "1" --> "0..*" Explanation : has history
     VocabularyExpression --> "0..1" Explanation : currentExplanation
+    Explanation "1" --> "1..5" Sense : contains
     Explanation "1" --> "0..*" VisualImage : has history
     Explanation --> "0..1" VisualImage : currentImage
+    VisualImage --> "0..1" Sense : depicts
     VisualImage --> "0..1" VisualImage : previousImage
     LearningState --> "1" VocabularyExpression : vocabularyExpression
     VocabularyExpression --> VocabularyExpressionKind : kind
@@ -106,10 +122,10 @@ classDiagram
     LearningState --> Proficiency : proficiency
 ```
 
-- `VocabularyExpression` は学習者が所有する登録対象で、表示上は `currentExplanation` だけを参照する
-- `Explanation` は解説本文の集約で、表示上は `currentImage` だけを参照する
-- `VisualImage.previousImage` によって、同一解説内の画像履歴を辿る
-- `LearningState` は `Learner` と `VocabularyExpression` の関係上にある習熟度専用の集約
+- `Sense` は `Explanation` が所有する意味単位の内部エンティティである
+- `VisualImage` は `Explanation` と `sense?` の両方を参照できる独立集約である
+- `Explanation.currentImage` はこの phase では単一の current 参照を維持する
+- `Learner`、`VocabularyExpression`、`LearningState` の ownership boundary は変えない
 
 ## Aggregate: Learner
 
@@ -158,18 +174,16 @@ classDiagram
 
 ## Aggregate: Explanation
 
-**Purpose**: `VocabularyExpression` に紐づく生成済み解説を表す知識集約。現在表示中画像の参照を持つ。
+**Purpose**: `VocabularyExpression` に紐づく生成済み解説を表す知識集約。意味単位として `Sense` を持ち、現在表示中画像の参照を持つ。
 
 | Field | Type | Cardinality | Description |
 |-------|------|-------------|-------------|
 | identifier | ExplanationIdentifier | 1 | 解説識別子 |
 | vocabularyExpression | VocabularyExpressionIdentifier | 1 | 元の登録対象 |
-| meaning | Meaning | 1 | 意味のまとまり |
+| senses | Sense[] | 1..5 | 意味単位の一覧 |
 | pronunciation | Pronunciation | 1 | 発音と発音記号 |
 | frequency | Frequency | 1 | 頻出度と理由 |
 | sophistication | Sophistication | 1 | 知的度と理由 |
-| collocations | Collocation[] | 1..10 | コロケーション |
-| examples | ExampleSentence[] | 1..3 | 例文 |
 | etymology | Etymology | 1 | 語源 |
 | similarities | SimilarExpression[] | 1..5 | 類似表現 |
 | imageGeneration | ImageGenerationStatus | 1 | 画像生成状態 |
@@ -179,12 +193,13 @@ classDiagram
 **Validation rules**:
 
 - `vocabularyExpression` は常に 1 つの `VocabularyExpressionIdentifier` を参照する
-- `meaning.values` は 1 件以上
-- `collocations` は 1 件以上 10 件以下
-- `examples` は 1 件以上 3 件以下
-- `similarities` は 1 件以上 5 件以下
+- `senses` は 1 件以上 5 件以下
+- `senses.order` は同一 `Explanation` 内で重複してはならない
+- `senses.identifier` は同一 `Explanation` 内で一意でなければならない
 - `currentImage` は同じ `Explanation` に属する完了済み `VisualImage` だけを参照できる
+- `currentImage` が `sense` を持つ画像を指す場合、その `sense` は同じ `Explanation.senses` のいずれかでなければならない
 - 画像再生成中または再生成失敗時でも、直前の完了済み画像がある場合は `currentImage` を保持してよい
+- `frequency` と `sophistication` は `Explanation` が所有し、`Sense` や `LearningState` へ移してはならない
 
 **State transitions**:
 
@@ -192,14 +207,39 @@ classDiagram
 - `imageGeneration`: `failed -> pending` を retry として許可
 - `imageGeneration`: `succeeded -> running` を regenerate として許可
 
+## Entity: Sense
+
+**Purpose**: `Explanation` が所有する意味単位。意味ごとの説明、状況、ニュアンス、例文、コロケーションをまとめる。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| identifier | SenseIdentifier | 1 | 同一 `Explanation` 内での意味識別子 |
+| label | string | 1 | 意味を短く表す代表ラベル |
+| situation | string | 1 | 使われる状況 |
+| nuance | string | 1 | ニュアンス |
+| order | positive integer | 1 | 表示順序 |
+| collocations | Collocation[] | 0..5 | その意味に結びつくコロケーション |
+| examples | ExampleSentence[] | 0..3 | その意味に結びつく例文 |
+
+**Validation rules**:
+
+- `label` は 1 文字以上 255 文字以下
+- `situation` は 1 文字以上 255 文字以下
+- `nuance` は 1 文字以上 255 文字以下
+- `order` は 1 以上の整数
+- `collocations` は 5 件以下
+- `examples` は 3 件以下
+- `examples` と `collocations` は `Explanation` 全体ではなく、その `Sense` の意味に対応していなければならない
+
 ## Aggregate: VisualImage
 
-**Purpose**: `Explanation` に基づく視覚的表現を表す画像集約。独立した保存先参照と履歴を持つ。
+**Purpose**: `Explanation` に基づく視覚的表現を表す画像集約。独立した保存先参照と履歴を持ち、必要に応じて特定の `Sense` を描写する。
 
 | Field | Type | Cardinality | Description |
 |-------|------|-------------|-------------|
 | identifier | VisualImageIdentifier | 1 | 画像識別子 |
 | explanation | ExplanationIdentifier | 1 | 生成元解説 |
+| sense | SenseIdentifier | 0..1 | 画像が描写する意味単位 |
 | previousImage | VisualImageIdentifier | 0..1 | 同一解説内の直前画像履歴 |
 | storageReference | StorageReference | 1 | 永続化先の再取得参照 |
 | timeline | Timeline | 1 | 作成・更新日時 |
@@ -209,7 +249,9 @@ classDiagram
 - `storageReference` は安定した取得参照でなければならない
 - 同一 `identifier` は 1 つの保存先だけを指す
 - `previousImage` を持つ場合、その `VisualImage` は同じ `Explanation` に属していなければならない
+- `sense` を持つ場合、その `Sense` は同じ `Explanation` に属していなければならない
 - `previousImage` の循環参照を作ってはならない
+- `previousImage` が `sense` を持つ画像で、現在画像も `sense` を持つ場合、両者は同じ `Sense` を指していなければならない
 
 ## Aggregate: LearningState
 
@@ -258,119 +300,10 @@ classDiagram
 ### Existing value objects retained
 
 - `AuthenticationSubject`
-- `VocabularyExpressionText`
-- `NormalizedVocabularyExpressionText`
-- `Frequency`
-- `FrequencyLevel`
-- `Sophistication`
-- `SophisticationLevel`
-- `Meaning`
-- `PhoneticSymbols`
 - `Pronunciation`
+- `Frequency`
+- `Sophistication`
 - `Collocation`
 - `ExampleSentence`
 - `SimilarExpression`
 - `Etymology`
-- `Proficiency`
-- `Timeline`
-- `StorageReference`
-
-## Relationships
-
-- `Learner` 1 : n `VocabularyExpression`
-- `Learner` 1 : n `LearningState`
-- `VocabularyExpression` 1 : n `Explanation`, ただし `currentExplanation` は 0..1
-- `Explanation` 1 : n `VisualImage`, ただし `currentImage` は 0..1
-- `LearningState` は `Learner` と `VocabularyExpression` の関係上でのみ存在できる
-- `VisualImage.previousImage` は同一 `Explanation` の履歴を辿る
-
-## Domain Events
-
-### VocabularyExpressionRegistered
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 所有学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 登録された表現 |
-| occurredAt | DateTime | 発生日時 |
-
-### ExplanationGenerated
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 所有学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 対象登録表現 |
-| explanation | ExplanationIdentifier | 完了した解説 |
-| occurredAt | DateTime | 発生日時 |
-
-### ExplanationGenerationFailed
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 所有学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 対象登録表現 |
-| reason | FailureReason | 失敗理由 |
-| occurredAt | DateTime | 発生日時 |
-
-### ExplanationRegenerated
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 所有学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 対象登録表現 |
-| beforeExplanation | ExplanationIdentifier | 以前の解説 |
-| afterExplanation | ExplanationIdentifier | 新しい解説 |
-| occurredAt | DateTime | 発生日時 |
-
-### ImageGenerated
-
-| Field | Type | Description |
-|-------|------|-------------|
-| explanation | ExplanationIdentifier | 対象解説 |
-| image | VisualImageIdentifier | 完了した画像 |
-| occurredAt | DateTime | 発生日時 |
-
-### ImageRegenerated
-
-| Field | Type | Description |
-|-------|------|-------------|
-| explanation | ExplanationIdentifier | 対象解説 |
-| beforeImage | VisualImageIdentifier | 以前の画像 |
-| afterImage | VisualImageIdentifier | 新しい画像 |
-| occurredAt | DateTime | 発生日時 |
-
-### ProficiencyChanged
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 対象学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 対象登録表現 |
-| before | Proficiency | 変更前の習熟度 |
-| after | Proficiency | 変更後の習熟度 |
-| occurredAt | DateTime | 発生日時 |
-
-## Repository Contracts
-
-- `LearnerRepository`
-  - `find(identifier)`
-  - `findByAuthenticationSubject(authenticationSubject)`
-  - `persist(learner)`
-- `VocabularyExpressionRepository`
-  - `find(identifier)`
-  - `findByLearnerAndNormalizedText(learner, normalizedText)`
-  - `listByLearner(learner)`
-  - `persist(vocabularyExpression)`
-  - `archive(identifier)`
-- `ExplanationRepository`
-  - `find(identifier)`
-  - `findCurrentByVocabularyExpression(vocabularyExpression)`
-  - `listByVocabularyExpression(vocabularyExpression)`
-  - `persist(explanation)`
-- `VisualImageRepository`
-  - `find(identifier)`
-  - `findCurrentByExplanation(explanation)`
-  - `listByExplanation(explanation)`
-  - `persist(image)`
-- `LearningStateRepository`
-  - `findByLearnerAndVocabularyExpression(learner, vocabularyExpression)`
-  - `persist(state)`

--- a/specs/005-domain-modeling/plan.md
+++ b/specs/005-domain-modeling/plan.md
@@ -1,47 +1,48 @@
 # Implementation Plan: ドメインモデリング
 
-**Branch**: `005-domain-modeling` | **Date**: 2026-04-16 | **Spec**: [/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md)
+**Branch**: `009-sense-modeling` | **Date**: 2026-04-17 | **Spec**: [/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md)
 **Input**: Feature specification from `/specs/005-domain-modeling/spec.md`
 
 **Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
-vocastock プロジェクト全体のドメインを、`Learner` を所有境界、`VocabularyExpression` を
-学習者が所有する登録対象として再整理する。単語と連語は同一の `VocabularyExpression`
-概念で扱い、`Explanation` は現在表示中の解説参照、`VisualImage` は履歴を保持する独立集約、
-`LearningState` は習熟度専用集約として設計する。あわせて、`VocabularyExpression*` /
-`LearningState*` 命名、完了済み結果のみ表示する非同期規則、外部 identity を含む port 境界を
-project-wide の source of truth に落とし込める設計成果物を生成する。
+vocastock project-wide domain language を維持したまま、`Explanation` に `Sense` を導入する。
+`Sense` は多義語の意味単位を表す `Explanation` 所有の内部エンティティとし、意味、状況、
+ニュアンス、例文、コロケーションを意味単位で保持できるようにする。`VisualImage` は
+独立集約のまま維持しつつ、必要に応じてどの `Sense` を描写する画像かを示せるようにする。
+一方で、非同期表示ルールと `currentImage` の単一 current 参照は維持し、意味と画像の対応を
+明確にしながら中間生成物を見せない設計成果物を生成する。
 
 ## Technical Context
 
 **Language/Version**: Markdown 1.x, YAML/JSON reference documents  
 **Primary Dependencies**: 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`  
 **Storage**: Git-managed repository files、設計上で参照する抽象的な learner store、explanation store、image asset store  
-**Testing**: spec / constitution / ADR / domain docs の手動クロスレビュー、所有境界レビュー、一意性レビュー、状態遷移レビュー、識別子命名レビュー  
+**Testing**: spec / constitution / ADR / domain docs の手動クロスレビュー、sense ownership review、image mapping review、非同期表示レビュー、識別子命名レビュー  
 **Target Platform**: Flutter client、Rust command/query runtime、Haskell workflow runtime をまたぐ project-wide domain language  
 **Project Type**: documentation / domain design  
-**Performance Goals**: レビュー担当者が 5 分以内に主要概念、所有境界、不変条件を説明できること、非同期状態とユーザー表示ルールを 5 分以内に判定できること、source-of-truth 文書の参照先を 3 分以内に辿れること  
-**Constraints**: product code は追加しない、完了済み結果のみをユーザーへ表示する、頻出度・知的度・習熟度・登録状態・解説生成状態・画像生成状態を統合しない、`Learner` は独立集約、`VocabularyExpression` は学習者所有、重複判定は同一学習者内で行う、`VisualImage` は独立集約として履歴を保持する、認証そのものは外部責務として扱う、外部依存はポート越しに接続する、派生命名は `VocabularyExpression*` / `LearningState*` に統一する、識別子命名は憲章に従う  
-**Scale/Scope**: 5 つの中心集約、6 つの状態/指標概念、4 つの契約文書、`docs/internal/domain/` の新規追加 3 件と更新 4 件を想定する
+**Performance Goals**: レビュー担当者が 5 分以内に `Sense` と `Explanation` / `VisualImage` の責務差分を説明できること、画像と意味の対応ルールを 5 分以内に判定できること、source-of-truth 文書の参照先を 3 分以内に辿れること  
+**Constraints**: product code は追加しない、完了済み結果のみをユーザーへ表示する、頻出度・知的度・習熟度・登録状態・解説生成状態・画像生成状態を統合しない、`Sense` は `Explanation` 所有の内部エンティティとして扱う、`VisualImage` は独立集約として履歴を保持する、`Explanation.currentImage` はこの feature では単一 current 参照のまま維持する、画像を複数枚扱う場合も意味との対応なしに `Explanation` 直下へ裸の配列を足さない、外部依存はポート越しに接続する、派生命名は `VocabularyExpression*` / `LearningState*` に統一する、識別子命名は憲章に従う  
+**Scale/Scope**: 5 つの中心集約、1 つの内部エンティティ、6 つの状態/指標概念、5 つの契約文書、`docs/internal/domain/` の更新 3 件以上と `docs/external/*.md` の整合更新を想定する
 
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-- [x] Domain impact is identified. `docs/internal/domain/common.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/service.md`、`docs/internal/domain/visual.md` を更新対象とし、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md` を新規 source-of-truth 候補として扱う。
-- [x] Async generation flows define `pending`、`running`、`succeeded`、`failed`、再試行、再生成、表示可否を分けて扱い、不完全な生成物をユーザーへ見せない。再生成中も直前の完了済み `currentExplanation` / `currentImage` は保持し、新しい成功時だけ参照を切り替える。
-- [x] 単語検証、重複登録判定、学習者 identity 解決、解説生成、画像生成、アセット保存、発音参照はすべて external port として扱い、ドメインモデルへベンダー固有実装を持ち込まない。
-- [x] User stories are independently reviewable. project-wide scope、非同期表示、文書横断整合は research / data-model / contracts で別々に検証できる。
-- [x] 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態は別概念として維持し、どれも代替概念として扱わない。
-- [x] Identifier naming follows the constitution: `LearnerIdentifier`、`VocabularyExpressionIdentifier`、`ExplanationIdentifier`、`VisualImageIdentifier`、`LearningStateIdentifier` を使い、self identifier は `identifier`、関連参照は `learner`、`vocabularyExpression`、`currentImage` のような概念名で持つ。
+- [x] Domain impact is identified. `docs/internal/domain/common.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md` を主要更新対象とし、必要に応じて `docs/external/requirements.md` と `docs/external/adr.md` の用語整合も更新対象とする。
+- [x] Async generation flows define `pending`、`running`、`succeeded`、`failed`、再試行、再生成、表示可否を分けて扱い、不完全な生成物をユーザーへ見せない。`Sense` を導入しても `currentImage` は新しい成功時だけ切り替え、再生成中は直前の完了済み画像を維持する。
+- [x] 画像生成、解説生成、アセット保存、発音参照、単語検証はすべて external port として扱い、`Sense` 導入によってもベンダー固有実装をドメインモデルへ持ち込まない。
+- [x] User stories are independently reviewable. concept boundary、sense-image mapping、文書横断整合は research / data-model / contracts で別々に検証できる。
+- [x] 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態は別概念として維持し、`Sense` は意味単位として追加されるが評価指標へ吸収しない。
+- [x] Identifier naming follows the constitution: `SenseIdentifier` を含むすべての識別子型は `XxxIdentifier` を使い、self identifier は `identifier`、関連参照は `vocabularyExpression`、`currentImage`、`sense` のような概念名で持つ。
 
 Post-design re-check: PASS. Verified against `research.md`, `data-model.md`,
 `contracts/vocabulary-expression-identity-contract.md`,
 `contracts/concept-separation-contract.md`,
 `contracts/async-visibility-contract.md`,
-and `contracts/domain-port-catalog.md`.
+`contracts/domain-port-catalog.md`,
+and `contracts/sense-image-mapping-contract.md`.
 
 ## Project Structure
 
@@ -57,6 +58,7 @@ specs/005-domain-modeling/
 │   ├── async-visibility-contract.md
 │   ├── concept-separation-contract.md
 │   ├── domain-port-catalog.md
+│   ├── sense-image-mapping-contract.md
 │   └── vocabulary-expression-identity-contract.md
 └── tasks.md
 ```
@@ -72,11 +74,11 @@ docs/
     └── domain/
         ├── common.md
         ├── explanation.md
-        ├── learner.md                 # planned source-of-truth
-        ├── learning-state.md          # planned source-of-truth
+        ├── learner.md
+        ├── learning-state.md
         ├── service.md
         ├── visual.md
-        └── vocabulary-expression.md   # planned source-of-truth
+        └── vocabulary-expression.md
 
 specs/
 ├── 001-complete-domain-model/
@@ -86,11 +88,11 @@ specs/
 ```
 
 **Structure Decision**: 実装時の正本は `docs/internal/domain/*.md` と
-`docs/external/requirements.md` / `docs/external/adr.md` に置く。`specs/005-domain-modeling/`
-は、project-wide なドメイン再整理の根拠、所有境界、状態契約、ポート契約、review 導線を
-保持する設計パッケージとして扱う。`Learner`、`VocabularyExpression`、`LearningState`
-を独立した source-of-truth に切り出し、現行の `Explanation` / `VisualImage` 中心の記述を
-学習者所有の登録対象中心へ移行する。
+`docs/external/requirements.md` / `docs/external/adr.md` に置く。`Sense` は
+`Explanation` 配下の内部エンティティとして扱い、意味単位の説明責務を `Explanation`
+本体から切り出す。一方で `VisualImage` は独立集約のまま維持し、必要に応じて
+どの `Sense` を描写する画像かを示す。`Explanation.currentImage` は単一 current 参照のまま
+維持し、複数 current image の導入は follow-on scope とする。
 
 ## Complexity Tracking
 

--- a/specs/005-domain-modeling/quickstart.md
+++ b/specs/005-domain-modeling/quickstart.md
@@ -2,30 +2,29 @@
 
 ## 1. planning artifact を確認する
 
-- [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md) で対象範囲、`Learner`、学習者所有の `VocabularyExpression`、`VisualImage` 独立集約を確認する
-- [research.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/research.md) で所有境界、一意性境界、current 参照、命名統一の判断を確認する
-- [data-model.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/data-model.md) で aggregate、value object、状態遷移、履歴保持を確認する
-- `contracts/` で識別子、概念分離、非同期表示、外部ポートの契約を確認する
+- [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md) で 005 の project-wide domain 境界を確認する
+- [plan.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/plan.md) で `Sense` を `Explanation` 内部エンティティとして導入する設計判断を確認する
+- [research.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/research.md) で meaning-image mapping、単一 current image 維持、説明責務再編の判断を確認する
+- [data-model.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/data-model.md) で aggregate、entity、value object、状態遷移、履歴保持を確認する
+- `contracts/` で識別子、概念分離、非同期表示、外部ポート、sense-image mapping の契約を確認する
 
 ## 2. repository-level source of truth を更新する
 
-- `docs/internal/domain/learner.md` を新規追加し、`Learner` の source-of-truth にする
-- `docs/internal/domain/vocabulary-expression.md` を新規追加し、学習者所有の `VocabularyExpression` と学習者内一意性の正本にする
-- `docs/internal/domain/learning-state.md` を新規追加し、`LearningState` と `Proficiency` 分離の正本にする
-- `docs/internal/domain/explanation.md` で `VocabularyExpression.currentExplanation` と `Explanation.currentImage` の責務を明確化する
-- `docs/internal/domain/visual.md` で `VisualImage` の履歴保持と `previousImage` 規則を明確化する
-- `docs/internal/domain/service.md` を learner identity を含む external port catalog に整合させる
-- `docs/external/requirements.md` と `docs/external/adr.md` の語彙差分を埋める
+- `docs/internal/domain/common.md` に `Sense` を project-wide 用語として追加し、`Meaning` からの移行メモを明記する
+- `docs/internal/domain/explanation.md` で `Explanation.senses`、`Sense`、例文とコロケーションの ownership を正本化する
+- `docs/internal/domain/visual.md` で `VisualImage.sense` と `previousImage` の整合条件を正本化する
+- `docs/external/requirements.md` と `docs/external/adr.md` に、多義語の意味単位と画像対応の前提を同期する
 
 ## 3. cross-review を行う
 
-- `Learner` が所有境界、`VocabularyExpression` が登録対象、`LearningState` が学習進捗として分離されているか確認する
-- `normalizedText` の一意性が同一学習者内に閉じているか確認する
-- `Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態が混同されていないか確認する
+- `Sense` が `Explanation` 所有の内部エンティティとして定義されているか確認する
+- `Learner`、`VocabularyExpression`、`LearningState` の ownership boundary が `Sense` 導入で変わっていないか確認する
+- `Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態が `Sense` と混同されていないか確認する
+- 例文とコロケーションが explanation 全体ではなく対応する `Sense` に結びついているか確認する
+- `VisualImage.sense` が同一 `Explanation` 配下の意味だけを指せるか確認する
 - explanation / image の regenerate 中も、直前の完了済み `currentExplanation` / `currentImage` だけが表示可能になっているか確認する
-- 外部責務が `LearnerIdentityPort`、`WordValidationPort`、`RegistrationLookupPort`、`ExplanationGenerationPort`、`ImageGenerationPort`、`AssetStoragePort`、`PronunciationMediaPort` に整理されているか確認する
 
 ## 4. 次フェーズへ渡す
 
-- `/speckit.tasks` では source-of-truth の新規追加、既存文書の再編、用語整合、契約整合を task 化する
+- `/speckit.tasks` では `Sense` 用語導入、`Explanation` / `VisualImage` 再編、外部文書整合、契約整合を task 化する
 - `/speckit.implement` では docs-first で `docs/internal/domain/*.md` と `docs/external/*.md` を同一変更セットで更新する

--- a/specs/005-domain-modeling/research.md
+++ b/specs/005-domain-modeling/research.md
@@ -1,107 +1,85 @@
 # Research: ドメインモデリング
 
-## Decision: `Learner` を所有境界とし、`VocabularyExpression` は学習者が所有する登録対象として扱う
+## Decision: `Sense` を `Explanation` 所有の内部エンティティとして導入する
 
-**Rationale**: 習熟度が学習者ごとに変わる以上、語彙登録の境界も学習者側に寄せる方が自然である。
-`VocabularyExpression` を共有語彙にすると、重複登録判定、登録状態、生成状態、学習進捗の責務が
-再び混ざる。`Learner` を独立集約とし、その配下に `VocabularyExpression` を置くことで、
-語彙自体の概念と学習者の所有責務を同時に明確化できる。
-
-**Alternatives considered**:
-
-- `VocabularyExpression` を project-wide 共有語彙として扱う
-- `Learner` を domain に持たず、外部 identity のみを参照する
-
-## Decision: 英単語と連語は同一の `VocabularyExpression` 概念で扱う
-
-**Rationale**: 登録、検証、解説生成、画像生成、学習進捗は単語と連語で大きく変わらない。
-別概念に分けると、一意性判定、状態遷移、ポート契約、文書更新が二重化する。
-`VocabularyExpression` に `VocabularyExpressionKind` を持たせる方が、学習者所有の登録対象として
-一貫したルールを保ちやすい。
+**Rationale**: 多義語の「意味の数」と「画像の数」を直接結びつける前に、意味単位そのものを
+明示する必要がある。`Sense` を `Explanation` 配下に置くと、語彙登録対象や学習状態の境界は
+変えずに、意味、状況、ニュアンス、例文、コロケーションを意味単位で整理できる。
+`Sense` を独立集約にすると、`Explanation` から切り離された更新順序や参照整合が必要になり、
+現時点の domain complexity に対して過剰である。
 
 **Alternatives considered**:
 
-- 単一英単語だけを対象にする
-- 単語と連語を別々の集約として扱う
+- `Meaning.values` のまま文字列一覧だけを維持する
+- `Sense` を `Explanation` から独立した集約にする
 
-## Decision: `VocabularyExpression` の重複登録判定は同一学習者内の `NormalizedVocabularyExpressionText` で行う
+## Decision: `Explanation.meaning` を coarse-grained な意味の塊ではなく、`Explanation.senses` へ置き換える
 
-**Rationale**: 学習者所有モデルでは、同じ英語表現でも別学習者なら独立して存在できる。
-一方で同一学習者内の重複は登録状態や生成状態を分岐させるため避けたい。
-`NormalizedVocabularyExpressionText` を一意キーに使うと、表記揺れを吸収しつつ学習者境界の
-内側だけで重複を制御できる。
-
-**Alternatives considered**:
-
-- システム全体で英語表現を一意にする
-- 同一学習者内でも重複登録を許可する
-
-## Decision: `Proficiency` は `LearningState` に分離し、`Learner` と `VocabularyExpression` の関係上で扱う
-
-**Rationale**: 頻出度と知的度は語彙や解説の属性であり、習熟度は学習者の状態である。
-`Proficiency` を `VocabularyExpression` や `Explanation` に置くと、客観属性と主観進捗が混ざる。
-`LearningState` を独立集約にすると、学習者所有の語彙であっても評価軸を分離できる。
+**Rationale**: 既存の `Meaning.values + situation + nuance` では、複数意味がある場合でも
+状況やニュアンスが explanation 全体で 1 つに潰れてしまう。`Sense` に `label`、
+`situation`、`nuance` を持たせると、意味ごとの差分を domain 上で保てる。
+多義語に対して「どの例文がどの意味か」を説明しやすくなる。
 
 **Alternatives considered**:
 
-- `Proficiency` を `VocabularyExpression` の内部フィールドにする
-- `Proficiency` を `Explanation` の属性として扱う
+- `Meaning.values` に補足文字列を追記して疑似的に意味を増やす
+- 画像だけ複数にして意味の構造化は行わない
 
-## Decision: `Explanation` は `VocabularyExpression` の current 参照を持つ知識集約とし、再生成中は直前の完了済み結果を保持する
+## Decision: 例文とコロケーションは `Sense` に属させ、発音・語源・頻出度・知的度は `Explanation` に残す
 
-**Rationale**: 解説生成は `VocabularyExpression` 単位で進むが、ユーザーへ見せるのは常に完了済み結果のみである。
-そのため `VocabularyExpression.currentExplanation` を明示し、再生成開始時にこれを消さず、
-新しい成功時だけ差し替える設計が一貫する。これにより中間結果を見せず、再生成失敗時も
-最後の正常結果を維持できる。
-
-**Alternatives considered**:
-
-- 解説を常に最新ジョブ 1 件だけに上書きする
-- 解説生成中は過去の完了済み解説も隠す
-
-## Decision: `VisualImage` は `Explanation` から独立した集約とし、`currentImage` と履歴を分ける
-
-**Rationale**: 画像は生成タイミング、保存先参照、再生成履歴が解説本文と異なる。`Explanation` が
-`currentImage` を参照し、各 `VisualImage` が `previousImage` で同一解説内の履歴を辿れるようにすると、
-現在表示中の画像と履歴画像の責務が分離される。再生成中も現在画像を維持し、新しい成功時だけ
-参照を切り替えられる。
+**Rationale**: 例文とコロケーションは意味ごとの使われ方に強く依存する。一方で発音、語源、
+頻出度、知的度は表現全体の説明として扱う方が自然であり、意味ごとに分割すると重複や
+説明のばらつきが増える。これにより、説明全体の共通情報と意味別の局所情報を分離できる。
 
 **Alternatives considered**:
 
-- `Explanation` が画像 URL を直接持つ
-- 画像を `Explanation` の子エンティティとして扱う
-- 画像再生成時に過去画像を破棄する
+- 例文、コロケーション、発音、語源をすべて `Sense` に移す
+- 例文、コロケーションも explanation 全体の配列のままにする
 
-## Decision: `Learner` は独立集約だが、認証そのものは外部責務として `AuthenticationSubject` 参照だけを持つ
+## Decision: `VisualImage` は独立集約のまま維持し、必要に応じて `sense` 参照を持つ
 
-**Rationale**: 学習者は domain 上の所有者として明示したいが、認証方式や credential まで domain に
-持ち込むべきではない。`Learner` が外部 identity を表す `AuthenticationSubject` を保持し、
-認証・セッション管理自体は外部ポートに委ねる方が architecture / tech stack と整合する。
-
-**Alternatives considered**:
-
-- `Learner` を auth provider の実装詳細ごと domain に持ち込む
-- 学習者 identity を domain 外に完全に追い出し、所有境界も external に依存する
-
-## Decision: external responsibility は learner identity を含む port catalog として整理する
-
-**Rationale**: 単語存在確認、重複登録判定、学習者 identity 解決、解説生成、画像生成、アセット保存、
-発音参照はすべて外部依存であり、project-wide domain に実装詳細を持ち込むべきではない。
-ドメインでは入力、出力、保証事項だけを定義し、adapter 実装は後続 feature に委ねる。
+**Rationale**: 画像は非同期生成、保存先参照、再生成履歴の責務を持つため、`Explanation` の
+内部値へ戻すべきではない。ただし意味と画像の対応は domain 上で明示したいので、
+`VisualImage` が `Explanation` と同時に `sense?` を持てるようにする。
+これにより、「この画像はどの意味を描いているか」を示せる。
 
 **Alternatives considered**:
 
-- auth provider や AI vendor 名をドメインサービスへ埋め込む
-- ポート定義を作らず実装時に都度判断する
+- `VisualImage` を `Explanation` の子エンティティとして扱う
+- 画像と意味の対応を持たず、画像説明テキストだけで補う
 
-## Decision: source-of-truth は `learner.md`、`vocabulary-expression.md`、`learning-state.md` を追加して再編する
+## Decision: この phase では `Explanation.currentImage` を単一 current 参照のまま維持する
 
-**Rationale**: 現行 `explanation.md` と `visual.md` だけでは、学習者所有、一意性境界、
-習熟度分離、命名統一を表現しきれない。`Learner`、`VocabularyExpression`、`LearningState`
-を独立した source-of-truth に切り出し、既存文書はそれらとの関係へ再配置する方が、
-後続 feature の task と review 導線を明確にできる。
+**Rationale**: `Sense` の導入目的は、まず意味単位と画像単位の対応関係を明示することであり、
+current image を複数 current image へ拡張することではない。単一 current 参照を維持すると、
+既存の async visibility rule、retry / regenerate rule、UI 表示契約を壊さずに導入できる。
+複数 current image は follow-on scope として、`Sense` の運用が固まってから判断する方が安全である。
 
 **Alternatives considered**:
 
-- 既存 4 文書だけを追記して拡張する
-- `Explanation` 文書内に `Learner` と `VocabularyExpression` と学習進捗を内包する
+- `Explanation.currentImages` を直ちに複数化する
+- 画像 current 参照を廃止し、履歴配列から都度選ぶ
+
+## Decision: 画像枚数より意味対応の明確さを優先する
+
+**Rationale**: 学習体験では画像数の多さより、「どの意味を補助する画像か」が明確であることが
+重要である。`Sense` 導入により、画像を増やす前に meaning-image mapping を安定化できる。
+これにより、意味と無関係な装飾画像や、複数意味を曖昧に代表する画像の乱用を避けられる。
+
+**Alternatives considered**:
+
+- 意味構造を持たずに画像だけ増やす
+- 画像を 1 枚に固定したまま多義語の意味区別を model しない
+
+## Decision: source-of-truth は `explanation.md` と `visual.md` を中心に `common.md` を更新して再編する
+
+**Rationale**: `Sense` は `Explanation` の責務再編であり、既存の `Learner`、
+`VocabularyExpression`、`LearningState` の ownership boundary を変えるものではない。
+そのため正本の中心は `explanation.md` と `visual.md` であり、project-wide 用語差分は
+`common.md` で吸収するのが最小変更である。必要な外部文書整合は `requirements.md` と
+`adr.md` に限定できる。
+
+**Alternatives considered**:
+
+- `sense.md` を独立 source-of-truth として新設する
+- 既存文書を変えず、spec artifacts だけで `Sense` を説明する

--- a/specs/005-domain-modeling/spec.md
+++ b/specs/005-domain-modeling/spec.md
@@ -1,133 +1,123 @@
-# Feature Specification: ドメインモデリング
+# Feature Specification: ドメインモデリング - Sense導入差分
 
-**Feature Branch**: `005-domain-modeling`  
-**Created**: 2026-04-15  
+**Feature Branch**: `009-sense-modeling`  
+**Created**: 2026-04-17  
 **Status**: Draft  
-**Input**: User description: "ドメインモデリングを行う。私と議論しながら進めていきましょう。"
+**Input**: User description: "005をSense導入差分へ更新する"
 
 ## Clarifications
 
-### Session 2026-04-16
+### Session 2026-04-17
 
-- Q: 習熟度 (`Proficiency`) は誰に属する状態として扱うか → A: 学習者ごとの状態として扱う
-- Q: 学習者 identity は今回のドメインモデルでどう扱うか → A: 学習者を独立集約として扱う
-- Q: `VocabularyExpression` は誰に属する概念として扱うか → A: 各学習者が自分の `VocabularyExpression` を所有する
-- Q: 同じ英語表現の重複登録はどの粒度で禁止するか → A: 同一学習者内だけ一意にする
-- Q: 画像再生成時、以前の `VisualImage` はどう扱うか → A: 履歴として保持し、現在画像だけ別参照で示す
-- Q: `Entry` の標準名を何にするか → A: `VocabularyExpression` を標準名にする
-- Q: `EntryLearningState` の置き換え名を何にするか → A: `LearningState` を標準名にする
-- Q: `VocabularyExpression` への派生名をどう扱うか → A: 識別子型、repository、値オブジェクトを含めて `VocabularyExpression*` / `LearningState*` に全面改名する
-- Q: `EntryExpression` 系の値オブジェクト名を何にするか → A: `VocabularyExpressionText` / `NormalizedVocabularyExpressionText` を標準名にする
+- Q: 多義語の意味単位はどこに置くか → A: `Sense` を `Explanation` 所有の内部エンティティとして導入する
+- Q: `VisualImage` は複数意味を扱うために `Explanation` の内部値へ戻すか → A: 独立集約のまま維持し、必要に応じて `sense` を参照する
+- Q: `Sense` 導入時に `currentImage` は複数化するか → A: 今回は単一 `currentImage` を維持し、複数 current image は後続 scope とする
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - 主要概念の境界を定める (Priority: P1)
+### User Story 1 - 意味単位を明確化する (Priority: P1)
 
-ドメイン設計者として、vocastock の主要概念とその境界を一貫した言葉で整理したい。そうすることで、
-後続の設計、実装、レビューで同じ言葉を同じ意味で使えるようにしたい。
+ドメイン設計者として、多義語の解説を意味単位で整理したい。そうすることで、意味、状況、
+ニュアンス、例文、コロケーションがどの意味に属するかを一貫した言葉で説明できるようにしたい。
 
-**Why this priority**: 概念境界が曖昧なままでは、集約、状態、責務の切り方がぶれ続けるため。
+**Why this priority**: `Sense` を定義しないまま画像や例文を増やすと、どの意味を補助しているかが曖昧になるため。
 
-**Independent Test**: 第三者が設計成果物だけを読み、主要概念、責務境界、不変条件を 5 分以内に説明できれば成立する。
+**Independent Test**: 第三者が設計成果物だけを読み、`Sense`、`Explanation`、`VisualImage` の責務差分を 5 分以内に説明できれば成立する。
 
 **Acceptance Scenarios**:
 
-1. **Given** 既存文書に概念の重複や不足がある, **When** ドメインモデリング結果を確認する, **Then** 主要概念、責務、関係が一貫した用語で定義されている
-2. **Given** 新しい実装担当者が成果物を読む, **When** 英単語登録、解説生成、画像生成、学習状態管理の関係を確認する, **Then** 追加説明なしで概念の境界を理解できる
+1. **Given** 1 つの英語表現に複数の意味がある, **When** ドメインモデリング結果を確認する, **Then** 意味ごとの説明単位として `Sense` が定義されている
+2. **Given** 例文やコロケーションを確認する, **When** どの意味に属するかを見る, **Then** explanation 全体ではなく対応する `Sense` に結びついている
 
 ---
 
-### User Story 2 - 非同期生成の業務意味を定める (Priority: P2)
+### User Story 2 - 意味と画像の対応を定義する (Priority: P2)
 
-実装担当者として、解説生成と画像生成の状態、再試行、再生成、表示可否をドメインの言葉で整理したい。
-そうすることで、完了済み結果のみを表示するルールを壊さずに設計できる。
+実装担当者として、`Sense` 導入後も画像生成の current 参照、再試行、再生成、表示可否を壊さずに、
+どの画像がどの意味を補助するかをドメインの言葉で整理したい。
 
-**Why this priority**: 非同期生成の扱いが曖昧だと、中間結果の誤表示や重複処理の不整合が起きやすいため。
+**Why this priority**: 画像と意味の対応が曖昧だと、多義語で誤った画像を表示しても domain 上で検出できないため。
 
-**Independent Test**: レビュー担当者が成果物だけを読み、生成依頼から完了・失敗・再生成までの状態遷移と表示ルールを説明できれば成立する。
+**Independent Test**: レビュー担当者が成果物だけを読み、sense-aware image generation と単一 `currentImage` の業務意味を説明できれば成立する。
 
 **Acceptance Scenarios**:
 
-1. **Given** 解説生成または画像生成を扱う設計レビューを行う, **When** 成果物を確認する, **Then** `pending`、`running`、`succeeded`、`failed` と再試行条件が定義されている
-2. **Given** ユーザー表示ルールを確認する, **When** 生成途中または失敗時の扱いを見る, **Then** 中間生成結果は表示せず状態のみが見えることが定義されている
+1. **Given** `Explanation` に複数の `Sense` がある, **When** 画像生成ルールを確認する, **Then** `VisualImage` が必要に応じて対応する `Sense` を参照できる
+2. **Given** 画像再生成中または失敗中である, **When** ユーザー表示ルールを確認する, **Then** 直前の完了済み `currentImage` だけを維持し、中間生成結果は表示しない
 
 ---
 
-### User Story 3 - 文書横断で用語を統一する (Priority: P3)
+### User Story 3 - 差分導入の境界を周辺文書へ反映する (Priority: P3)
 
-レビュー担当者として、要件、ADR、既存ドメイン文書の前提が揃った状態にしたい。そうすることで、
-後続の architecture、tech stack、実装計画と矛盾しない土台を持ちたい。
+レビュー担当者として、`Sense` 導入が既存の 005 全体設計を壊さず、どこまでが今回の対象で、
+どこからが後続 scope かを周辺文書から一貫して確認したい。
 
-**Why this priority**: ドメイン文書だけが正しくても、周辺文書と食い違うと設計判断が再びぶれるため。
+**Why this priority**: `Sense` 導入差分と既存 005 全体スコープの境界が曖昧だと、plan と tasks が spec とずれ続けるため。
 
-**Independent Test**: 要件文書、ADR、ドメイン文書を横断して、主要概念と責務境界の矛盾がないと第三者が判定できれば成立する。
+**Independent Test**: 要件文書、ADR、共通 glossary を横断して、`Sense` 導入、meaning-to-image mapping、後続 scope が矛盾なく説明できれば成立する。
 
 **Acceptance Scenarios**:
 
-1. **Given** 要件文書とドメイン文書を比較する, **When** 頻出度、知的度、習熟度、生成状態を確認する, **Then** 概念の違いと関係が矛盾なく説明できる
-2. **Given** ADR とドメイン文書を比較する, **When** 外部サービスとの責務分担を確認する, **Then** ドメイン内責務と外部依存責務の境界が一貫している
+1. **Given** 要件文書とドメイン文書を比較する, **When** `Sense`、`Meaning`、画像対応を確認する, **Then** 用語差分と移行方針が矛盾なく説明できる
+2. **Given** ADR とドメイン文書を比較する, **When** 単一 `currentImage` の維持と複数 current image の後続 scope を確認する, **Then** 今回の対象範囲と後続範囲が一貫している
 
 ---
 
 ### Edge Cases
 
-- 既存文書で `Explanation` が画像を直接持つ定義と `VisualImage` を独立概念として扱う定義が競合する場合
-- 単語と連語を同じ識別子体系で扱うか、別概念として扱うかで不変条件が変わる場合
-- 同一学習者が同じ英語表現を再登録しようとした場合に、重複として拒否するか更新として扱うかが曖昧な場合
-- 画像再生成時に、過去画像を破棄するのか履歴として保持するのかが曖昧な場合
-- 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態が混同される場合
-- 同じ解説に対して画像生成が重複依頼されたとき、何を同一依頼とみなすか曖昧な場合
-- 外部の単語検証、解説生成、画像生成、アセット保存の責務がドメイン内に入り込む場合
+- 単一の `Explanation` に `Sense` が 1 件しかない場合でも、`Sense` 導入によって説明が過剰に複雑にならないこと
+- `VisualImage` が explanation 全体を代表する画像であり、特定の `Sense` に結びつかない場合を許可するかどうかが曖昧な場合
+- 画像再生成時に `previousImage` と `sense` の関係が崩れ、異なる意味の画像履歴を誤って連結してしまう場合
+- `Meaning.values` の旧表現が残り、`Sense` と explanation-wide meaning の二重管理になる場合
+- `Sense` を導入したことにより、`Frequency`、`Sophistication`、`Proficiency` が意味単位へ吸収されたように誤読される場合
+- `currentImage` を複数 current image と誤解し、完了済み結果のみ表示する rule が崩れる場合
 
 ## Domain & Async Impact *(mandatory when applicable)*
 
-- **Domain Models Affected**: `docs/internal/domain/common.md`, `docs/internal/domain/explanation.md`, `docs/internal/domain/service.md`, `docs/internal/domain/visual.md`, `docs/internal/domain/learner.md`, `docs/internal/domain/vocabulary-expression.md`, `docs/internal/domain/learning-state.md`
-- **Invariants / Terminology**: 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態は別概念として保ち、相互変換や代替関係として扱わない。正規名称は `VocabularyExpression` と `LearningState` を使い、識別子型、repository、値オブジェクトなどの派生名も `VocabularyExpression*` / `LearningState*` に統一する。文字列表現の値オブジェクトは `VocabularyExpressionText` と `NormalizedVocabularyExpressionText` を正規名称とする
-- **Async Lifecycle**: 解説生成と画像生成は少なくとも `pending`、`running`、`succeeded`、`failed` を持ち、再試行と再生成は冪等性を壊さない前提で定義する
-- **User Visibility Rule**: ユーザーに見せる生成物は完了済み結果のみとし、生成中・失敗時は状態のみを表示対象とする
-- **Identifier Naming Rule**: 識別子型は `XxxIdentifier`、集約自身の識別子フィールドは `identifier`、関連識別子フィールドは概念名で定義し、`id`、`ID`、`xxxId`、`xxxIdentifier` は使わない
-- **External Ports / Adapters**: 単語存在確認、登録済み判定、解説生成、画像生成、アセット保存、外部発音リソース参照をドメイン外責務として整理する
+- **Domain Models Affected**: `docs/internal/domain/common.md`, `docs/internal/domain/explanation.md`, `docs/internal/domain/service.md`, `docs/internal/domain/visual.md`
+- **Invariants / Terminology**: `Sense` は `Explanation` 所有の意味単位であり、頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態とは別概念として保つ。`ExampleSentence` と `Collocation` は `Sense` に属し、`Frequency` と `Sophistication` は引き続き `Explanation` に属する。`currentImage` は単一参照のままとする
+- **Async Lifecycle**: 解説生成と画像生成は少なくとも `pending`、`running`、`succeeded`、`failed` を持ち、再試行と再生成は冪等性を壊さない前提で定義する。`Sense` を導入しても、画像生成は新しい成功時だけ `currentImage` を切り替える
+- **User Visibility Rule**: ユーザーに見せる生成物は完了済みの `currentExplanation` と `currentImage` のみとし、生成中・失敗時は状態のみを表示対象とする。`Explanation` が複数の `Sense` を持っていても、今回の current image は 1 件のみ表示対象とする
+- **Identifier Naming Rule**: 識別子型は `XxxIdentifier`、集約自身の識別子フィールドは `identifier`、関連識別子フィールドは概念名で定義し、`id`、`ID`、`xxxId`、`xxxIdentifier` は使わない。`Sense` を導入する場合は `SenseIdentifier` を使う
+- **External Ports / Adapters**: 解説生成、画像生成、アセット保存、外部発音リソース参照をドメイン外責務として整理する。画像生成は必要に応じて対象 `Sense` を指定できるが、ベンダー固有実装は持ち込まない
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: 成果物は、vocastock プロジェクト全体のドメインを対象とし、core flow、学習管理、周辺サブドメインを含む全体境界を明示しなければならない
-- **FR-002**: 成果物は、対象範囲に含まれる主要概念について、意味、責務、関係、不変条件、用語上の区別を定義しなければならない
-- **FR-003**: 成果物は、英単語と連語を同一の `VocabularyExpression` 概念として扱い、その識別、分類、不変条件の共通ルールを定義しなければならない。`VocabularyExpression` は各学習者が所有する登録対象として扱わなければならない
-- **FR-003a**: 成果物は、同じ英語表現の `VocabularyExpression` を同一学習者内で一意に扱い、重複登録判定は学習者境界の内側で行うことを定義しなければならない
-- **FR-004**: 成果物は、頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態を別概念として定義し、その関係と非関係を明文化しなければならない。特に習熟度は学習者ごとに所有される状態として扱わなければならない
-- **FR-005**: 成果物は、解説生成と画像生成について、依頼、進行、完了、失敗、再試行、再生成の業務意味を定義しなければならない
-- **FR-006**: 成果物は、`VisualImage` を `Explanation` とは独立した集約として扱い、生成、再生成、保存先参照、現在表示中画像との関係を定義しなければならない
-- **FR-006a**: 成果物は、画像再生成時に以前の `VisualImage` を履歴として保持し、現在表示中の画像だけを別参照で示す関係を定義しなければならない
-- **FR-007**: 成果物は、ユーザーに見せてよい情報と内部状態を区別し、中間生成結果を表示しないルールを定義しなければならない
-- **FR-008**: 成果物は、単語検証、生成、保存などの外部責務をドメイン内概念と区別し、ポート越しに扱う前提を定義しなければならない
-- **FR-009**: 成果物は、要件、ADR、既存ドメイン文書の用語差分を整理し、どの用語を正として採用するかを示さなければならない。特に `VocabularyExpression` と `LearningState` を正規名称とし、識別子型、repository、値オブジェクトなどの派生名も同じ語幹へ統一しなければならない。文字列表現の値オブジェクト名は `VocabularyExpressionText` と `NormalizedVocabularyExpressionText` を採用しなければならない
-- **FR-010**: 成果物は、学習者を独立集約として定義し、`VocabularyExpression` および学習進捗との関係、および外部 identity / 認証責務との境界を示さなければならない
-- **FR-011**: 成果物は、今回扱わない論点を明示し、後続 feature へ委ねる範囲を示さなければならない
+- **FR-001**: 成果物は、既存の 005 ドメインモデルを前提とした差分機能として、`Explanation` への `Sense` 導入範囲を明示しなければならない
+- **FR-002**: 成果物は、`Sense` を `Explanation` 所有の意味単位として定義し、その意味、責務、関係、不変条件、用語上の区別を示さなければならない
+- **FR-003**: 成果物は、`ExampleSentence` と `Collocation` を explanation-wide の配列ではなく、対応する `Sense` に属する情報として定義しなければならない
+- **FR-004**: 成果物は、`Frequency`、`Sophistication`、`Proficiency`、登録状態、解説生成状態、画像生成状態を `Sense` と混同しないように定義しなければならない
+- **FR-005**: 成果物は、`VisualImage` を `Explanation` とは独立した集約として維持しつつ、必要に応じてどの `Sense` を描写する画像かを示す関係を定義しなければならない
+- **FR-006**: 成果物は、`Explanation.currentImage` を単一の current 参照として維持し、`Sense` 導入だけを理由に複数 current image を導入してはならない
+- **FR-006a**: 成果物は、画像再生成時に以前の `VisualImage` を履歴として保持し、`previousImage` と `sense` の関係が矛盾しない条件を定義しなければならない
+- **FR-007**: 成果物は、`Sense` を導入した後も、ユーザーに見せてよい生成物と内部状態を区別し、中間生成結果を表示しないルールを維持しなければならない
+- **FR-008**: 成果物は、sense-aware な画像生成と保存の責務をドメイン内概念と区別し、外部ポート越しに扱う前提を定義しなければならない
+- **FR-009**: 成果物は、`Meaning` から `Sense` への用語差分と移行メモを整理し、要件、ADR、既存ドメイン文書でどの用語を正として採用するかを示さなければならない
+- **FR-010**: 成果物は、`Learner`、`VocabularyExpression`、`LearningState` の既存 ownership boundary を再定義せず、今回の差分が `Explanation` / `VisualImage` 中心の変更であることを明示しなければならない
+- **FR-011**: 成果物は、今回扱わない論点として「複数 current image を同時に公開する設計」を明示し、後続 feature へ委ねる範囲を示さなければならない
 
 ### Key Entities *(include if feature involves data)*
 
-- **VocabularyExpression**: 学習者が所有する登録対象となる英語表現を表す中心概念であり、単語または連語の扱いを定義対象とし、同一学習者内で一意に管理される。以前は `Entry` と呼んでいた概念の正規名称とする
-- **Learner**: 学習者本人を表す独立集約であり、自身が所有する `VocabularyExpression` と学習進捗の起点となる
-- **Explanation**: 登録対象に対する解説を表す概念であり、意味、発音、頻出度、知的度、例文、類似表現、語源との関係を持つ
-- **VisualImage**: 解説に対応する視覚的表現を表す概念であり、画像生成状態、保存先参照、再生成後の履歴保持の責務境界を持つ
-- **LearningState**: 学習者ごとの習熟状態を表す概念であり、`Learner` と `VocabularyExpression` の関係上で語彙自体の属性と分離された学習進捗を担う。以前は `EntryLearningState` と呼んでいた概念の正規名称とする
-- **Learning Indicators**: 頻出度、知的度、習熟度など、学習上の異なる評価軸を表す概念群であり、習熟度は `LearningState` 側で扱う
-- **Generation State**: 解説生成と画像生成の依頼から完了までを表す業務状態概念であり、表示可否と再試行条件の判断基準になる
+- **Explanation**: `VocabularyExpression` に対する解説を表す概念であり、`Sense`、発音、頻出度、知的度、類似表現、語源、画像生成状態、現在表示中画像との関係を持つ
+- **Sense**: `Explanation` が所有する意味単位であり、意味ラベル、状況、ニュアンス、意味ごとの例文、意味ごとのコロケーションを担う
+- **VisualImage**: 解説に対応する視覚的表現を表す独立集約であり、画像生成状態、保存先参照、再生成後の履歴保持、必要に応じた `Sense` 参照の責務境界を持つ
+- **Meaning-to-Image Mapping**: どの画像が explanation 全体を代表するか、またはどの `Sense` を補助するかを表す関係概念であり、単一 `currentImage` を維持したまま意味対応を説明する判断基準になる
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: 成果物を読んだ第三者が、対象範囲内の主要概念、責務境界、不変条件を 5 分以内に説明できる
-- **SC-002**: 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態の混同に関する文書上の矛盾が 0 件になる
-- **SC-003**: 解説生成と画像生成について、状態遷移、再試行条件、ユーザー表示ルールをレビュー担当者が曖昧さなく判定できる
-- **SC-004**: 要件文書、ADR、ドメイン文書を横断確認したとき、主要概念と責務境界の食い違いが 0 件になる
+- **SC-001**: 成果物を読んだ第三者が、`Sense`、`Explanation`、`VisualImage` の責務差分と ownership boundary を 5 分以内に説明できる
+- **SC-002**: `Sense`、`Meaning`、`Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態の混同に関する文書上の矛盾が 0 件になる
+- **SC-003**: レビュー担当者が、sense-aware image generation と単一 `currentImage` の表示ルールを 5 分以内に判定できる
+- **SC-004**: 要件文書、ADR、ドメイン文書を横断確認したとき、`Sense` 導入差分と後続 scope の食い違いが 0 件になる
 
 ## Assumptions
 
-- 今回の主要成果物はプロジェクト全体のドメインモデル文書とその整合整理であり、アプリケーションコードの実装変更は含まない
-- 既存の architecture / tech stack の決定は所与とし、今回はその上でドメイン言語と責務境界を整理する
+- 005 の既存 docs-first 実装は完了しており、今回はそのうち `Explanation` / `VisualImage` / glossary 周辺の差分更新を行う
+- `Learner`、`VocabularyExpression`、`LearningState` の ownership boundary と命名統一は既存 005 の成果物を正本として再利用する
 - 完了済み結果のみをユーザーに表示するルールは前提として維持する
-- 外部サービスの具体製品選定や API 詳細は扱わず、業務責務とポート境界のみを整理対象とする
+- 外部サービスの具体製品選定や API 詳細は扱わず、sense-aware な業務責務とポート境界のみを整理対象とする
+- 複数 current image の同時公開は今回の scope 外であり、`Sense` 導入後の follow-on feature で扱う

--- a/specs/005-domain-modeling/tasks.md
+++ b/specs/005-domain-modeling/tasks.md
@@ -17,9 +17,9 @@
 
 **Purpose**: 新しい source-of-truth 文書の受け皿を作る
 
-- [ ] T001 [P] Create learner source-of-truth skeleton in docs/internal/domain/learner.md
-- [ ] T002 [P] Create vocabulary expression source-of-truth skeleton in docs/internal/domain/vocabulary-expression.md
-- [ ] T003 [P] Create learning state source-of-truth skeleton in docs/internal/domain/learning-state.md
+- [X] T001 [P] Create learner source-of-truth skeleton in docs/internal/domain/learner.md
+- [X] T002 [P] Create vocabulary expression source-of-truth skeleton in docs/internal/domain/vocabulary-expression.md
+- [X] T003 [P] Create learning state source-of-truth skeleton in docs/internal/domain/learning-state.md
 
 ---
 
@@ -29,9 +29,9 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T004 Define canonical glossary, deprecated-name crosswalk, and naming rules in docs/internal/domain/common.md
-- [ ] T005 Add source-of-truth index and aggregate relationship overview in docs/internal/domain/common.md
-- [ ] T006 Add backlinks from docs/internal/domain/explanation.md, docs/internal/domain/visual.md, and docs/internal/domain/service.md to the new source-of-truth files
+- [X] T004 Define canonical glossary, deprecated-name crosswalk, and naming rules in docs/internal/domain/common.md
+- [X] T005 Add source-of-truth index and aggregate relationship overview in docs/internal/domain/common.md
+- [X] T006 Add backlinks from docs/internal/domain/explanation.md, docs/internal/domain/visual.md, and docs/internal/domain/service.md to the new source-of-truth files
 
 **Checkpoint**: Foundation ready - user story implementation can now begin in parallel
 
@@ -45,11 +45,11 @@
 
 ### Implementation for User Story 1
 
-- [ ] T007 [US1] Define `Learner` aggregate, external identity boundary, and ownership semantics in docs/internal/domain/learner.md
-- [ ] T008 [P] [US1] Define `VocabularyExpression` aggregate, uniqueness scope, `VocabularyExpressionText`, `NormalizedVocabularyExpressionText`, and `currentExplanation` in docs/internal/domain/vocabulary-expression.md
-- [ ] T009 [P] [US1] Define `LearningState` aggregate, `Proficiency` ownership, and relations to `Learner` / `VocabularyExpression` in docs/internal/domain/learning-state.md
-- [ ] T010 [US1] Reframe `Explanation` domain narrative around `VocabularyExpression` references in docs/internal/domain/explanation.md
-- [ ] T011 [US1] Add relationship cross-links across docs/internal/domain/learner.md, docs/internal/domain/vocabulary-expression.md, docs/internal/domain/learning-state.md, and docs/internal/domain/explanation.md
+- [X] T007 [US1] Define `Learner` aggregate, external identity boundary, and ownership semantics in docs/internal/domain/learner.md
+- [X] T008 [P] [US1] Define `VocabularyExpression` aggregate, uniqueness scope, `VocabularyExpressionText`, `NormalizedVocabularyExpressionText`, and `currentExplanation` in docs/internal/domain/vocabulary-expression.md
+- [X] T009 [P] [US1] Define `LearningState` aggregate, `Proficiency` ownership, and relations to `Learner` / `VocabularyExpression` in docs/internal/domain/learning-state.md
+- [X] T010 [US1] Reframe `Explanation` domain narrative around `VocabularyExpression` references in docs/internal/domain/explanation.md
+- [X] T011 [US1] Add relationship cross-links across docs/internal/domain/learner.md, docs/internal/domain/vocabulary-expression.md, docs/internal/domain/learning-state.md, and docs/internal/domain/explanation.md
 
 **Checkpoint**: User Story 1 should be independently understandable and reviewable
 
@@ -63,11 +63,11 @@
 
 ### Implementation for User Story 2
 
-- [ ] T012 [P] [US2] Document `VocabularyExpression` explanation-generation lifecycle, retry/regenerate rules, and `currentExplanation` visibility in docs/internal/domain/vocabulary-expression.md
-- [ ] T013 [P] [US2] Document `Explanation` image-generation lifecycle and `currentImage` visibility in docs/internal/domain/explanation.md
-- [ ] T014 [P] [US2] Document `VisualImage` history, `previousImage` chain, and current-image handoff in docs/internal/domain/visual.md
-- [ ] T015 [US2] Align generation, storage, and failure responsibilities with external ports in docs/internal/domain/service.md
-- [ ] T016 [US2] Reconcile async visibility language across docs/internal/domain/vocabulary-expression.md, docs/internal/domain/explanation.md, docs/internal/domain/visual.md, and docs/internal/domain/service.md
+- [X] T012 [P] [US2] Document `VocabularyExpression` explanation-generation lifecycle, retry/regenerate rules, and `currentExplanation` visibility in docs/internal/domain/vocabulary-expression.md
+- [X] T013 [P] [US2] Document `Explanation` image-generation lifecycle and `currentImage` visibility in docs/internal/domain/explanation.md
+- [X] T014 [P] [US2] Document `VisualImage` history, `previousImage` chain, and current-image handoff in docs/internal/domain/visual.md
+- [X] T015 [US2] Align generation, storage, and failure responsibilities with external ports in docs/internal/domain/service.md
+- [X] T016 [US2] Reconcile async visibility language across docs/internal/domain/vocabulary-expression.md, docs/internal/domain/explanation.md, docs/internal/domain/visual.md, and docs/internal/domain/service.md
 
 **Checkpoint**: User Story 2 should be independently reviewable without relying on intermediate generated results
 
@@ -81,12 +81,12 @@
 
 ### Implementation for User Story 3
 
-- [ ] T017 [P] [US3] Replace `Entry` terminology with `VocabularyExpression` terms in docs/external/requirements.md
-- [ ] T018 [P] [US3] Replace `Entry` / `EntryLearningState` terminology and port names in docs/external/adr.md
-- [ ] T019 [US3] Add canonical terminology and deprecated synonym guidance in docs/internal/domain/common.md
-- [ ] T020 [US3] Normalize `VocabularyExpressionText` and `NormalizedVocabularyExpressionText` naming in docs/external/requirements.md and docs/external/adr.md
-- [ ] T021 [US3] Add out-of-scope / deferred scope guidance and follow-on feature boundaries in docs/internal/domain/common.md and docs/external/adr.md
-- [ ] T022 [US3] Cross-check terminology consistency and deferred scope alignment across docs/external/requirements.md, docs/external/adr.md, and docs/internal/domain/common.md
+- [X] T017 [P] [US3] Replace `Entry` terminology with `VocabularyExpression` terms in docs/external/requirements.md
+- [X] T018 [P] [US3] Replace `Entry` / `EntryLearningState` terminology and port names in docs/external/adr.md
+- [X] T019 [US3] Add canonical terminology and deprecated synonym guidance in docs/internal/domain/common.md
+- [X] T020 [US3] Normalize `VocabularyExpressionText` and `NormalizedVocabularyExpressionText` naming in docs/external/requirements.md and docs/external/adr.md
+- [X] T021 [US3] Add out-of-scope / deferred scope guidance and follow-on feature boundaries in docs/internal/domain/common.md and docs/external/adr.md
+- [X] T022 [US3] Cross-check terminology consistency and deferred scope alignment across docs/external/requirements.md, docs/external/adr.md, and docs/internal/domain/common.md
 
 **Checkpoint**: User Story 3 should make the external docs and glossary align on the same canonical terms and deferred boundaries
 
@@ -96,8 +96,8 @@
 
 **Purpose**: 最終整合確認と残差分の除去
 
-- [ ] T023 Validate specs/005-domain-modeling/quickstart.md against docs/internal/domain/learner.md, docs/internal/domain/vocabulary-expression.md, docs/internal/domain/learning-state.md, docs/internal/domain/explanation.md, docs/internal/domain/visual.md, docs/internal/domain/service.md, docs/external/requirements.md, and docs/external/adr.md
-- [ ] T024 Remove leftover deprecated-name references beyond the allowed migration note across docs/internal/domain/*.md and docs/external/*.md
+- [X] T023 Validate specs/005-domain-modeling/quickstart.md against docs/internal/domain/learner.md, docs/internal/domain/vocabulary-expression.md, docs/internal/domain/learning-state.md, docs/internal/domain/explanation.md, docs/internal/domain/visual.md, docs/internal/domain/service.md, docs/external/requirements.md, and docs/external/adr.md
+- [X] T024 Remove leftover deprecated-name references beyond the allowed migration note across docs/internal/domain/*.md and docs/external/*.md
 
 ---
 

--- a/specs/005-domain-modeling/tasks.md
+++ b/specs/005-domain-modeling/tasks.md
@@ -1,9 +1,9 @@
 # Tasks: ドメインモデリング
 
-**Input**: Design documents from `/Users/lihs/workspace/vocastock/specs/005-domain-modeling/`
+**Input**: Design documents from `/Users/lihs/workspace/vocastock/specs/005-domain-modeling/`  
 **Prerequisites**: [plan.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/plan.md), [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md), [research.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/research.md), [data-model.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/data-model.md), [quickstart.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/quickstart.md), [contracts/](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/contracts)
 
-**Tests**: 自動テストは明示要求されていないため生成しない。各 user story は spec.md の独立テスト条件と quickstart の cross-review 手順で検証する。
+**Tests**: 自動テストは追加しない。各 user story は spec.md の独立テスト条件と quickstart の cross-review 手順で検証する。
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 
@@ -15,23 +15,23 @@
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-**Purpose**: 新しい source-of-truth 文書の受け皿を作る
+**Purpose**: `Sense` 導入で触る正本文書の受け皿を整える
 
-- [X] T001 [P] Create learner source-of-truth skeleton in docs/internal/domain/learner.md
-- [X] T002 [P] Create vocabulary expression source-of-truth skeleton in docs/internal/domain/vocabulary-expression.md
-- [X] T003 [P] Create learning state source-of-truth skeleton in docs/internal/domain/learning-state.md
+- [X] T001 Create `Sense` review anchors and migration-note placeholders in /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
+- [X] T002 [P] Create `Sense` section placeholders for aggregate/entity updates in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md and /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md
 
 ---
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-**Purpose**: すべての user story で共有する命名規約と導線を固める
+**Purpose**: すべての user story で共有する用語、識別子、mapping 前提を固める
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [X] T004 Define canonical glossary, deprecated-name crosswalk, and naming rules in docs/internal/domain/common.md
-- [X] T005 Add source-of-truth index and aggregate relationship overview in docs/internal/domain/common.md
-- [X] T006 Add backlinks from docs/internal/domain/explanation.md, docs/internal/domain/visual.md, and docs/internal/domain/service.md to the new source-of-truth files
+- [X] T003 Define canonical `Sense` terminology, `Meaning` migration note, and project-wide mapping rules in /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
+- [X] T004 [P] Align `SenseIdentifier` naming, ownership language, and related-field naming across /Users/lihs/workspace/vocastock/docs/internal/domain/common.md, /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md, and /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md
+- [X] T005 [P] Document the single-current-image rule and meaning-to-image mapping baseline in /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
+- [X] T006 Add `Sense`-aware image generation and storage port vocabulary in /Users/lihs/workspace/vocastock/docs/internal/domain/service.md
 
 **Checkpoint**: Foundation ready - user story implementation can now begin in parallel
 
@@ -39,17 +39,17 @@
 
 ## Phase 3: User Story 1 - 主要概念の境界を定める (Priority: P1) 🎯 MVP
 
-**Goal**: `Learner`、`VocabularyExpression`、`LearningState`、`Explanation` の責務境界を一貫した用語で定義する
+**Goal**: `Sense` を `Explanation` 所有の意味単位として定義し、`Explanation` / `VisualImage` との責務差分を明確化する
 
-**Independent Test**: 第三者が docs/internal/domain/learner.md、docs/internal/domain/vocabulary-expression.md、docs/internal/domain/learning-state.md、docs/internal/domain/explanation.md、docs/internal/domain/common.md だけを読み、主要概念、所有境界、不変条件を 5 分以内に説明できること
+**Independent Test**: 第三者が /Users/lihs/workspace/vocastock/docs/internal/domain/common.md、/Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md、/Users/lihs/workspace/vocastock/docs/internal/domain/visual.md だけを読み、`Sense`、`Explanation`、`VisualImage` の責務と不変条件を 5 分以内に説明できること
 
 ### Implementation for User Story 1
 
-- [X] T007 [US1] Define `Learner` aggregate, external identity boundary, and ownership semantics in docs/internal/domain/learner.md
-- [X] T008 [P] [US1] Define `VocabularyExpression` aggregate, uniqueness scope, `VocabularyExpressionText`, `NormalizedVocabularyExpressionText`, and `currentExplanation` in docs/internal/domain/vocabulary-expression.md
-- [X] T009 [P] [US1] Define `LearningState` aggregate, `Proficiency` ownership, and relations to `Learner` / `VocabularyExpression` in docs/internal/domain/learning-state.md
-- [X] T010 [US1] Reframe `Explanation` domain narrative around `VocabularyExpression` references in docs/internal/domain/explanation.md
-- [X] T011 [US1] Add relationship cross-links across docs/internal/domain/learner.md, docs/internal/domain/vocabulary-expression.md, docs/internal/domain/learning-state.md, and docs/internal/domain/explanation.md
+- [X] T007 [US1] Define `Sense` as an `Explanation`-owned internal entity with fields, order, and invariants in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
+- [X] T008 [P] [US1] Replace coarse `Meaning` ownership with `Explanation.senses` language in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
+- [X] T009 [P] [US1] Move example and collocation ownership from explanation-wide wording to sense-specific wording in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
+- [X] T010 [US1] Add cross-links from /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md to /Users/lihs/workspace/vocastock/docs/internal/domain/common.md and /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md for `Sense` semantics
+- [X] T011 [US1] Reconcile `Explanation` aggregate summary and invariants with the `Sense` model in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
 
 **Checkpoint**: User Story 1 should be independently understandable and reviewable
 
@@ -57,47 +57,44 @@
 
 ## Phase 4: User Story 2 - 非同期生成の業務意味を定める (Priority: P2)
 
-**Goal**: 解説生成と画像生成の状態、再試行、再生成、表示可否を domain language で明文化する
+**Goal**: `Sense` 導入後も画像生成の current 参照、retry、regenerate、表示可否を壊さないようにする
 
-**Independent Test**: レビュー担当者が docs/internal/domain/vocabulary-expression.md、docs/internal/domain/explanation.md、docs/internal/domain/visual.md、docs/internal/domain/service.md だけを読み、生成依頼から完了・失敗・再生成までの状態遷移と表示ルールを説明できること
+**Independent Test**: レビュー担当者が /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md、/Users/lihs/workspace/vocastock/docs/internal/domain/visual.md、/Users/lihs/workspace/vocastock/docs/internal/domain/service.md だけを読み、sense-aware image generation と単一 `currentImage` の業務意味を説明できること
 
 ### Implementation for User Story 2
 
-- [X] T012 [P] [US2] Document `VocabularyExpression` explanation-generation lifecycle, retry/regenerate rules, and `currentExplanation` visibility in docs/internal/domain/vocabulary-expression.md
-- [X] T013 [P] [US2] Document `Explanation` image-generation lifecycle and `currentImage` visibility in docs/internal/domain/explanation.md
-- [X] T014 [P] [US2] Document `VisualImage` history, `previousImage` chain, and current-image handoff in docs/internal/domain/visual.md
-- [X] T015 [US2] Align generation, storage, and failure responsibilities with external ports in docs/internal/domain/service.md
-- [X] T016 [US2] Reconcile async visibility language across docs/internal/domain/vocabulary-expression.md, docs/internal/domain/explanation.md, docs/internal/domain/visual.md, and docs/internal/domain/service.md
+- [X] T012 [P] [US2] Document `currentImage` as a single completed image even when multiple `Sense` values exist in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
+- [X] T013 [P] [US2] Define `VisualImage.sense`, same-explanation ownership, and same-sense regeneration constraints in /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md
+- [X] T014 [P] [US2] Update image generation port wording to accept `sense?` and preserve completion-only visibility in /Users/lihs/workspace/vocastock/docs/internal/domain/service.md
+- [X] T015 [US2] Reconcile retry/regenerate and visibility language across /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md, /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md, and /Users/lihs/workspace/vocastock/docs/internal/domain/service.md
 
-**Checkpoint**: User Story 2 should be independently reviewable without relying on intermediate generated results
+**Checkpoint**: User Story 2 should be independently reviewable without exposing intermediate results
 
 ---
 
 ## Phase 5: User Story 3 - 文書横断で用語と deferred scope を統一する (Priority: P3)
 
-**Goal**: 要件、ADR、既存 domain docs の用語と out-of-scope / deferred 範囲を `VocabularyExpression` / `LearningState` 前提で整合させる
+**Goal**: 要件、ADR、共通 glossary を `Sense` 前提へ揃え、複数 current image を後続 scope として明示する
 
-**Independent Test**: docs/external/requirements.md、docs/external/adr.md、docs/internal/domain/common.md を横断して、主要概念、責務境界、今回扱わない論点が矛盾なく整理されていると第三者が判定できること
+**Independent Test**: /Users/lihs/workspace/vocastock/docs/external/requirements.md、/Users/lihs/workspace/vocastock/docs/external/adr.md、/Users/lihs/workspace/vocastock/docs/internal/domain/common.md を横断して、`Sense` 導入、meaning-to-image mapping、follow-on scope が矛盾なく説明できること
 
 ### Implementation for User Story 3
 
-- [X] T017 [P] [US3] Replace `Entry` terminology with `VocabularyExpression` terms in docs/external/requirements.md
-- [X] T018 [P] [US3] Replace `Entry` / `EntryLearningState` terminology and port names in docs/external/adr.md
-- [X] T019 [US3] Add canonical terminology and deprecated synonym guidance in docs/internal/domain/common.md
-- [X] T020 [US3] Normalize `VocabularyExpressionText` and `NormalizedVocabularyExpressionText` naming in docs/external/requirements.md and docs/external/adr.md
-- [X] T021 [US3] Add out-of-scope / deferred scope guidance and follow-on feature boundaries in docs/internal/domain/common.md and docs/external/adr.md
-- [X] T022 [US3] Cross-check terminology consistency and deferred scope alignment across docs/external/requirements.md, docs/external/adr.md, and docs/internal/domain/common.md
+- [X] T016 [P] [US3] Add `Sense` terminology and meaning-unit language to /Users/lihs/workspace/vocastock/docs/external/requirements.md
+- [X] T017 [P] [US3] Add `Sense` boundary, single-current-image decision, and follow-on scope notes to /Users/lihs/workspace/vocastock/docs/external/adr.md
+- [X] T018 [US3] Update deferred-scope guidance for multi-image-per-explanation follow-on work in /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
+- [X] T019 [US3] Cross-check `Sense`, `Meaning`, and image mapping terminology across /Users/lihs/workspace/vocastock/docs/external/requirements.md, /Users/lihs/workspace/vocastock/docs/external/adr.md, and /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
 
-**Checkpoint**: User Story 3 should make the external docs and glossary align on the same canonical terms and deferred boundaries
+**Checkpoint**: User Story 3 should make external docs and glossary align on `Sense` and follow-on boundaries
 
 ---
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-**Purpose**: 最終整合確認と残差分の除去
+**Purpose**: 最終整合確認と旧表現の残差分除去
 
-- [X] T023 Validate specs/005-domain-modeling/quickstart.md against docs/internal/domain/learner.md, docs/internal/domain/vocabulary-expression.md, docs/internal/domain/learning-state.md, docs/internal/domain/explanation.md, docs/internal/domain/visual.md, docs/internal/domain/service.md, docs/external/requirements.md, and docs/external/adr.md
-- [X] T024 Remove leftover deprecated-name references beyond the allowed migration note across docs/internal/domain/*.md and docs/external/*.md
+- [X] T020 Validate /Users/lihs/workspace/vocastock/specs/005-domain-modeling/quickstart.md and /Users/lihs/workspace/vocastock/specs/005-domain-modeling/contracts/sense-image-mapping-contract.md against /Users/lihs/workspace/vocastock/docs/internal/domain/common.md, /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md, /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md, /Users/lihs/workspace/vocastock/docs/internal/domain/service.md, /Users/lihs/workspace/vocastock/docs/external/requirements.md, and /Users/lihs/workspace/vocastock/docs/external/adr.md
+- [X] T021 Remove leftover explanation-wide `Meaning.values` wording and ambiguous multi-image wording beyond intentional migration notes across /Users/lihs/workspace/vocastock/docs/internal/domain/*.md and /Users/lihs/workspace/vocastock/docs/external/*.md
 
 ---
 
@@ -118,40 +115,41 @@
 
 ### Within Each User Story
 
-- Shared terminology and backlinks from Foundational must exist first
-- Source-of-truth files before cross-links that reference them
-- Aggregate definitions before cross-document reconciliation
-- Story completion before Polish validation
+- Shared terminology, identifier rules, and mapping baselines from Foundational must exist first
+- `Explanation` aggregate updates before cross-links that depend on `Sense`
+- `VisualImage.sense` rules before async reconciliation that references them
+- External-doc alignment before final terminology cleanup
 
 ### Parallel Opportunities
 
-- T001, T002, T003 can run in parallel
+- T002 can run in parallel with T001
+- T004 and T005 can run in parallel
 - T008 and T009 can run in parallel
 - T012, T013, and T014 can run in parallel
-- T017, T018, and T021 can run in parallel
+- T016 and T017 can run in parallel
 
 ---
 
 ## Parallel Example: User Story 1
 
 ```bash
-Task: "Define `VocabularyExpression` aggregate in docs/internal/domain/vocabulary-expression.md"
-Task: "Define `LearningState` aggregate in docs/internal/domain/learning-state.md"
+Task: "Replace coarse `Meaning` ownership with `Explanation.senses` language in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md"
+Task: "Move example and collocation ownership to sense-specific wording in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md"
 ```
 
 ## Parallel Example: User Story 2
 
 ```bash
-Task: "Document `VocabularyExpression` explanation-generation lifecycle in docs/internal/domain/vocabulary-expression.md"
-Task: "Document `Explanation` image-generation lifecycle in docs/internal/domain/explanation.md"
-Task: "Document `VisualImage` history in docs/internal/domain/visual.md"
+Task: "Document single `currentImage` behavior in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md"
+Task: "Define `VisualImage.sense` constraints in /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md"
+Task: "Update sense-aware image generation port wording in /Users/lihs/workspace/vocastock/docs/internal/domain/service.md"
 ```
 
 ## Parallel Example: User Story 3
 
 ```bash
-Task: "Replace terminology in docs/external/requirements.md"
-Task: "Replace terminology in docs/external/adr.md"
+Task: "Add `Sense` terminology to /Users/lihs/workspace/vocastock/docs/external/requirements.md"
+Task: "Add `Sense` boundary and follow-on scope notes to /Users/lihs/workspace/vocastock/docs/external/adr.md"
 ```
 
 ---
@@ -163,20 +161,20 @@ Task: "Replace terminology in docs/external/adr.md"
 1. Complete Phase 1: Setup
 2. Complete Phase 2: Foundational
 3. Complete Phase 3: User Story 1
-4. **STOP and VALIDATE**: Review the concept boundaries independently before proceeding
+4. **STOP and VALIDATE**: Review the `Sense` / `Explanation` / `VisualImage` boundaries independently before proceeding
 
 ### Incremental Delivery
 
 1. Complete Setup + Foundational
-2. Deliver User Story 1 and verify concept boundaries
-3. Deliver User Story 2 and verify async lifecycle / visibility rules
+2. Deliver User Story 1 and verify `Sense` boundary
+3. Deliver User Story 2 and verify sense-aware async visibility rules
 4. Deliver User Story 3 and verify cross-document terminology alignment
-5. Run Polish validation against quickstart and remove leftover old names
+5. Run Polish validation against quickstart and contracts, then remove leftover old wording
 
 ### Parallel Team Strategy
 
-1. One writer prepares the three new source-of-truth files in Phase 1
-2. A second writer stabilizes glossary and backlinks in Phase 2
+1. One writer prepares glossary anchors and placeholders in Phase 1
+2. A second writer stabilizes identifier and mapping rules in Phase 2
 3. After Foundational:
    - Writer A: User Story 1
    - Writer B: User Story 2
@@ -189,5 +187,5 @@ Task: "Replace terminology in docs/external/adr.md"
 - [P] tasks = different files, no dependencies
 - [US1], [US2], [US3] labels map tasks to user stories for traceability
 - Each user story is independently reviewable with its own document set
-- Keep deprecated names only where the migration note explicitly calls them out once
+- Keep `currentImage` singular in this feature; multi-current-image support is follow-on scope
 - Commit after each logical group of document changes

--- a/specs/007-backend-command-design/checklists/requirements.md
+++ b/specs/007-backend-command-design/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: バックエンド Command 設計
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-17  
+**Feature**: [spec.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 既存の architecture / domain 決定を前提とした command 設計 feature として整理し、実装技術そのものは scope から外した。
+- `specs/005-domain-modeling/spec.md` を暫定 semantic source とする条件と、`docs/internal/domain/learner.md`、`vocabulary-expression.md`、`learning-state.md` へ切り替える exit 条件を spec に明記した。

--- a/specs/007-backend-command-design/contracts/command-acceptance-contract.md
+++ b/specs/007-backend-command-design/contracts/command-acceptance-contract.md
@@ -1,0 +1,27 @@
+# Contract: Command Acceptance
+
+## Purpose
+
+command ごとの受理条件、拒否条件、重複時の扱い、利用者向け即時応答を固定する。
+
+## Acceptance Rules
+
+| Command | Accept When | Reject When | Reuse Existing When | User-visible Response |
+|--------|-------------|-------------|---------------------|----------------------|
+| `registerVocabularyExpression` | 同一学習者内で未登録、または明示条件を満たす登録のみ | 所有者不整合、入力不正、抑止不能な前提違反 | 同一学習者内で同じ正規化表現が既に存在する | `accepted` または `reused-existing` と対象状態要約 |
+| `requestExplanationGeneration` | 対象登録表現が存在し、所有者整合を満たす | 対象不在、所有者不整合、前提状態不正 | 同一業務キーで `pending` / `running` が既に存在する | 状態要約のみ。解説本文は返さない |
+| `requestImageGeneration` | 対象解説が完了済みで、所有者整合を満たす | 解説未完了、対象不在、所有者不整合 | 同一業務キーで `pending` / `running` が既に存在する | 状態要約のみ。画像本体は返さない |
+| `retryGeneration` | 対象生成が `failed` | 対象が `failed` でない、所有者不整合 | 同一 retry 要求が既に受理済みである | retry 受付結果と状態要約 |
+
+## Duplicate Registration Rule
+
+- 同一学習者内の重複登録は新規作成しない
+- 既存 `VocabularyExpression` と現在状態を返す
+- 既存状態が `not-started` または `failed` で、かつ開始抑止がない場合だけ追加の生成開始を再受理する
+- 既存状態が `pending`、`running`、`succeeded`、または開始抑止がある場合は追加の生成開始を行わない
+- 重複登録時の即時応答は既存対象参照と現在状態を返し、再開有無は状態要約または次アクションで示す
+
+## Visibility Rule
+
+- `accepted`、`reused-existing`、`rejected`、`failed` のいずれでも、未完了成果物本体は返してはならない
+- 利用者へ返すのは状態要約、対象参照、次アクションだけである

--- a/specs/007-backend-command-design/contracts/command-boundary-contract.md
+++ b/specs/007-backend-command-design/contracts/command-boundary-contract.md
@@ -1,0 +1,28 @@
+# Contract: Command Boundary
+
+## Purpose
+
+backend command 境界が直接持つ責務、持たない責務、依存する境界を固定する。
+
+## Responsibility Split
+
+| Boundary | Owns | Must Not Own | Depends On |
+|----------|------|--------------|------------|
+| Backend Command | 登録、生成開始、再試行の受理、前提条件確認、重複判定、即時応答 | 長時間生成処理、read model 整形、provider SDK 直結 | validation port、repository port、workflow dispatch port、authentication subject resolution |
+| Query | 表示用 read model の組み立て | 状態変更、生成開始受理 | projection / repository |
+| Workflow | 長時間生成処理、状態遷移、完了 / 失敗確定 | command 受理判断、利用者入力の解釈 | provider port、storage port |
+| Client | command 起動と状態表示 | backend 内部状態判断、provider 直結 | command contract、query contract |
+
+## Port Rules
+
+- `WordValidationPort` は command 受理前の副作用なし検証だけに使う
+- repository port は command 側の状態確認と状態確定に限定して使う
+- workflow dispatch port は command 受理確定の一部であり、成功しない限り `pending` を確定しない
+- provider 個別実装や storage 個別実装は command 境界へ持ち込まない
+
+## Out of Scope
+
+- query schema や read model 詳細
+- workflow 実行本体の state machine
+- provider ごとの request / response 詳細
+- infrastructure adapter の実装方式

--- a/specs/007-backend-command-design/contracts/command-catalog-contract.md
+++ b/specs/007-backend-command-design/contracts/command-catalog-contract.md
@@ -1,0 +1,21 @@
+# Contract: Command Catalog
+
+## Purpose
+
+backend command 境界が受け付ける主要 command と、その意図、対象、即時応答の輪郭を固定する。
+
+## Command Catalog
+
+| Command | Primary Intent | Target | Default Behavior | Immediate Response |
+|--------|-----------------|--------|------------------|--------------------|
+| `registerVocabularyExpression` | 新規登録 | learner-owned `VocabularyExpression` | 既定では解説生成開始まで受け付ける。明示的に開始抑止もできる。重複登録時は既存状態が `not-started` または `failed` で、かつ開始抑止がない場合だけ再開する | 受付結果、対象参照、状態要約 |
+| `requestExplanationGeneration` | 解説生成開始 / 再生成 | `VocabularyExpression` | 対象が所有者整合を満たす場合のみ受け付ける | 受付結果、対象参照、状態要約 |
+| `requestImageGeneration` | 画像生成開始 / 再生成 | `Explanation` | 対応する解説が完了済みの場合のみ受け付ける | 受付結果、対象参照、状態要約 |
+| `retryGeneration` | 失敗済み生成の再試行 | failed explanation or image generation | 同一業務キーまたは明示的 retry reason に基づいて受け付ける | 受付結果、対象参照、状態要約 |
+
+## Rules
+
+- command は長時間生成そのものを実行しない
+- command は完了済み成果物本文や画像本体を即時応答に含めない
+- command 名は意図を表す正規名称として扱い、query 名や workflow 名と混同してはならない
+- command catalog にない状態変更要求は backend command 境界の外とみなす

--- a/specs/007-backend-command-design/contracts/command-dispatch-consistency-contract.md
+++ b/specs/007-backend-command-design/contracts/command-dispatch-consistency-contract.md
@@ -1,0 +1,28 @@
+# Contract: Command Dispatch Consistency
+
+## Purpose
+
+command の受付確定と workflow dispatch の成否が不整合にならないよう、状態確定順序と failure handling を固定する。
+
+## Consistency Rules
+
+| Case | Command Outcome | Persisted State | User-visible Result | Internal Handling |
+|------|------------------|-----------------|---------------------|------------------|
+| dispatch 成功 | `accepted` | 受付済み初期状態を確定してよい | 状態要約を返す | correlation 情報を保持する |
+| dispatch 失敗 | `failed` | 受付済み `pending` を確定しない | 受付失敗の要約のみ返す | failure detail を内部に保持する |
+| duplicate in `not-started/failed` without suppression | `reused-existing` | 既存対象を再利用し、dispatch 成功時のみ新しい生成要求を確定してよい | 既存参照と再開後の状態要約を返す | 同一登録対象を再利用し、再開条件を記録する |
+| duplicate in `pending/running` | `reused-existing` | 新規状態は作らない | 既存状態を返す | 同一業務キーを再利用する |
+| invalid precondition | `rejected` | 状態変更なし | 拒否理由の要約のみ返す | validation detail を内部に保持してよい |
+
+## Ordering Rule
+
+1. 入力と所有者整合を確認する
+2. 重複、既存進行中要求、または重複再開条件の有無を確認する
+3. dispatch 成功を伴う受理だけを受付済みとして確定する
+4. dispatch 失敗時は command 全体を不成立として扱う
+
+## Prohibited States
+
+- dispatch 不成立なのに `pending` が見える状態
+- 利用者向け即時応答と内部保持状態が食い違う状態
+- duplicate 要求ごとに別の業務キーを増やしてしまう状態

--- a/specs/007-backend-command-design/data-model.md
+++ b/specs/007-backend-command-design/data-model.md
@@ -1,0 +1,248 @@
+# Data Model: バックエンド Command 設計
+
+## Command Design Overview
+
+```mermaid
+classDiagram
+    class CommandDefinition {
+        <<DesignEntity>>
+        +CommandName name
+        +CommandIntent intent
+        +AcceptanceRule acceptanceRule
+        +AcceptanceResult successResult
+        +AcceptanceResult rejectionResult
+        +IdempotencyKeyDefinition idempotencyKey
+    }
+
+    class RegisterVocabularyExpressionCommand {
+        <<Command>>
+        +LearnerIdentifier learner
+        +VocabularyExpressionText text
+        +bool startExplanationByDefault
+        +bool suppressExplanationStart
+    }
+
+    class RequestExplanationGenerationCommand {
+        <<Command>>
+        +LearnerIdentifier learner
+        +VocabularyExpressionIdentifier vocabularyExpression
+        +ExplanationRequestReason reason
+    }
+
+    class RequestImageGenerationCommand {
+        <<Command>>
+        +LearnerIdentifier learner
+        +ExplanationIdentifier explanation
+        +ImageRequestReason reason
+    }
+
+    class RetryGenerationCommand {
+        <<Command>>
+        +LearnerIdentifier learner
+        +TargetKind targetKind
+        +TargetIdentifier target
+        +RetryReason reason
+    }
+
+    class AcceptanceResult {
+        <<DesignEntity>>
+        +AcceptanceOutcome outcome
+        +StateSummary summary
+        +ReturnedReference returnedReference
+        +NextAction nextAction
+    }
+
+    class DuplicateRegistrationResult {
+        <<DesignEntity>>
+        +ReturnedReference existingReference
+        +StateSummary currentState
+        +DuplicateRestartDecision restartDecision
+        +RestartConditionSummary restartCondition
+    }
+
+    class DispatchConsistencyRule {
+        <<DesignEntity>>
+        +bool pendingRequiresDispatchSuccess
+        +FailureSummary failureSummary
+        +InternalFailureDetail internalFailureDetail
+    }
+
+    CommandDefinition --> AcceptanceResult : returns
+    RegisterVocabularyExpressionCommand --> DuplicateRegistrationResult : mayReturn
+    CommandDefinition --> DispatchConsistencyRule : constrainedBy
+    RegisterVocabularyExpressionCommand --> CommandDefinition : describedBy
+    RequestExplanationGenerationCommand --> CommandDefinition : describedBy
+    RequestImageGenerationCommand --> CommandDefinition : describedBy
+    RetryGenerationCommand --> CommandDefinition : describedBy
+```
+
+## Design Entity: CommandDefinition
+
+**Purpose**: backend command ごとの受理対象、前提条件、冪等性、即時応答を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| name | CommandName | 1 | command の正規名称 |
+| intent | CommandIntent | 1 | 何を変えようとする command か |
+| acceptanceRule | AcceptanceRule | 1 | 受理条件、拒否条件、重複時扱い |
+| successResult | AcceptanceResult | 1 | 受理時の即時応答 |
+| rejectionResult | AcceptanceResult | 1 | 不受理時の即時応答 |
+| idempotencyKey | IdempotencyKeyDefinition | 1 | 同一業務要求の畳み込み規則 |
+
+**Validation rules**:
+
+- `name` は command catalog 内で一意でなければならない
+- `successResult` は未完了成果物本体を含んではならない
+- `rejectionResult` は内部 failure detail を含んではならない
+
+## Command: RegisterVocabularyExpressionCommand
+
+**Purpose**: 学習者所有の新規 `VocabularyExpression` を登録し、通常は解説生成開始まで受け付ける。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| learner | LearnerIdentifier | 1 | 登録主体 |
+| text | VocabularyExpressionText | 1 | 登録対象表現 |
+| startExplanationByDefault | boolean | 1 | 通常経路では `true` とみなす |
+| suppressExplanationStart | boolean | 1 | `true` の場合は登録のみ受理する |
+
+**Acceptance rules**:
+
+- `learner + normalizedText` が未登録なら新規登録候補として扱う
+- `suppressExplanationStart = false` の場合、登録と解説生成開始を一体として受理対象にする
+- 重複登録時は新規作成を行わず、既存 `VocabularyExpression` と現在状態を返す
+- 重複登録時でも、既存状態が `not-started` または `failed` で、かつ `suppressExplanationStart = false` の場合だけ生成開始を再受理する
+- 既存状態が `pending`、`running`、`succeeded`、または `suppressExplanationStart = true` の場合は追加生成を開始しない
+
+**State impact**:
+
+- 新規登録時のみ登録対象を作成する
+- 解説生成開始を伴う場合のみ、dispatch 成功後に初期状態を確定する
+- 重複登録かつ再開条件を満たす場合は既存登録対象を再利用し、新規 `VocabularyExpression` は作成しない
+- dispatch 不成立時は登録受付全体を失敗として扱い、受付済み状態を確定しない
+
+## Command: RequestExplanationGenerationCommand
+
+**Purpose**: 既存 `VocabularyExpression` に対して解説生成開始または再生成を受け付ける。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| learner | LearnerIdentifier | 1 | 操作主体 |
+| vocabularyExpression | VocabularyExpressionIdentifier | 1 | 対象登録表現 |
+| reason | ExplanationRequestReason | 1 | 初回生成か再生成かの意図 |
+
+**Acceptance rules**:
+
+- 対象 `VocabularyExpression` は同じ `learner` の所有物でなければならない
+- 同一業務キーで `pending` / `running` が存在する場合は重複として扱い、既存状態を返す
+- dispatch 成功前に `pending` を確定してはならない
+
+## Command: RequestImageGenerationCommand
+
+**Purpose**: 完了済み `Explanation` に対して画像生成開始または再生成を受け付ける。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| learner | LearnerIdentifier | 1 | 操作主体 |
+| explanation | ExplanationIdentifier | 1 | 対象解説 |
+| reason | ImageRequestReason | 1 | 初回生成か再生成かの意図 |
+
+**Acceptance rules**:
+
+- 対象 `Explanation` は同じ学習者所有の `VocabularyExpression` に属さなければならない
+- `Explanation` が完了済みでない場合は受理してはならない
+- 同一業務キーで `pending` / `running` が存在する場合は既存状態を返す
+
+## Command: RetryGenerationCommand
+
+**Purpose**: 失敗済みの生成要求に対して、同一業務キーまたは明示的再生成理由で再受理する。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| learner | LearnerIdentifier | 1 | 操作主体 |
+| targetKind | TargetKind | 1 | explanation か image か |
+| target | TargetIdentifier | 1 | 対象識別子 |
+| reason | RetryReason | 1 | 再試行理由 |
+
+**Acceptance rules**:
+
+- `failed` 状態の対象に対してのみ再試行として受理する
+- `succeeded` 状態に対する再要求は retry ではなく regenerate として扱う
+- retry でも user-visible content は返さず、状態要約のみ返す
+
+## Design Entity: AcceptanceResult
+
+**Purpose**: command が利用者へ返す即時応答の構造を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| outcome | AcceptanceOutcome | 1 | accepted / reused-existing / rejected / failed |
+| summary | StateSummary | 1 | 利用者向けの状態要約 |
+| returnedReference | ReturnedReference | 0..1 | 既存対象または新規対象の参照 |
+| nextAction | NextAction | 0..1 | 利用者が取れる次の行動 |
+
+**Validation rules**:
+
+- `summary` は未完了成果物本文や画像本体を含んではならない
+- `outcome = reused-existing` の場合は `returnedReference` が必須
+- `outcome = failed` の場合も provider / dispatch の内部詳細を直接含めない
+
+## Design Entity: DuplicateRegistrationResult
+
+**Purpose**: 重複登録時に既存対象を返しつつ、生成再開可否の判断を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| existingReference | ReturnedReference | 1 | 既存 `VocabularyExpression` への参照 |
+| currentState | StateSummary | 1 | 現在の登録・生成状態の要約 |
+| restartDecision | DuplicateRestartDecision | 1 | 再開するかしないかの判定 |
+| restartCondition | RestartConditionSummary | 1 | 判定条件の要約 |
+
+**Validation rules**:
+
+- `restartDecision = restart-accepted` は既存状態が `not-started` または `failed` で、`suppressExplanationStart = false` の場合に限る
+- `restartDecision = no-restart` は `pending`、`running`、`succeeded`、または開始抑止時に使う
+- `currentState` は未完了成果物本体を含んではならない
+
+## Design Entity: DispatchConsistencyRule
+
+**Purpose**: command 受付確定と workflow dispatch の整合規則を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| pendingRequiresDispatchSuccess | boolean | 1 | `true` 固定。dispatch 成功前に `pending` を確定しない |
+| failureSummary | FailureSummary | 1 | 利用者向けの失敗要約 |
+| internalFailureDetail | InternalFailureDetail | 1 | 内部観測用の詳細失敗情報 |
+
+**Validation rules**:
+
+- `pendingRequiresDispatchSuccess` は常に `true`
+- user-visible summary と internal failure detail を混在させてはならない
+
+## Enumerations
+
+### AcceptanceOutcome
+
+- `accepted`
+- `reused-existing`
+- `rejected`
+- `failed`
+
+### DuplicateRestartDecision
+
+- `restart-accepted`
+- `no-restart`
+
+### CommandName
+
+- `registerVocabularyExpression`
+- `requestExplanationGeneration`
+- `requestImageGeneration`
+- `retryGeneration`
+
+### CommandIntent
+
+- `register`
+- `start-explanation`
+- `start-image`
+- `retry-or-regenerate`

--- a/specs/007-backend-command-design/plan.md
+++ b/specs/007-backend-command-design/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: バックエンド Command 設計
+
+**Branch**: `007-backend-command-design` | **Date**: 2026-04-17 | **Spec**: [/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md)
+**Input**: Feature specification from `/specs/007-backend-command-design/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+vocastock の backend command 境界について、登録、解説生成開始、画像生成開始、再試行/
+再生成を受け付ける command 契約を定義する。登録 command は既定では解説生成開始を含む
+一体 command としつつ、明示的に生成開始を抑止できる。重複登録時は既存
+`VocabularyExpression` と現在状態を返し、既存状態が `not-started` または `failed`
+で、かつ開始抑止がない場合だけ生成開始を再受理する。workflow dispatch に失敗した
+場合は `pending` を確定せず command 全体を失敗として扱う。`Learner` /
+`VocabularyExpression` の所有意味は、`docs/internal/domain/learner.md`、
+`vocabulary-expression.md`、`learning-state.md` が正本化されるまで
+`specs/005-domain-modeling/` を暫定 semantic source とし、その materialization と
+007 の参照切替は 005-domain-modeling 側の follow-on work へ handoff する。
+
+## Technical Context
+
+**Language/Version**: Markdown 1.x, YAML/JSON reference documents  
+**Primary Dependencies**: 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/005-domain-modeling/`  
+**Storage**: Git-managed repository files、設計上で参照する抽象的な command-side persistence、workflow state store、identity reference store  
+**Testing**: spec / constitution / architecture / domain docs の手動クロスレビュー、command catalog review、受理条件 review、冪等性 review、失敗整合 review  
+**Target Platform**: Rust command/query runtime 上の Vocabulary Command boundary、GraphQL mutation boundary、Cloud Run command service  
+**Project Type**: documentation / backend application design  
+**Performance Goals**: レビュー担当者が 10 分以内に主要 command の受理対象、拒否条件、即時応答を説明できること、重複登録・重複登録時の再開条件・再送・dispatch failure の扱いを 5 分以内に判定できること、実装着手前の参照文書と暫定 semantic source の終了条件を 3 分以内に辿れること  
+**Constraints**: product code は追加しない、command は長時間生成を直接実行しない、未完了成果物を即時応答で返さない、登録 command は既定で解説生成開始を含むが抑止可能、同一学習者内の重複登録は既存対象を返す、重複登録時の生成再開は既存状態が `not-started` または `failed` で、かつ開始抑止がない場合に限る、workflow dispatch failure では `pending` を確定しない、外部依存は port 越しに扱う、識別子命名は憲章に従う、暫定 semantic source は 005-domain-modeling の domain docs materialization 完了後に置き換える  
+**Scale/Scope**: 4 から 6 の主要 command、3 から 4 の acceptance outcome、4 つの契約文書、既存 architecture / tech stack / domain specs を横断する command design package を対象とする
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Domain impact is identified. `docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md` を command-side rule の参照対象として扱い、`Learner` / `VocabularyExpression` の所有意味は `specs/005-domain-modeling/` を暫定 semantic source として参照する。終了条件は `docs/internal/domain/learner.md`、`vocabulary-expression.md`、`learning-state.md` の正本化と 007 の参照切替である。
+- [x] Async generation flows keep `pending`、`running`、`succeeded`、`failed` と user-visible status rule を維持し、command は未完了成果物を返さない。workflow dispatch failure では `pending` を確定しない前提で整合を取る。
+- [x] 英語表現検証、永続化、workflow dispatch、認証主体解決はすべて external port として扱い、domain / command 契約からベンダー固有詳細を分離する。
+- [x] User stories are independently reviewable. command boundary catalog、acceptance / idempotency rule、参照文書と除外範囲は、共有語彙を Foundational へ寄せる前提で別々に確認できる。
+- [x] 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態を混同せず、command は状態変更責務だけを扱う。
+- [x] Identifier naming follows the constitution. `VocabularyExpressionIdentifier`、`ExplanationIdentifier` などの既存命名を前提にし、command 契約でも `id` / `xxxId` を採用しない。
+
+Post-design re-check: PASS with documented exception and handoff. Verified against
+`research.md`, `data-model.md`, `contracts/command-catalog-contract.md`,
+`contracts/command-acceptance-contract.md`,
+`contracts/command-dispatch-consistency-contract.md`, and
+`contracts/command-boundary-contract.md`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-backend-command-design/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── command-acceptance-contract.md
+│   ├── command-boundary-contract.md
+│   ├── command-catalog-contract.md
+│   └── command-dispatch-consistency-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+docs/
+├── external/
+│   ├── adr.md
+│   └── requirements.md
+└── internal/
+    └── domain/
+        ├── common.md
+        ├── explanation.md
+        ├── service.md
+        └── visual.md
+
+specs/
+├── 003-architecture-design/
+├── 004-tech-stack-definition/
+├── 005-domain-modeling/
+└── 007-backend-command-design/
+```
+
+**Structure Decision**: 実装時の正本は `docs/external/requirements.md`、
+`docs/external/adr.md`、`docs/internal/domain/*.md` に置き、`specs/007-backend-command-design/`
+は backend command 実装前提の設計パッケージとして扱う。ここでは command 一覧、
+受理結果、冪等性規則、dispatch 整合、責務分離、非対象範囲を定義し、後続の plan / tasks /
+implementation が query や workflow の論点を混ぜずに進められる状態を目指す。なお
+`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、
+`docs/internal/domain/learning-state.md` は 005 で planned source-of-truth とされているが
+未実体化のため、本 feature では `specs/005-domain-modeling/` を暫定 semantic source とし、
+007 独自に所有意味や一意性規則を再定義しない。exit 条件は前記 3 文書が正本として
+materialize され、007 の command 設計参照が `docs/internal/domain/*.md` へ切り替わること。
+この domain-doc materialization と参照切替の follow-on owner は 005-domain-modeling 側の
+source-of-truth 整備作業とし、007 はその handoff 条件だけを明記する。
+
+## Complexity Tracking
+
+> Temporary constitution exception is documented below.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| `Learner` / `VocabularyExpression` の正本が `docs/internal/domain/*.md` ではなく一部 `specs/005-domain-modeling/` に残っている | 005 が planned source-of-truth を定義したが、domain docs 本体はまだ未実体化であり、007 は learner-owned vocabulary semantics を先に参照する必要がある。終了条件は 3 つの domain docs の正本化と 007 参照の切替であり、その follow-on owner は 005-domain-modeling 側の文書整備作業である | 005 の文書実装完了まで 007 を停止すると command 設計が進まず、現時点では暫定 semantic source と handoff を明示した方が再定義リスクを抑えられる |

--- a/specs/007-backend-command-design/quickstart.md
+++ b/specs/007-backend-command-design/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: バックエンド Command 設計
+
+## 1. 前提文書を確認する
+
+1. [requirements.md](/Users/lihs/workspace/vocastock/docs/external/requirements.md) を読み、登録、解説生成、画像生成の業務要求を確認する
+2. [boundary-responsibility-contract.md](/Users/lihs/workspace/vocastock/specs/003-architecture-design/contracts/boundary-responsibility-contract.md) と [async-visibility-contract.md](/Users/lihs/workspace/vocastock/specs/003-architecture-design/contracts/async-visibility-contract.md) を読み、Vocabulary Command の責務と可視性規則を確認する
+3. [spec.md](/Users/lihs/workspace/vocastock/specs/004-tech-stack-definition/spec.md) を読み、`Command/Query = Rust`、`GraphQL`、`Pub/Sub + Firestore state` の前提を確認する
+4. [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md) を読み、学習者所有、一意性、非同期状態語彙の前提を確認する。`docs/internal/domain/learner.md` などの正本が未実体化なため、ここでは 005 spec を暫定 semantic source として扱う。exit 条件は `learner.md`、`vocabulary-expression.md`、`learning-state.md` の正本化と 007 参照の切り替えであり、その handoff は 005-domain-modeling 側の文書整備作業が担う
+
+## 2. 007 の設計成果物を読む
+
+1. [research.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/research.md) で command 設計上の判断理由を確認する
+2. [data-model.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/data-model.md) で command definition、acceptance result、dispatch consistency rule を確認する
+3. [contracts/command-catalog-contract.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-catalog-contract.md) と [contracts/command-acceptance-contract.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-acceptance-contract.md) で command 一覧と受理条件を確認する
+4. [contracts/command-dispatch-consistency-contract.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-dispatch-consistency-contract.md) と [contracts/command-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-boundary-contract.md) で dispatch 整合と責務分離を確認する
+
+## 3. 実装前レビューで確認すること
+
+1. 登録 command が既定で解説生成開始を含みつつ、開始抑止パターンを持てること
+2. 重複登録時に新規作成せず、既存 `VocabularyExpression` と現在状態を返すこと
+3. 重複登録時の生成再開は、既存状態が `not-started` または `failed` で、かつ開始抑止がない場合だけ許可されること
+4. 画像生成 command が完了済み `Explanation` を前提条件にすること
+5. dispatch failure では `pending` を確定せず command 全体を失敗として扱うこと
+6. 即時応答が未完了成果物本文や画像本体を返さないこと
+7. 暫定 semantic source は恒久運用ではなく、3 つの domain docs 正本化後に `docs/internal/domain/*.md` 参照へ切り替えること
+
+## 4. この feature で扱わないこと
+
+1. query 側の read model 詳細
+2. workflow 側の長時間実行ロジック
+3. provider 固有 adapter の request / response 詳細
+4. Rust コードの module 構成や GraphQL schema 実装詳細

--- a/specs/007-backend-command-design/research.md
+++ b/specs/007-backend-command-design/research.md
@@ -1,0 +1,122 @@
+# Research: バックエンド Command 設計
+
+## Decision: 登録 command を command catalog の中心に置き、既定では解説生成開始を含める
+
+**Rationale**: 既存要件では「未登録なら解説生成を行う」が主経路であり、登録と解説生成開始を
+別 command に完全分離すると通常フローが二段階化する。一方で、下書き登録や管理操作のために
+生成開始を抑止する余地も必要である。そこで `registerVocabularyExpression` は既定では
+解説生成開始を伴うが、明示フラグで開始を抑止できる command として定義する。
+
+**Alternatives considered**:
+
+- 登録 command を常に解説生成開始まで固定する
+- 登録と解説生成開始を必ず別 command に分離する
+
+## Decision: 重複登録時は新規作成せず、既存 `VocabularyExpression` と現在状態を返す
+
+**Rationale**: 同一学習者内一意性を維持する以上、重複登録で新規項目を作るべきではない。
+単純エラーにすると、既に何が登録済みで、現在どの状態にあるかが利用者にも実装者にも見えにくい。
+既存対象と現在状態を返す contract にすると、冪等性と利用者フィードバックを両立できる。
+
+**Alternatives considered**:
+
+- 重複として常に拒否し、エラーだけ返す
+- 既存項目を更新扱いにして再登録を受け付ける
+
+## Decision: 重複登録時の生成再開は `not-started` または `failed` で、かつ開始抑止がない場合に限る
+
+**Rationale**: 重複登録で常に生成を再開すると、すでに `pending`、`running`、`succeeded`
+の対象まで再度動かしてしまい、冪等性と利用者期待が崩れる。一方で `not-started` や
+`failed` のままなら、通常登録フローの再要求として再開余地を残した方が自然である。
+そのため既存対象を再利用しつつ、再開条件だけを限定する。
+
+**Alternatives considered**:
+
+- 重複登録では生成を再開せず、常に既存状態だけ返す
+- `pending` / `running` 以外なら常に再開する
+- 明示的な `restartOnDuplicate` 指定がある場合だけ再開する
+
+## Decision: command は `pending` の作成前に dispatch 成功を確認し、失敗時は command 全体を不成立にする
+
+**Rationale**: command が受付済み状態だけを先に保存し、dispatch が失敗すると、
+「受け付けたのに動かない」半端な状態が生じる。backend command の整合責務を明確にするため、
+dispatch 成功を伴わない受付は不成立とし、利用者へは受付失敗を返す設計とする。
+
+**Alternatives considered**:
+
+- `pending` を保存したうえで後続補正ジョブへ委ねる
+- `dispatch_failed` のような中間状態を command 側で持つ
+- command 自体は成功として返し、自動再送を前提にする
+
+## Decision: command catalog は command definition、acceptance result、idempotency key を分けて扱う
+
+**Rationale**: 「何を受け付けるか」「どう返すか」「重複をどう畳むか」は別の判断軸である。
+これらを 1 つの表に混ぜると、後続実装で validation、result mapping、deduplication rule が
+分離しにくい。command ごとの定義を中心にしつつ、acceptance result と idempotency key を
+横断規則として持つ方が review と実装分解に向く。
+
+**Alternatives considered**:
+
+- command ごとの文章説明だけで整理する
+- すべてを 1 つの巨大な matrix で表現する
+
+## Decision: 所有者整合は command 受理の前提条件として扱う
+
+**Rationale**: `VocabularyExpression` は学習者所有であり、他者の登録対象へ command を
+通すと責務境界が崩れる。認証主体と対象所有者の整合は command 実行途中ではなく、受理前の
+前提条件として扱う方が、拒否条件と state mutation の境界が明確になる。
+
+**Alternatives considered**:
+
+- workflow 側で所有者整合を再確認する
+- query 側で見え方だけを制御し、command では受理する
+
+## Decision: command は user-facing summary と internal failure detail を分離する
+
+**Rationale**: 利用者へは状態要約だけを返し、詳細な provider / dispatch failure は内部ログや
+内部状態へ留めるという既存方針を維持する必要がある。これにより、command contract は安定し、
+失敗の内部調査性は別の運用文脈で担保できる。
+
+**Alternatives considered**:
+
+- command 即時応答に provider 由来の詳細をそのまま含める
+- 失敗要約すら返さず、汎用エラーだけを返す
+
+## Decision: 今回の設計対象から query、workflow 実行本体、provider 個別仕様を除外する
+
+**Rationale**: 007 の目的は backend command 実装のための設計書であり、read model、worker の
+実行詳細、プロバイダ別 adapter まで同時に扱うと scope が崩れる。command が何を受け付け、
+どこまで責務を持つかに集中するため、非対象範囲を明示して分離する。
+
+**Alternatives considered**:
+
+- query と command を同時に設計する
+- workflow state machine と adapter 契約まで 1 feature に含める
+
+## Decision: 005 の domain docs 実装完了までは `specs/005-domain-modeling/` を暫定 semantic source とする
+
+**Rationale**: 007 は learner-owned `VocabularyExpression` と一意性前提に依存するが、
+その正本候補である `docs/internal/domain/learner.md`、
+`docs/internal/domain/vocabulary-expression.md`、
+`docs/internal/domain/learning-state.md` はまだ materialize されていない。現在の
+`docs/internal/domain/*.md` を無理に再定義すると 005 と二重管理になるため、007 は 005 の
+設計成果物を暫定 semantic source として参照し、再定義を避ける。
+
+**Alternatives considered**:
+
+- 007 の中で learner-owned vocabulary semantics を独自に再定義する
+- 005 の文書実装完了まで 007 の planning を止める
+
+## Decision: 暫定 semantic source の exit は 3 つの domain docs 正本化と 007 参照切替で判定し、その handoff は 005-domain-modeling 側が担う
+
+**Rationale**: 暫定参照だけを記録すると、「いつ終わるか」と「誰が終わらせるか」が曖昧なまま残る。
+憲章例外として扱う以上、終了条件と follow-on owner を同時に明記する必要がある。007 は
+command design package であり domain docs 本体の materialization は直接の対象外なので、
+`docs/internal/domain/learner.md`、`vocabulary-expression.md`、`learning-state.md` の
+正本化と 007 の参照切替を exit 条件とし、その handoff を 005-domain-modeling 側の
+source-of-truth 整備作業へ置く。
+
+**Alternatives considered**:
+
+- 007 の中で domain docs materialization まで ownership を引き取る
+- exit 条件だけを書き、follow-on owner を曖昧なまま残す

--- a/specs/007-backend-command-design/spec.md
+++ b/specs/007-backend-command-design/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: バックエンド Command 設計
+
+**Feature Branch**: `007-backend-command-design`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "バックエンドのCommandの実装を行うための設計書を作成する。"
+
+## Clarifications
+
+### Session 2026-04-17
+
+- Q: 登録 command と解説生成開始 command の関係をどう扱うか → A: 登録 command は既定で解説生成を開始するが、明示的に開始しない登録も許可する
+- Q: 同一学習者の重複登録時の受理方針をどうするか → A: 新規作成せず、既存 `VocabularyExpression` と現在状態を返す
+- Q: command 受理後に workflow dispatch だけ失敗した場合の扱いをどうするか → A: command 全体を失敗として扱い、受付状態を確定しない
+- Q: 重複登録時に生成を再開する条件をどうするか → A: 既存状態が `not-started` または `failed` で、かつ開始抑止がない場合だけ再開する
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Command の責務境界を定義する (Priority: P1)
+
+設計担当者として、バックエンドの Command 境界が何を受け付け、どこまで責務を持つかを明確にしたい。これにより、登録、生成開始、再試行の処理を query や workflow と混同せずに実装判断できる。
+
+**Why this priority**: Command 境界の責務が曖昧だと、後続実装で状態変更責務と表示責務が混線するため。
+
+**Independent Test**: 第三者が設計書だけを読んで、各 command が「何を受け付け、何を返し、何を直接実行しないか」を説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 実装担当者が新しい状態変更処理の配置先を判断したい, **When** 設計書を読む, **Then** その処理が backend command 境界に属するかどうかを判断できる
+2. **Given** レビュー担当者が責務分離を確認したい, **When** command と query / workflow の責務一覧を見る, **Then** command が長時間処理や表示整形を直接持たないことを確認できる
+
+---
+
+### User Story 2 - Command 契約と状態変更規則を整理する (Priority: P2)
+
+実装担当者として、各 command の入力条件、受理条件、即時応答、状態変更、再試行時の扱いを明文化したい。これにより、登録や生成依頼を一貫した契約で実装できる。
+
+**Why this priority**: 契約が曖昧なままだと、重複登録判定、生成依頼、再試行の挙動が実装ごとにぶれるため。
+
+**Independent Test**: 第三者が設計書だけを読み、主要 command の受理条件、即時応答、状態遷移を説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 学習者が新しい英語表現を登録する, **When** command 契約を確認する, **Then** 重複判定、受付結果、後続生成開始条件を説明できる
+2. **Given** 解説生成または画像生成の再試行を設計する, **When** command 規則を確認する, **Then** 同一業務キーでの受理条件と冪等な扱いを説明できる
+3. **Given** 学習者が下書き登録だけを行いたい, **When** 登録 command 契約を確認する, **Then** 解説生成を開始しない明示的な受理パターンを説明できる
+
+---
+
+### User Story 3 - 実装前提と除外範囲を合意する (Priority: P3)
+
+設計担当者として、backend command 実装の前提文書、依存境界、今回扱わない範囲を整理したい。これにより、後続の実装計画で scope を広げすぎずに進められる。
+
+**Why this priority**: command 設計だけで解決しない論点まで混ぜると、実装着手条件と成果物の境界が曖昧になるため。
+
+**Independent Test**: 第三者が設計書と既存文書を照合し、command 実装に必要な前提と今回の非対象領域を区別できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 開発者が command 実装前に参照すべき文書を確認したい, **When** 設計書を読む, **Then** 依存する要求、ドメイン、アーキテクチャ判断を特定できる
+2. **Given** query 側や workflow 側の設計を別 feature で扱いたい, **When** 設計書の scope を確認する, **Then** 今回の対象外である論点を明確に説明できる
+
+### Edge Cases
+
+- 同一学習者が同じ英語表現を再登録しようとした場合に、新規登録、拒否、既存状態の再利用のどれを command が返すか
+- 同一学習者が同じ英語表現を再登録しようとした場合に、既存状態が `not-started` または `failed` で、かつ開始抑止がない場合だけ生成開始を再受理すること
+- 解説未完了の状態で画像生成 command が要求された場合に、受付拒否と状態通知をどう分けるか
+- すでに `pending` または `running` の生成依頼に対して同じ command が再送された場合に、重複実行を避けつつどう受理結果を返すか
+- 外部検証や外部生成の失敗詳細を、command の即時応答にどこまで含めるか
+- command 受理後に workflow dispatch だけ失敗した場合に、受理結果と状態整合をどう保つか
+- command が状態変更を確定した後に dispatch 失敗が起きないよう、どの順で永続化と dispatch を扱うか
+
+## Domain & Async Impact *(mandatory when applicable)*
+
+- **Domain Models Affected**: `docs/internal/domain/common.md`, `docs/internal/domain/service.md`, `docs/internal/domain/explanation.md`, `docs/internal/domain/visual.md`, 暫定 semantic source として参照する `specs/005-domain-modeling/spec.md`
+- **Invariants / Terminology**: 学習者、英語表現、解説、画像、頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態は別概念として保ち、command はそれらの状態変更責務のみを扱う
+- **Async Lifecycle**: command は登録、生成依頼、再試行、再生成の受付と初期状態設定を担い、長時間実行そのものは別境界へ委譲する。再送時は同一業務キーで冪等に扱う前提を維持する
+- **User Visibility Rule**: command は完了済み成果物を即時応答で返す前提を持たず、未完了・失敗は状態のみ扱う
+- **Identifier Naming Rule**: 識別子型は `XxxIdentifier`、集約自身の識別子は `identifier`、関連参照は概念名で表現し、`id` / `xxxId` / `xxxIdentifier` を使わない
+- **External Ports / Adapters**: 英語表現検証、永続化、workflow dispatch、認証主体受け渡し、生成受付に必要な外部接続境界を整理対象とする
+- **Temporary Semantic Source & Exit Condition**: `docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md` が未実体化の間は `specs/005-domain-modeling/spec.md` を learner ownership、一意性、非同期状態語彙の暫定 semantic source とする。exit 条件は、前記 3 文書が正本として materialize され、007 の command 設計がその文書参照へ切り替わることである
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 設計成果物は、backend command 境界が受け付ける状態変更要求の範囲を定義しなければならない
+- **FR-002**: 設計成果物は、少なくとも英語表現登録、解説生成開始、画像生成開始、再試行または再生成に関する command を一覧化しなければならない
+- **FR-002a**: 設計成果物は、英語表現登録 command が既定では解説生成開始を含む一体 command として振る舞うこと、ただし明示的に解説生成を開始しない登録パターンも許可することを定義しなければならない
+- **FR-003**: 設計成果物は、各 command について入力、前提条件、重複判定、受理条件、即時応答、拒否条件を定義しなければならない
+- **FR-003a**: 設計成果物は、同一学習者内の重複登録時に新規作成を行わず、既存 `VocabularyExpression` と現在状態を返す受理方針を定義しなければならない
+- **FR-003b**: 設計成果物は、重複登録時の追加生成開始について、既存状態が `not-started` または `failed` で、かつ開始抑止がない場合だけ再受理する規則を定義しなければならない
+- **FR-004**: 設計成果物は、command が直接担う状態変更と、別境界へ委譲する処理を区別して示さなければならない
+- **FR-004a**: 設計成果物は、workflow dispatch が成立しなかった場合は command 全体を失敗として扱い、受付済み `pending` 状態を確定しない規則を定義しなければならない
+- **FR-005**: 設計成果物は、登録済み判定、生成中判定、再試行受理など、同一業務キーに対する冪等な扱いを定義しなければならない
+- **FR-006**: 設計成果物は、command 受理直後に利用者へ見せてよい情報を定義し、未完了成果物を完了済みとして返さない規則を含まなければならない
+- **FR-007**: 設計成果物は、command が参照する外部依存と永続化責務をポート境界として整理しなければならない
+- **FR-008**: 設計成果物は、query 境界、workflow 境界、client 境界との責務分離を明記しなければならない
+- **FR-009**: 設計成果物は、認証済み主体と command 対象の所有者整合をどの時点で確認するかを定義しなければならない
+- **FR-010**: 設計成果物は、失敗時に command が返す要約状態と、内部にのみ保持する失敗詳細を区別しなければならない
+- **FR-011**: 設計成果物は、後続実装者が command 実装着手前に参照すべき既存文書とその依存関係を示し、`docs/internal/domain/*.md` 側の正本が未実体化な論点については暫定 semantic source と exit 条件を明記しなければならない
+- **FR-012**: 設計成果物は、今回扱わない範囲を明示し、query 実装、workflow 実装、provider 個別実装などを別論点として切り分けなければならない
+
+### Key Entities *(include if feature involves data)*
+
+- **Command Definition**: どの要求を受け付け、何を検証し、何を返すかを表す command ごとの定義
+- **Command Acceptance Result**: command 受理時に返す受付結果、状態要約、対象識別情報を表す
+- **Duplicate Registration Result**: 重複登録時に既存対象の識別情報、現在状態、追加実行有無、およびその決定条件を返す受理結果
+- **Command Ownership Rule**: command 境界が直接更新してよい状態と委譲すべき状態を表す責務規則
+- **Dispatch Consistency Rule**: command の受付確定と workflow dispatch が不整合にならないための整合規則
+- **Command Idempotency Key**: 重複登録や重複生成依頼を同一業務要求として扱うための識別単位
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: レビュー参加者が 10 分以内に、主要 command の 100% について受理対象、拒否条件、即時応答を対応付けられる
+- **SC-002**: command と query / workflow の責務境界に関するレビュー上の曖昧さが 0 件になる
+- **SC-003**: 重複登録、生成再送、失敗再試行の各ケースについて、第三者が一貫した受理ルールを説明できる
+- **SC-004**: 既存要求、ドメイン文書、アーキテクチャ設計との矛盾がレビュー時に 0 件である
+
+## Assumptions
+
+- 今回の feature は backend command の実装そのものではなく、後続 implementation に使う設計成果物の整備を対象とする
+- command 境界は既存アーキテクチャで定義済みの状態変更責務を引き継ぎ、長時間実行や表示整形は別境界が担う
+- 学習者ごとに英語表現を所有し、同一学習者内で重複登録を判定する前提は維持される
+- 英語表現登録 command は通常の利用では解説生成開始を同時に受け付けるが、明示的な入力によって生成開始を抑止できる
+- 重複登録時は新規作成ではなく既存対象の再利用を返すことで、利用者は現在状態を再確認できる
+- 重複登録時の生成再開は、既存状態が `not-started` または `failed` で、かつ開始抑止がない場合に限る
+- workflow dispatch に失敗した場合は command 自体を不成立として扱い、利用者へは受付失敗を返し、`pending` 状態は保存しない
+- 完了済み成果物のみを利用者へ見せる表示規則は不変であり、command はその規則を壊さない即時応答を返す
+- `docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md` が正本として整備されるまでは、`specs/005-domain-modeling/spec.md` を learner ownership、一意性、非同期状態語彙の暫定 semantic source とする
+- 上記の暫定参照は、3 つの domain docs が正本化され、007 の参照先が `docs/internal/domain/*.md` に切り替わった時点で終了する
+- query 側の read model 詳細、workflow 側の実行詳細、外部 provider 個別仕様は今回の主要対象外とする

--- a/specs/007-backend-command-design/tasks.md
+++ b/specs/007-backend-command-design/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: バックエンド Command 設計
+
+**Input**: Design documents from `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/`
+**Prerequisites**: [plan.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md) (required), [spec.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md) (required), [research.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/research.md), [data-model.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/data-model.md), [contracts/](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts), [quickstart.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/quickstart.md)
+
+**Tests**: 専用の test-first task は追加しない。検証は command catalog review、acceptance review、dispatch consistency review、cross-document review を independent test として扱う。
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this belongs to (`US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 007 の設計成果物を置く受け皿と参照導線を揃える
+
+- [ ] T001 Create the feature artifact skeleton in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/research.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/data-model.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/quickstart.md`, and `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/`
+- [ ] T002 [P] Update `/Users/lihs/workspace/vocastock/.specify/feature.json` to keep `/Users/lihs/workspace/vocastock/specs/007-backend-command-design` as the active feature directory
+- [ ] T003 [P] Sync `/Users/lihs/workspace/vocastock/AGENTS.md` with the planning context for backend command design
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: すべての user story が依存する command 境界の前提文書と参照元を固定する
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Reconcile backend command scope references across `/Users/lihs/workspace/vocastock/docs/external/requirements.md`, `/Users/lihs/workspace/vocastock/docs/external/adr.md`, and `/Users/lihs/workspace/vocastock/specs/003-architecture-design/contracts/boundary-responsibility-contract.md`
+- [ ] T005 [P] Reconcile command-related terminology across `/Users/lihs/workspace/vocastock/docs/internal/domain/common.md`, `/Users/lihs/workspace/vocastock/docs/internal/domain/service.md`, `/Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md`, and `/Users/lihs/workspace/vocastock/docs/internal/domain/visual.md`
+- [ ] T006 [P] Capture command-side assumptions, exclusions, temporary semantic source references, exit conditions, and justified constitution exception details in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md` and `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/research.md`
+- [ ] T007 Normalize command naming, identifier references, acceptance-result terminology, and duplicate-restart vocabulary across `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/data-model.md`, and `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Command の責務境界を定義する (Priority: P1) 🎯 MVP
+
+**Goal**: backend command が受け付ける状態変更要求と、query / workflow / client に委譲する責務を明確化する
+
+**Independent Test**: [command-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-boundary-contract.md) と [command-catalog-contract.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-catalog-contract.md) を読むだけで、各 command が何を受け付け、何を直接実行しないかを第三者が説明できること
+
+### Implementation for User Story 1
+
+- [ ] T008 [P] [US1] Define the primary backend command catalog, including duplicate-registration default/restart behavior summary, in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-catalog-contract.md`
+- [ ] T009 [P] [US1] Define command-side responsibility boundaries in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-boundary-contract.md`
+- [ ] T010 [US1] Map command definitions and ownership rules into `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/data-model.md`
+- [ ] T011 [US1] Align User Story 1 scope and acceptance wording in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md` with the finalized command catalog
+
+**Checkpoint**: User Story 1 should define the backend command boundary independently
+
+---
+
+## Phase 4: User Story 2 - Command 契約と状態変更規則を整理する (Priority: P2)
+
+**Goal**: 各 command の受理条件、重複時挙動、重複登録時の再開条件、即時応答、dispatch failure 規則を一貫した contract として定義する
+
+**Independent Test**: [command-acceptance-contract.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-acceptance-contract.md)、[command-dispatch-consistency-contract.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-dispatch-consistency-contract.md)、[data-model.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/data-model.md) を読めば、重複登録、重複登録時の生成再開条件、生成再送、dispatch failure の扱いを第三者が一貫して説明できること
+
+### Implementation for User Story 2
+
+- [ ] T012 [P] [US2] Define command acceptance rules, including duplicate-registration restart conditions, in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-acceptance-contract.md`
+- [ ] T013 [P] [US2] Define dispatch consistency and ordering rules in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-dispatch-consistency-contract.md`
+- [ ] T014 [US2] Extend `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/data-model.md` with acceptance results, duplicate registration results, duplicate restart decision conditions, and dispatch consistency entities
+- [ ] T015 [US2] Reconcile User Story 2 requirements, FR-003b, and edge cases in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md` with the finalized acceptance rules
+- [ ] T016 [US2] Summarize the rationale for registration default behavior, duplicate reuse, duplicate restart conditions, and dispatch failure handling in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/research.md`
+
+**Checkpoint**: User Story 2 should make command acceptance, duplicate restart conditions, and state-change rules independently reviewable
+
+---
+
+## Phase 5: User Story 3 - 実装前提と除外範囲を合意する (Priority: P3)
+
+**Goal**: command 実装前に参照すべき文書、前提条件、暫定 semantic source の終了条件、後続 feature owner、今回の対象外範囲を運用可能な形で整理する
+
+**Independent Test**: [quickstart.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/quickstart.md)、[plan.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md)、[research.md](/Users/lihs/workspace/vocastock/specs/007-backend-command-design/research.md) を読めば、後続実装者が参照順序、暫定 semantic source の終了条件、`005-domain-modeling` への引き継ぎ責任、非対象範囲を説明できること
+
+### Implementation for User Story 3
+
+- [ ] T017 [P] [US3] Document implementation entry guidance, including the temporary `specs/005-domain-modeling/` semantic source, exit conditions, and operator-facing handoff notes, in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/quickstart.md`
+- [ ] T018 [P] [US3] Document source-of-truth, assumptions, exclusions, the justified temporary semantic-source exception, and the follow-on owner for materializing `docs/internal/domain/learner.md`, `vocabulary-expression.md`, and `learning-state.md` in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md`
+- [ ] T019 [US3] Reconcile research decisions with out-of-scope boundaries, temporary semantic-source rationale, and migration handoff toward `005-domain-modeling` domain-doc materialization in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/research.md`
+- [ ] T020 [US3] Align User Story 3 scope, assumptions, success criteria, temporary semantic-source exit wording, and follow-on ownership notes in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md`
+
+**Checkpoint**: User Story 3 should make implementation prerequisites, temporary semantic-source exit conditions, and exclusions independently reviewable
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 複数ストーリーに跨る整合と最終導線を整える
+
+- [ ] T021 [P] Reconcile all 007 artifacts across `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/spec.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/research.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/data-model.md`, and `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/`
+- [ ] T022 [P] Cross-check 007 command terminology against `/Users/lihs/workspace/vocastock/specs/003-architecture-design/`, `/Users/lihs/workspace/vocastock/specs/004-tech-stack-definition/`, and `/Users/lihs/workspace/vocastock/specs/005-domain-modeling/`
+- [ ] T023 Re-run the quickstart review flow in `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/quickstart.md` and reconcile operator guidance with the shipped design
+- [ ] T024 Update `/Users/lihs/workspace/vocastock/AGENTS.md` and final repository guidance if the command design introduces new canonical terminology worth surfacing
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on other stories
+- **User Story 2 (P2)**: Can start after Foundational - shared command terms and duplicate-restart vocabulary are fixed in Phase 2, so no dependency on US1 remains
+- **User Story 3 (P3)**: Can start after Foundational - consumes finalized command rules and documents how to use them without changing their semantics
+
+### Within Each User Story
+
+- Command catalog and boundary definitions should land before cross-document wording adjustments
+- Acceptance and dispatch rules should be defined before final edge-case alignment
+- Quickstart and operational guidance should be finalized after the corresponding design artifacts are stable
+
+### Parallel Opportunities
+
+- `T002` and `T003` can run in parallel after `T001`
+- `T005` and `T006` can run in parallel after `T004`
+- In US1, `T008` and `T009` can run in parallel
+- In US2, `T012` and `T013` can run in parallel
+- In US3, `T017` and `T018` can run in parallel
+- Final polish `T021` and `T022` can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch boundary-definition tasks together:
+Task: "Define the primary backend command catalog in /Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-catalog-contract.md"
+Task: "Define command-side responsibility boundaries in /Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-boundary-contract.md"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch acceptance-rule tasks together:
+Task: "Define command acceptance rules in /Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-acceptance-contract.md"
+Task: "Define dispatch consistency and ordering rules in /Users/lihs/workspace/vocastock/specs/007-backend-command-design/contracts/command-dispatch-consistency-contract.md"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch implementation-guidance tasks together:
+Task: "Document implementation entry guidance, temporary semantic-source exit conditions, and handoff notes in /Users/lihs/workspace/vocastock/specs/007-backend-command-design/quickstart.md"
+Task: "Document source-of-truth, assumptions, exclusions, and follow-on ownership in /Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate that backend command boundary ownership can be reviewed independently
+5. Stop and review before adding acceptance / dispatch details
+
+### Incremental Delivery
+
+1. Ship Setup + Foundational to fix source-of-truth references, temporary semantic-source exception, and terminology
+2. Add User Story 1 to define the backend command boundary
+3. Add User Story 2 to fix acceptance, duplicate, duplicate restart, and dispatch consistency rules
+4. Add User Story 3 to document implementation entry guidance, temporary semantic-source exit conditions, and exclusions
+5. Finish with cross-cutting reconciliation
+
+### Parallel Team Strategy
+
+1. One contributor handles Setup and Foundational alignment
+2. After Foundation:
+   - Contributor A: User Story 1 command catalog and boundary split
+   - Contributor B: User Story 2 acceptance and dispatch consistency
+   - Contributor C: User Story 3 quickstart, source-of-truth guidance, and migration handoff
+3. Reconcile all artifacts together in Phase 6
+
+---
+
+## Notes
+
+- [P] tasks target different files and can proceed in parallel after dependencies
+- No standalone test-file tasks were generated because this feature is a design package and independent review is the intended validation mode
+- Keep backend command terminology aligned with `Vocabulary Command`, `VocabularyExpression`, and the existing async visibility rules
+- Do not pull query, workflow execution, or provider-specific adapter design into this feature

--- a/specs/008-auth-session-design/checklists/requirements.md
+++ b/specs/008-auth-session-design/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: 会員登録・ログイン・ログアウト設計
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-17  
+**Feature**: [spec.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 認証は vocastock のコアドメイン外として扱い、会員登録、ログイン、ログアウトと利用主体解決の責務分離を明記した。
+- `Basic` と `Google` を初期対象、`Apple ID` と `LINE` を条件付き対象として整理し、コスト条件を scope に織り込んだ。
+- Flutter が認証 UI と provider 開始を担い、Firebase Authentication を本人確認基盤とし、backend が Firebase ID token を検証して actor reference を handoff する責務分離を spec に反映した。
+- `Verified Firebase Identity` を主要概念として追加し、provider 条件に Firebase Authentication または承認済み同等経路の前提を明記した。

--- a/specs/008-auth-session-design/contracts/auth-boundary-contract.md
+++ b/specs/008-auth-session-design/contracts/auth-boundary-contract.md
@@ -1,0 +1,25 @@
+# Contract: Auth Boundary
+
+## Purpose
+
+Flutter client、Firebase Authentication、backend token verification、session 管理、
+actor resolution、アプリ本体の責務分離を固定する。
+
+## Boundary Catalog
+
+| Boundary | Owns | Must Not Own | Depends On |
+|----------|------|--------------|------------|
+| Flutter Auth UI | 会員登録、ログイン、ログアウト画面、provider 開始、loading / error 表示、auth state 購読 | actor 解決、学習データ所有判断、provider token 検証 | Firebase Auth Client Adapter、Auth Handoff Endpoint |
+| Firebase Auth Client Adapter | `Basic` / `Google` / `Apple` / `LINE` の sign-in 開始、Firebase client session の取得 | app core の保護操作判断、backend actor 解決 | Firebase Authentication |
+| Backend Token Verifier | Flutter から受け取った Firebase ID token の検証、verified Firebase subject の正規化 | 語彙、解説、画像、学習状態の更新 | Firebase Authentication、auth account store |
+| Session Manager | app-session 発行、失効、状態照会 | provider 固有本人確認、ドメイン概念の解釈 | auth account store、session store |
+| Actor Resolver | 検証済み Firebase subject を actor / learner reference へ正規化 | provider token 保持、Firebase client session 永続化 | auth account store、identity link store |
+| App Core Entry | 正規化済み actor reference に基づく保護操作の起点 | Firebase token 検証、provider credential 管理、auth account 作成 | Actor Resolver または auth handoff result |
+
+## Dependency Rules
+
+- Flutter Auth UI は raw `FirebaseUser` や provider 成功だけで app core を通してはならない
+- Firebase Auth Client Adapter は語彙、解説、画像、学習状態を直接更新してはならない
+- Backend Token Verifier は HTTPS 越しに受け取った Firebase ID token を検証し、検証済み subject を actor resolution 前提へ正規化しなければならない
+- Session Manager は actor resolution を暗黙化してはならず、必要な handoff 条件を満たした後だけ利用可能状態を返す
+- アプリ本体は Firebase ID token、refresh token、password、provider credential detail を直接扱ってはならない

--- a/specs/008-auth-session-design/contracts/auth-flow-contract.md
+++ b/specs/008-auth-session-design/contracts/auth-flow-contract.md
@@ -1,0 +1,26 @@
+# Contract: Auth Flow
+
+## Purpose
+
+会員登録、ログイン、ログアウトの受理条件、拒否条件、完了条件を、Flutter client、
+Firebase Authentication、backend token verification を含めて固定する。
+
+## Flow Rules
+
+| Flow | Accept When | Reject When | Complete When | User-visible Result |
+|------|-------------|-------------|---------------|---------------------|
+| `registerAccount` | Flutter 側で初期対象または条件を満たした provider が利用可能で、重複会員規則に反しない | provider unavailable、重複会員を新規作成しようとする、必須入力不足、Firebase sign-in 失敗 | Firebase registration / sign-in 成功、backend の ID token 検証成功、会員作成または既存会員再利用、必要な session と actor reference が整う | `registered` / `reused-existing` / `rejected` / `failed` |
+| `loginAccount` | 対象会員が存在し、Flutter で Firebase sign-in を開始でき、利用不能状態でない | account missing、disabled、provider unavailable、Firebase sign-in 失敗、backend token verification 失敗 | active session と resolved actor reference が両方成立する | `logged-in` / `rejected` / `failed` |
+| `logoutAccount` | active Firebase current user または app-session の失効確認対象がある | session store 不達など、完了判定自体ができない | Flutter 側の Firebase sign-out と session invalidated または already-invalid が確定し、再認証要求が明示される | `logged-out` / `already-invalid` / `failed` |
+
+## Duplicate Account Rule
+
+- 同じメールアドレスまたは同じ Firebase provider subject で重複会員を新規作成してはならない
+- 重複検知時は既存会員の再利用または既存会員案内へ切り替える
+- 重複時の戻り値は新規会員作成成功ではなく `reused-existing` または `rejected` とする
+
+## Partial Success Rule
+
+- Flutter 側の Firebase sign-in 成功だけ、backend の token 検証成功だけ、session 発行成功だけを単独で利用可能状態として返してはならない
+- actor reference の解決に失敗した場合は、アプリ本体利用開始を成功として見せてはならない
+- logout は Firebase current user の破棄だけで成功とせず、session 側の失効確認まで必要とする

--- a/specs/008-auth-session-design/contracts/provider-availability-contract.md
+++ b/specs/008-auth-session-design/contracts/provider-availability-contract.md
@@ -1,0 +1,20 @@
+# Contract: Provider Availability
+
+## Purpose
+
+provider ごとの初期対象、条件付き対象、利用不可条件を固定する。
+
+## Provider Policy
+
+| Provider | Initial Tier | Enable When | Disable When | Fallback Guidance |
+|----------|--------------|-------------|--------------|------------------|
+| `Basic` | `baseline` | Firebase Authentication で email/password 登録と本人確認が提供可能 | 基本 credential 運用自体を採用しない場合 | 他の baseline provider を案内する |
+| `Google` | `baseline` | Firebase Authentication 経由で Google sign-in と backend token verification が利用可能 | provider 障害または運用停止 | `Basic` を案内する |
+| `Apple ID` | `conditional` | Firebase Authentication または同等の接続経路で追加の直接費用や必須運用負荷が発生しない | 追加コストまたは運用条件が発生する | `Basic` または `Google` を案内する |
+| `LINE` | `conditional` | Firebase Authentication 連携または同等の接続経路で追加の直接費用や必須運用負荷が発生しない | 追加コストまたは運用条件が発生する | `Basic` または `Google` を案内する |
+
+## Policy Rules
+
+- `Basic` と `Google` は初期リリースで Firebase Authentication 経由により利用可能でなければならない
+- `Apple ID` と `LINE` は、追加コストなし条件を満たすまで初期対象に含めてはならない
+- 利用不可の provider は案内上で無効または非表示とし、成立しない導線を見せてはならない

--- a/specs/008-auth-session-design/contracts/session-handoff-contract.md
+++ b/specs/008-auth-session-design/contracts/session-handoff-contract.md
@@ -1,0 +1,21 @@
+# Contract: Session Handoff
+
+## Purpose
+
+認証境界からアプリ本体へ利用可能状態を handoff する条件を、Flutter client、
+Firebase Authentication、backend actor resolution を含めて固定する。
+
+## Handoff Rules
+
+| Stage | Required Condition | Must Not Happen | Handoff Output |
+|-------|--------------------|-----------------|----------------|
+| Registration Completion | Flutter で Firebase sign-in が成功し、backend で ID token 検証、会員 account 確定、必要な session と actor reference が揃う | actor reference 未解決のまま利用可能状態を返す | `RegisterFlowResult` |
+| Login Completion | backend で検証済み Firebase subject、active session、resolved actor reference が揃う | Firebase sign-in 成功だけで app core を通す | `LoginFlowResult` |
+| Protected Operation Start | actor reference が有効で、session が active、または同等の handoff 条件が backend で再確認されている | expired / invalidated session を有効扱いする | normalized actor reference |
+| Logout Completion | Flutter 側の Firebase current user が解除され、session invalidated または already-invalid が確定し、再認証要求が明示される | logout 後も保護操作を通す | `LogoutFlowResult` |
+
+## Visibility Rules
+
+- handoff 結果には Firebase ID token、refresh token、provider token、password、外部 credential detail を含めてはならない
+- app core が受け取るのは actor reference と利用可否判断に必要な最小状態だけである
+- logout 後は保護操作で再認証が必要なことを user-visible に示す

--- a/specs/008-auth-session-design/data-model.md
+++ b/specs/008-auth-session-design/data-model.md
@@ -1,0 +1,272 @@
+# Data Model: 会員登録・ログイン・ログアウト設計
+
+## Auth Design Overview
+
+```mermaid
+classDiagram
+    class AuthAccount {
+        <<BoundaryEntity>>
+        +AuthAccountIdentifier identifier
+        +AccountStatus status
+        +AvailableMethod[] availableMethods
+        +PrimaryContact primaryContact
+    }
+
+    class ExternalIdentityLink {
+        <<BoundaryEntity>>
+        +ExternalIdentityLinkIdentifier identifier
+        +ProviderKind provider
+        +ProviderSubject providerSubject
+        +AuthAccount authAccount
+        +LinkStatus status
+    }
+
+    class VerifiedFirebaseIdentity {
+        <<BoundaryEntity>>
+        +FirebaseSubject subject
+        +ProviderKind provider
+        +VerificationStatus status
+        +AuthAccount authAccount
+    }
+
+    class SessionState {
+        <<BoundaryEntity>>
+        +SessionIdentifier identifier
+        +AuthAccount authAccount
+        +SessionStatus status
+        +AuthenticationMethod authenticatedBy
+    }
+
+    class ResolvedActorReference {
+        <<BoundaryEntity>>
+        +ActorReference actor
+        +ResolutionStatus status
+        +AuthAccount authAccount
+    }
+
+    class ProviderAvailabilityPolicy {
+        <<Policy>>
+        +ProviderKind provider
+        +AvailabilityTier tier
+        +AvailabilityCondition condition
+        +FallbackGuidance fallbackGuidance
+    }
+
+    class RegisterFlowResult {
+        <<DesignEntity>>
+        +RegistrationOutcome outcome
+        +AuthAccount account
+        +SessionState session
+        +ResolvedActorReference actorReference
+    }
+
+    class LoginFlowResult {
+        <<DesignEntity>>
+        +LoginOutcome outcome
+        +SessionState session
+        +ResolvedActorReference actorReference
+    }
+
+    class LogoutFlowResult {
+        <<DesignEntity>>
+        +LogoutOutcome outcome
+        +SessionState session
+        +ReauthRequirement reauthRequirement
+    }
+
+    ExternalIdentityLink --> AuthAccount : belongsTo
+    VerifiedFirebaseIdentity --> AuthAccount : verifiedFor
+    SessionState --> AuthAccount : authenticates
+    SessionState --> VerifiedFirebaseIdentity : establishedFrom
+    ResolvedActorReference --> AuthAccount : resolvedFrom
+    ResolvedActorReference --> VerifiedFirebaseIdentity : derivedFrom
+    RegisterFlowResult --> AuthAccount : returns
+    RegisterFlowResult --> SessionState : mayReturn
+    RegisterFlowResult --> ResolvedActorReference : mayReturn
+    LoginFlowResult --> SessionState : returns
+    LoginFlowResult --> ResolvedActorReference : returns
+    LogoutFlowResult --> SessionState : invalidates
+```
+
+## Boundary Entity: AuthAccount
+
+**Purpose**: 会員登録済みの利用単位と、利用可能な認証手段を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| identifier | AuthAccountIdentifier | 1 | 会員アカウント識別子 |
+| status | AccountStatus | 1 | active / disabled / pending-verification などの利用可否 |
+| availableMethods | AvailableMethod[] | 1..* | `Basic`、`Google` など利用可能な認証手段 |
+| primaryContact | PrimaryContact | 0..1 | メールアドレスなど主要連絡先 |
+
+**Validation rules**:
+
+- 同じ会員アカウントに同一 provider subject を重複リンクしてはならない
+- `status = disabled` の場合は新規 login を受理してはならない
+
+## Boundary Entity: ExternalIdentityLink
+
+**Purpose**: 外部 provider 側の本人識別情報と会員アカウントの対応を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| identifier | ExternalIdentityLinkIdentifier | 1 | link 識別子 |
+| provider | ProviderKind | 1 | Basic / Google / Apple / LINE |
+| providerSubject | ProviderSubject | 1 | provider 側の一意 subject |
+| authAccount | AuthAccount | 1 | 紐づく会員アカウント |
+| status | LinkStatus | 1 | active / inactive |
+
+**Validation rules**:
+
+- 同一 `provider + providerSubject` は複数会員へ紐づけてはならない
+- `Basic` の場合は primary contact と Firebase Authentication 上の credential owner が整合しなければならない
+
+## Boundary Entity: VerifiedFirebaseIdentity
+
+**Purpose**: Flutter client が Firebase Authentication で sign-in した後に、backend が
+Firebase ID token を検証して確定する認証済み subject を表す。Firebase Authentication の
+`uid` はこの境界では `FirebaseSubject` として扱う。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| subject | FirebaseSubject | 1 | backend が検証済みと判断した Firebase subject |
+| provider | ProviderKind | 1 | Basic / Google / Apple / LINE のどの経路で sign-in したか |
+| status | VerificationStatus | 1 | verified / rejected |
+| authAccount | AuthAccount | 0..1 | 解決済みまたは対応候補の会員アカウント |
+
+**Validation rules**:
+
+- `status = rejected` の場合は actor resolution へ進めてはならない
+- raw Firebase ID token や refresh token を app core 側の handoff object に含めてはならない
+
+## Boundary Entity: SessionState
+
+**Purpose**: 現在の利用可能状態とその終了状態を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| identifier | SessionIdentifier | 1 | session 識別子 |
+| authAccount | AuthAccount | 1 | 認証済み会員 |
+| status | SessionStatus | 1 | active / invalidated / expired |
+| authenticatedBy | AuthenticationMethod | 1 | どの手段で成立したか |
+
+**Validation rules**:
+
+- `status = invalidated` または `expired` の session では protected operation を通してはならない
+- logout 成功時は対象 session を `active` のまま残してはならない
+- session は backend が検証済みの Firebase identity と actor resolution が揃った後にのみ `active` として確定してよい
+
+## Boundary Entity: ResolvedActorReference
+
+**Purpose**: 認証境界からアプリ本体へ handoff する正規化済み利用主体参照を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| actor | ActorReference | 1 | アプリ本体が受け取る利用主体参照 |
+| status | ResolutionStatus | 1 | resolved / unresolved |
+| authAccount | AuthAccount | 1 | 対応元の会員アカウント |
+
+**Validation rules**:
+
+- `status = unresolved` の場合は login / registration を成功として返してはならない
+- `actor` は provider token、Firebase ID token、refresh token、credential detail を含んではならない
+
+## Policy: ProviderAvailabilityPolicy
+
+**Purpose**: provider ごとの採用 tier と有効化条件を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| provider | ProviderKind | 1 | 対象 provider |
+| tier | AvailabilityTier | 1 | baseline / conditional / unavailable |
+| condition | AvailabilityCondition | 1 | 有効化条件または無効理由 |
+| fallbackGuidance | FallbackGuidance | 0..1 | 利用不可時の案内 |
+
+**Validation rules**:
+
+- `Basic` と `Google` は初期状態で `baseline` でなければならず、Firebase Authentication 経由で利用可能でなければならない
+- `Apple` と `LINE` は追加コストなし条件を満たさない限り `conditional` または `unavailable` とする
+
+## Flow Result: RegisterFlowResult
+
+**Purpose**: 会員登録導線の最終結果を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| outcome | RegistrationOutcome | 1 | registered / reused-existing / rejected / failed |
+| account | AuthAccount | 0..1 | 登録または再利用対象 |
+| session | SessionState | 0..1 | 登録直後に有効化された session |
+| actorReference | ResolvedActorReference | 0..1 | アプリ本体へ handoff できる参照 |
+
+**Validation rules**:
+
+- `outcome = registered` でも backend の Firebase identity 検証と actor resolution が完了していなければ成功として見せてはならない
+- 重複登録時は `outcome = reused-existing` とし、新規会員を作成してはならない
+
+## Flow Result: LoginFlowResult
+
+**Purpose**: ログイン導線の最終結果を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| outcome | LoginOutcome | 1 | logged-in / rejected / failed |
+| session | SessionState | 0..1 | 有効な session |
+| actorReference | ResolvedActorReference | 0..1 | アプリ本体へ handoff する参照 |
+
+**Validation rules**:
+
+- Flutter 側の Firebase sign-in 成功だけでは `logged-in` として返してはならず、有効 session と resolved actor reference の両方が揃わなければならない
+- disabled account は login を受理してはならない
+
+## Flow Result: LogoutFlowResult
+
+**Purpose**: ログアウト導線の完了結果を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| outcome | LogoutOutcome | 1 | logged-out / already-invalid / failed |
+| session | SessionState | 0..1 | 失効後または既存状態の session |
+| reauthRequirement | ReauthRequirement | 1 | 次回保護操作時に再認証が必要か |
+
+**Validation rules**:
+
+- `logged-out` の場合は `reauthRequirement = required` でなければならない
+- logout 完了には Flutter 側の Firebase sign-out と backend 側の session 終了または既存無効判定の両方を含める
+- 既に無効な session でも、利用者には成功扱いと失敗扱いを明確に区別しなければならない
+
+## Enumerations
+
+### ProviderKind
+
+- `basic`
+- `google`
+- `apple`
+- `line`
+
+### AvailabilityTier
+
+- `baseline`
+- `conditional`
+- `unavailable`
+
+### AccountStatus
+
+- `active`
+- `disabled`
+- `pending-verification`
+
+### SessionStatus
+
+- `active`
+- `invalidated`
+- `expired`
+
+### ResolutionStatus
+
+- `resolved`
+- `unresolved`
+
+### VerificationStatus
+
+- `verified`
+- `rejected`

--- a/specs/008-auth-session-design/plan.md
+++ b/specs/008-auth-session-design/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: 会員登録・ログイン・ログアウト設計
+
+**Branch**: `008-auth-session-design` | **Date**: 2026-04-17 | **Spec**: [/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md)
+**Input**: Feature specification from `/specs/008-auth-session-design/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+vocastock における会員登録、ログイン、ログアウトを、語彙学習のコアドメイン外にある
+認証境界として設計する。認証 UI と provider 開始は Flutter client が担い、本人確認基盤は
+Firebase Authentication を標準とする。利用可能状態の最終確定は backend 側で行い、
+Flutter が取得した Firebase ID token を backend が検証し、検証済み Firebase subject
+から actor / learner を解決した後に、アプリ本体へは正規化済み actor reference のみを
+handoff する。`Basic` と `Google` を初期対象とし、`Apple ID` と `LINE` は追加コストが
+発生しない場合のみ有効化候補とする。部分的に成立した認証状態を利用可能状態として
+見せず、登録、ログイン、ログアウトの完了条件を Flutter / Firebase / backend handoff を
+含めて contract として固定する。
+
+## Technical Context
+
+**Language/Version**: Markdown 1.x, YAML/JSON reference documents  
+**Primary Dependencies**: 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend  
+**Storage**: Git-managed repository files、設計上で参照する抽象的な auth account store、external identity link store、session store、actor / learner resolution store、Firebase Authentication user records  
+**Testing**: spec / constitution / architecture / auth-flow の手動クロスレビュー、Firebase ID token handoff review、provider policy review、session handoff review、partial-success rejection review  
+**Target Platform**: Flutter client entry flow、Firebase Authentication identity boundary、custom backend token verification boundary、GraphQL / application entry boundary、session-backed protected operation flow  
+**Project Type**: documentation / auth integration design  
+**Performance Goals**: レビュー参加者が 10 分以内に `Basic` / `Google` の会員登録、ログイン、ログアウト導線を説明できること、5 分以内に Flutter / Firebase / backend の責務分離を説明できること、3 分以内に provider ごとの初期対象 / 条件付き対象を判定できること  
+**Constraints**: product code は追加しない、認証は vocastock のコアドメイン外として扱う、Flutter は認証 UI と provider 開始のみを担う、Firebase Authentication を本人確認基盤とする、backend は Firebase ID token を検証してから actor / learner を解決する、アプリ本体へ Firebase token や `FirebaseUser` を渡さない、部分的に成立した認証状態を成功として返さない、`Basic` と `Google` を初期対象とする、`Apple ID` と `LINE` は追加コストなしの場合のみ候補とする、ログアウト後は保護操作に再認証を要求する、識別子命名は憲章に従う  
+**Scale/Scope**: 3 つの主要 user flow、5 から 6 の boundary entity、4 つの契約文書、Firebase Auth handoff、provider 採用方針、session handoff ルールを含む auth design package を対象とする
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Domain impact is identified. 認証は vocastock のコアドメイン外として扱い、`docs/internal/domain/*.md` は参照専用とする。domain aggregate や学習概念の更新は本 feature では行わない。
+- [x] Async generation flows are unaffected. 本 feature は生成 workflow を追加せず、会員登録、ログイン、ログアウトを利用者から見て同期完了または失敗として扱う。部分成功を利用可能状態として見せない。
+- [x] External dependencies remain behind ports/adapters. Flutter の provider 開始、Firebase Authentication、backend の ID token 検証、actor resolution はすべて auth boundary 越しに扱い、アプリ本体へ provider 固有詳細を持ち込まない。
+- [x] User stories are independently reviewable. 基本導線、責務分離、provider 採用条件は別々にレビュー可能で、他ストーリー依存を持たない。
+- [x] 学習概念を混同しない。auth account、external identity、verified Firebase identity、session、actor resolution は frequency、sophistication、proficiency、登録状態、生成状態と分離して扱う。
+- [x] Identifier naming follows the constitution. `AuthAccountIdentifier`、`SessionIdentifier`、`ActorReferenceIdentifier` などの表記を前提にし、`id` / `xxxId` を採用しない。Firebase Authentication の `uid` は文書上 `Firebase subject` として扱い、アプリ内の識別子命名規則を崩さない。
+
+Post-design re-check: PASS. Verified against `research.md`, `data-model.md`,
+`contracts/auth-boundary-contract.md`, `contracts/auth-flow-contract.md`,
+`contracts/session-handoff-contract.md`, and
+`contracts/provider-availability-contract.md`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-auth-session-design/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── auth-boundary-contract.md
+│   ├── auth-flow-contract.md
+│   ├── provider-availability-contract.md
+│   └── session-handoff-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+docs/
+├── external/
+│   ├── adr.md
+│   └── requirements.md
+└── internal/
+    └── domain/
+        ├── common.md
+        ├── explanation.md
+        ├── service.md
+        └── visual.md
+
+specs/
+├── 003-architecture-design/
+├── 004-tech-stack-definition/
+└── 008-auth-session-design/
+```
+
+**Structure Decision**: 実装時の正本は `docs/external/requirements.md`、
+`docs/external/adr.md`、認証連携を扱う本 feature の設計成果物に置く。`docs/internal/domain/*.md`
+は参照専用とし、auth account や external identity をコアドメイン aggregate として
+追加しない。008 では Flutter client が認証 UI と provider 開始を担い、Firebase
+Authentication が本人確認基盤となり、backend が Firebase ID token を検証して
+verified subject を actor / learner へ解決し、アプリ本体へは actor reference のみを
+handoff する境界 contract を固定する。
+
+## Complexity Tracking
+
+> No constitution violations requiring justification were identified.

--- a/specs/008-auth-session-design/quickstart.md
+++ b/specs/008-auth-session-design/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: 会員登録・ログイン・ログアウト設計
+
+## 1. 前提文書を確認する
+
+1. [requirements.md](/Users/lihs/workspace/vocastock/docs/external/requirements.md) を読み、利用開始前提と保護操作の要求を確認する
+2. [boundary-responsibility-contract.md](/Users/lihs/workspace/vocastock/specs/003-architecture-design/contracts/boundary-responsibility-contract.md) を読み、アプリ本体と外部境界の責務分離を確認する
+3. [spec.md](/Users/lihs/workspace/vocastock/specs/004-tech-stack-definition/spec.md) を読み、Firebase Authentication を含む managed service baseline と provider adapter 前提を確認する
+4. [common.md](/Users/lihs/workspace/vocastock/docs/internal/domain/common.md) と [service.md](/Users/lihs/workspace/vocastock/docs/internal/domain/service.md) を読み、auth をコアドメインへ混ぜない前提を確認する
+
+## 2. 008 の設計成果物を読む
+
+1. [research.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/research.md) で Flutter auth UI、Firebase Authentication、backend token verification、actor resolution の判断理由を確認する
+2. [data-model.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md) で auth account、external identity、verified Firebase identity、session、actor handoff を確認する
+3. [contracts/auth-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/auth-boundary-contract.md) と [contracts/auth-flow-contract.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/auth-flow-contract.md) で Flutter / Firebase / backend の責務と完了条件を確認する
+4. [contracts/session-handoff-contract.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/session-handoff-contract.md) と [contracts/provider-availability-contract.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/provider-availability-contract.md) で actor handoff 条件と provider tier を確認する
+
+## 3. 実装前レビューで確認すること
+
+1. `Basic` と `Google` が初期対象として成立していること
+2. `Apple ID` と `LINE` は追加コストなし条件を満たす場合のみ候補であること
+3. Flutter client が認証 UI と provider 開始だけを担っていること
+4. Firebase Authentication を本人確認基盤として使っていること
+5. backend が Firebase ID token を検証してから actor / learner を解決していること
+6. 認証成功後にアプリ本体へ渡すのが actor reference だけであること
+7. 重複会員を新規作成しないこと
+8. 部分的に成立した認証状態を利用可能状態として返さないこと
+9. logout 後は保護操作に再認証が必要になること
+
+## 4. この feature で扱わないこと
+
+1. パスワード再設定
+2. メール確認や電話番号確認の詳細フロー
+3. プロフィール編集
+4. 外部 identity の高度なアカウント統合
+5. 課金や subscription と会員状態の統合

--- a/specs/008-auth-session-design/research.md
+++ b/specs/008-auth-session-design/research.md
@@ -1,0 +1,112 @@
+# Research: 会員登録・ログイン・ログアウト設計
+
+## Decision: 認証は vocastock のコアドメイン外に置き、アプリ本体へは正規化済み actor reference のみを渡す
+
+**Rationale**: 認証そのものを語彙学習ドメインへ持ち込むと、外部 identity、credential、
+session 管理が学習概念と混線する。アプリ本体は認証詳細を知らず、正規化済みの
+actor reference を受け取って保護操作を判断する方が、責務分離と provider 差し替えに向く。
+
+**Alternatives considered**:
+
+- 認証 account をコアドメイン aggregate として扱う
+- provider ごとの認証情報をアプリ本体へ直接渡す
+
+## Decision: 認証 UI と provider 開始は Flutter client が担い、本人確認基盤は Firebase Authentication を使う
+
+**Rationale**: メール入力、Google sign-in 開始、ログアウト導線の UX は Flutter 側に
+置く方がモバイルアプリとして自然で、provider 固有 SDK や Firebase client SDK の責務とも
+整合する。一方で credential 検証や provider セッションの正当性は Firebase
+Authentication に委ねる方が、複数 provider を同じ認証基盤で扱いやすい。
+
+**Alternatives considered**:
+
+- 認証 UI も provider 開始も backend 主導の web flow に寄せる
+- `Basic` / `Google` / `Apple` / `LINE` を Firebase ではなく個別基盤で別々に扱う
+
+## Decision: backend は Flutter から受け取った Firebase ID token を検証してから、Firebase subject を actor / learner へ解決する
+
+**Rationale**: Flutter で Firebase sign-in が成功しただけでは、アプリ本体で利用可能な
+actor が確定したことにはならない。backend が ID token を検証し、検証済み Firebase
+subject から actor / learner を解決して初めて、保護操作へ進める状態を安全に定義できる。
+
+**Alternatives considered**:
+
+- Flutter 側の `FirebaseUser` だけを信用して app core を通す
+- backend で token 検証をせず、client が送る uid 文字列をそのまま actor 解決に使う
+
+## Decision: 初期対象は `Basic` と `Google` とし、`Apple ID` と `LINE` は追加コストなしの場合のみ候補とする
+
+**Rationale**: 初期導線として最低限の認証手段を確保しつつ、provider 数を増やしすぎない方が
+設計と運用を単純にできる。`Apple ID` と `LINE` は利用価値がある一方で、追加の運用費、
+契約費、審査負荷が発生する可能性があるため、追加コストがない場合のみ後続候補として扱う。
+
+**Alternatives considered**:
+
+- 初期対象に `Apple ID` と `LINE` も含める
+- `Basic` のみを初期対象にする
+
+## Decision: 会員登録、ログイン、ログアウト、session handoff、actor resolution を別責務として整理する
+
+**Rationale**: 会員作成、本人確認、session 付与、利用主体解決はそれぞれ失敗条件と完了条件が
+異なる。1 つの責務にまとめると部分成功時の扱いが曖昧になるため、責務を分割して contract を
+定義する方が検証しやすい。
+
+**Alternatives considered**:
+
+- 会員登録とログインを単一責務として扱う
+- session handoff をアプリ本体側の暗黙処理にする
+
+## Decision: app core は actor reference だけを受け取り、Firebase token、`FirebaseUser`、provider credential を保持しない
+
+**Rationale**: app core が Firebase Authentication の詳細を知ると、認証境界と
+学習ドメインの責務が再び混線する。app core が受け取るのを actor reference と最小限の
+利用可否状態だけに限定すれば、認証基盤の差し替えや provider の増減が起きても影響範囲を
+auth boundary 内へ閉じ込めやすい。
+
+**Alternatives considered**:
+
+- app core が Firebase ID token を直接保持する
+- app core が provider 名や raw user profile を前提に分岐する
+
+## Decision: 重複会員は作成せず、既存会員案内または既存 identity への接続へ寄せる
+
+**Rationale**: 同じメールアドレスや同じ provider subject で重複会員を作ると、利用主体解決と
+保護操作の整合が崩れる。重複検知時は既存会員の再利用または案内に寄せることで、利用主体を
+一意に保てる。
+
+**Alternatives considered**:
+
+- 重複時も別会員として作成する
+- 常にエラーのみ返し、既存会員案内を行わない
+
+## Decision: 部分的に成立した認証状態は成功として返さない
+
+**Rationale**: 認証成功後に session 発行や actor resolution が失敗した状態を「利用可能」と
+見せると、後続操作で不整合が起きる。会員登録、ログイン、ログアウトのいずれでも、利用者に
+成功を返すのは必要な後続条件まで満たした場合だけに限定する。
+
+**Alternatives considered**:
+
+- 認証成功だけで利用可能状態を返し、後続補正に委ねる
+- 部分成功を暫定状態として画面へ見せる
+
+## Decision: ログアウトは active session の失効と protected operation の再認証要求をセットで定義する
+
+**Rationale**: ログアウトを UI 上の見かけの状態変更だけにすると、保護操作の可用性が曖昧に
+残る。session 失効と再認証要求を一体で定義することで、ログアウト完了の意味を固定できる。
+
+**Alternatives considered**:
+
+- ログアウトはクライアントの状態破棄だけで扱う
+- session の自然失効だけに依存する
+
+## Decision: logout は Flutter 側の Firebase sign-out と backend 側の app-session 終了をセットで定義する
+
+**Rationale**: Flutter 側だけで sign-out しても、backend 側の利用可能状態や actor handoff
+条件が残ると保護操作の意味が曖昧になる。Firebase Auth current user の解除と app-session
+終了をセットで定義することで、logout 完了の判定と再認証要求を一貫して扱える。
+
+**Alternatives considered**:
+
+- Flutter 側の Firebase sign-out のみで logout 完了とする
+- backend 側の session だけを終了し、client 側の Firebase sign-out を任意にする

--- a/specs/008-auth-session-design/spec.md
+++ b/specs/008-auth-session-design/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: 会員登録・ログイン・ログアウト設計
+
+**Feature Branch**: `008-auth-session-design`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "会員登録・ログイン・ログアウトに関する設計書を作成する"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 主要な会員導線を定義する (Priority: P1)
+
+利用者として、会員登録、ログイン、ログアウトの基本導線を明確に知りたい。これにより、サービス利用開始と再訪時の入口が一貫する。
+
+**Why this priority**: 会員導線が曖昧だと、利用開始前に離脱しやすく、後続機能の利用条件も定義できないため。
+
+**Independent Test**: 第三者が設計書だけを読み、`Basic` と `Google` の会員登録、ログイン、ログアウトが、Flutter 側の認証 UI と provider 開始から Firebase Authentication、backend の検証と利用主体解決を経て完了する流れとして説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 未登録の利用者が利用開始したい, **When** 会員登録導線を確認する, **Then** Flutter 側で `Basic` または `Google` の登録を開始し、Firebase Authentication による本人確認と backend の利用主体解決が完了した後に利用可能状態へ遷移する流れを説明できる
+2. **Given** 既存会員が再訪した, **When** ログイン導線を確認する, **Then** Flutter 側で利用可能な手段を開始し、Firebase Authentication と backend 検証の両方を通過してから利用可能状態へ入る流れを説明できる
+3. **Given** ログイン中の利用者が利用を終えたい, **When** ログアウト導線を確認する, **Then** 現在の利用状態を終了し、再度認証が必要な状態へ戻ることを説明できる
+
+---
+
+### User Story 2 - 認証をアプリのコアドメイン外として切り分ける (Priority: P2)
+
+設計担当者として、認証そのものを vocastock のコアドメインに混ぜず、会員状態と学習データの所有者解決だけを接続したい。これにより、語彙学習ドメインの複雑さを増やさずに認証基盤を差し替えやすくできる。
+
+**Why this priority**: 認証をドメインモデルに取り込むと、学習概念と外部 identity の責務が混線するため。
+
+**Independent Test**: 第三者が設計書だけを読み、Flutter が認証 UI と provider 開始を担い、Firebase Authentication が本人確認基盤となり、backend が Firebase ID token を検証して actor / learner を解決し、アプリ本体は正規化済みの利用主体だけを受け取ることを説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 実装担当者が会員登録責務の配置先を確認したい, **When** 設計書を読む, **Then** Flutter 認証 UI、Firebase Authentication、backend token 検証、session 管理、利用主体解決の責務分離を説明できる
+2. **Given** 学習データへのアクセス制御を設計したい, **When** 設計書を読む, **Then** backend 検証後にアプリへ渡す利用主体情報と、アプリが保持しない Firebase token や provider 資格情報を区別できる
+
+---
+
+### User Story 3 - 条件付き provider 採用方針を定義する (Priority: P3)
+
+運用担当者として、`Apple ID` と `LINE` を追加候補として評価しつつ、追加コストが発生する場合は初期導入から除外したい。これにより、認証手段の拡張余地を残しながら初期運用コストを抑えられる。
+
+**Why this priority**: provider ごとの採用条件が曖昧だと、設計上は対応していても実運用で有効化できない手段が混ざるため。
+
+**Independent Test**: 第三者が設計書だけを読み、`Basic` / `Google` が Firebase Authentication を前提とした初期対象であり、`Apple ID` / `LINE` は追加コストなしで Firebase Authentication または承認済み同等経路に載せられる場合の後続有効化候補であることを説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 認証手段の採用可否を判断したい, **When** provider 一覧を確認する, **Then** 初期対象と条件付き対象を区別できる
+2. **Given** `Apple ID` または `LINE` に追加コストが発生する、または Firebase Authentication もしくは承認済み同等経路に載せられない, **When** 採用条件を確認する, **Then** 初期リリースでは無効のまま扱うことを説明できる
+
+### Edge Cases
+
+- `Basic` 登録済みメールアドレスで再登録を試みた場合に、新規会員作成ではなく既存会員案内へ切り替えるか
+- `Google` で取得した外部 identity と既存会員が競合する場合に、重複会員を作らずどう案内するか
+- ログイン成功直後に利用主体解決ができない場合に、認証成功とアプリ利用開始をどう分離するか
+- ログアウト要求時に session が既に無効な場合に、利用者へどう結果を返すか
+- `Apple ID` または `LINE` がコスト条件や運用条件を満たさない場合に、UI 上でどう非表示または無効扱いにするか
+
+## Domain & Async Impact *(mandatory when applicable)*
+
+- **Domain Models Affected**: None。認証コンテキストは vocastock のコアドメイン外として扱い、`docs/internal/domain/*.md` は参照専用とする
+- **Invariants / Terminology**: Flutter は認証 UI と provider 開始だけを担い、Firebase Authentication は本人確認基盤、backend は Firebase ID token 検証と actor / learner 解決、app core は正規化済み利用主体参照のみを受け取る。会員アカウント、外部 identity、検証済み Firebase identity、session、利用主体解決、学習者所有は別概念として扱い、認証情報を語彙・解説・画像のドメイン概念へ混在させない
+- **Async Lifecycle**: 会員登録、ログイン、ログアウトは、Flutter 側の開始、Firebase Authentication、backend 検証、利用主体解決を内部で含んでも、利用者から見て即時完了または失敗として扱い、`pending` / `running` の長時間状態は公開しない
+- **User Visibility Rule**: Flutter 側での Firebase sign-in 成功だけでは「利用可能状態」と見せてはならず、backend 検証と actor / learner 解決が完了した後にのみ利用可能状態へ遷移できる。ログアウト完了後は認証が必要な状態へ戻ったことだけを示す
+- **Identifier Naming Rule**: 認証境界からアプリ本体へ受け渡す利用主体参照が存在する場合でも、識別子命名は憲章に従い `XxxIdentifier`、`identifier`、概念名参照を維持する
+- **External Ports / Adapters**: Flutter 認証 UI、provider 開始、Firebase Authentication、Firebase ID token 検証、Google identity 検証、Apple identity 検証、LINE identity 検証、session 発行、session 失効、利用主体解決
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 設計成果物は、会員登録、ログイン、ログアウトを vocastock のコアドメイン外にある認証境界として定義しなければならない
+- **FR-002**: 設計成果物は、初期対象の会員登録・ログイン手段として少なくとも `Basic` と `Google` を定義し、Flutter 側で開始して Firebase Authentication を本人確認基盤として使う流れを明記しなければならない
+- **FR-003**: 設計成果物は、`Apple ID` と `LINE` を追加コストが発生せず、Firebase Authentication または承認済み同等経路で提供できる場合の条件付き候補として定義し、その有効化条件を明記しなければならない
+- **FR-004**: 設計成果物は、Flutter 側の認証 UI と provider 開始、Firebase Authentication による本人確認、backend による Firebase ID token 検証、会員登録、ログイン、ログアウト、session 有効化、session 終了、利用主体解決を別責務として整理しなければならない
+- **FR-005**: 設計成果物は、認証成功後にアプリ本体へ渡す actor reference と、アプリ本体が保持しない Firebase ID token、refresh token、provider 資格情報、Firebase user 情報を区別して定義しなければならない
+- **FR-006**: 設計成果物は、既存メールアドレスまたは既存外部 identity との重複時に、重複会員を新規作成しない規則を定義しなければならない
+- **FR-007**: 設計成果物は、会員登録済み利用者のログイン条件として、Flutter 側での開始後に Firebase Authentication の本人確認と backend の Firebase ID token 検証、actor / learner 解決が完了することを定義し、利用不能状態で拒否する条件も定義しなければならない
+- **FR-008**: 設計成果物は、ログアウト時に Flutter 側の Firebase sign-out と backend 側の利用状態終了を完了させ、その後の保護操作が再認証を要求する規則を定義しなければならない
+- **FR-009**: 設計成果物は、会員登録、ログイン、ログアウトのいずれでも、Flutter 側の Firebase sign-in 成功だけ、または backend 側の部分完了だけの状態を利用者へ成功として見せない規則を定義しなければならない
+- **FR-010**: 設計成果物は、認証境界とアプリ本体の接続点として、backend が検証済み Firebase subject から解決した正規化済み利用主体参照の受け渡し方法を定義しなければならない
+- **FR-011**: 設計成果物は、provider ごとの利用可否が変わった場合の案内方針を定義し、Firebase Authentication または承認済み同等経路への搭載可否も利用可否判断へ含めなければならない
+- **FR-012**: 設計成果物は、今回扱わない範囲を明示し、パスワード再設定、プロフィール管理、課金連携、外部 identity の高度な統合は別論点として切り分けなければならない
+
+### Key Entities *(include if feature involves data)*
+
+- **Auth Account**: 会員登録済みの利用単位を表し、どの認証手段で利用可能かを示す
+- **External Identity**: `Google`、`Apple ID`、`LINE` など外部 provider 側の本人識別情報を表し、Firebase Authentication または承認済み同等経路へ接続される対象を示す
+- **Verified Firebase Identity**: backend が Firebase ID token を検証した後に得る、Firebase subject と検証結果を束ねた認証境界内の確認済み本人情報を表す
+- **Session State**: 現在の利用可能状態、無効状態、終了状態を表す
+- **Resolved Actor Reference**: 認証境界からアプリ本体へ受け渡す正規化済み利用主体参照を表す
+- **Provider Availability Policy**: 各 provider が初期対象か条件付き対象か、利用不可時にどう扱うかを表す
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: レビュー参加者が 10 分以内に、`Basic` と `Google` の会員登録、ログイン、ログアウト導線を 100% 対応付けられる
+- **SC-002**: 第三者が 5 分以内に、認証境界と vocastock コアドメインの責務分離を説明できる
+- **SC-003**: `Apple ID` と `LINE` の採用条件について、レビュー時の解釈ぶれが 0 件になる
+- **SC-004**: 重複会員作成、部分ログイン成功、ログアウト後の保護操作に関する矛盾がレビュー時に 0 件である
+
+## Assumptions
+
+- `Basic` はメールアドレスと秘密情報による一般的な会員登録・ログイン手段を指し、Flutter 側で開始して Firebase Authentication に委譲する
+- Flutter が認証 UI と provider 開始を担い、Firebase Authentication を本人確認基盤とし、backend が Firebase ID token を検証して uid から actor / learner を解決する
+- 初期リリースでは `Basic` と `Google` を主対象とし、`Apple ID` と `LINE` は追加コストがなく、Firebase Authentication または承認済み同等経路に載せられる場合のみ後続有効化候補とする
+- 認証そのものは vocastock のコアドメインモデルに含めず、app core は backend 検証後の正規化済み actor reference だけを受け取る
+- 会員登録、ログイン、ログアウトは利用者から見て同期的に完了または失敗し、長時間処理状態は公開しない
+- パスワード再設定、メール確認、プロフィール編集、外部 identity の高度なアカウント統合はこの feature の主要対象外とする

--- a/specs/008-auth-session-design/tasks.md
+++ b/specs/008-auth-session-design/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: 会員登録・ログイン・ログアウト設計
+
+**Input**: Design documents from `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/`  
+**Prerequisites**: [plan.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/plan.md) (required), [spec.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md) (required), [research.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/research.md), [data-model.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md), [contracts/](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts), [quickstart.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/quickstart.md)
+
+**Tests**: 専用の test-first task は追加しない。検証は auth flow review、Firebase ID token handoff review、boundary review、session handoff review、provider policy review、cross-document review を independent test として扱う。
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this belongs to (`US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 008 の設計成果物を置く受け皿と参照導線を揃える
+
+- [ ] T001 Create the feature artifact skeleton in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/plan.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/research.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/quickstart.md`, and `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/`
+- [ ] T002 [P] Update `/Users/lihs/workspace/vocastock/.specify/feature.json` to keep `/Users/lihs/workspace/vocastock/specs/008-auth-session-design` as the active feature directory
+- [ ] T003 [P] Sync `/Users/lihs/workspace/vocastock/AGENTS.md` with the planning context for Flutter / Firebase / backend auth design
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: すべての user story が依存する認証境界の前提文書と用語を固定する
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Reconcile auth-boundary references across `/Users/lihs/workspace/vocastock/docs/external/requirements.md`, `/Users/lihs/workspace/vocastock/docs/external/adr.md`, `/Users/lihs/workspace/vocastock/specs/003-architecture-design/contracts/boundary-responsibility-contract.md`, and `/Users/lihs/workspace/vocastock/specs/004-tech-stack-definition/spec.md`
+- [ ] T005 [P] Reconcile auth-outside-domain and Firebase-subject terminology across `/Users/lihs/workspace/vocastock/docs/internal/domain/common.md` and `/Users/lihs/workspace/vocastock/docs/internal/domain/service.md`
+- [ ] T006 [P] Normalize Flutter Auth UI, Firebase Authentication, verified Firebase identity, session, actor reference, and provider-tier terminology across `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md`, and `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/`
+- [ ] T007 [P] Capture feature-wide assumptions, Firebase handoff review method, and provider baseline / exclusion notes in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/plan.md` and `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/research.md`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - 主要な会員導線を定義する (Priority: P1) 🎯 MVP
+
+**Goal**: `Basic` と `Google` の会員登録、ログイン、ログアウト導線を、Flutter auth UI、Firebase Authentication、backend handoff を含む形で一貫した設計成果物として定義する
+
+**Independent Test**: [auth-flow-contract.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/auth-flow-contract.md) と [data-model.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md) を読むだけで、`Basic` / `Google` の会員登録、ログイン、ログアウトの流れと user-visible な完了条件を第三者が説明できること
+
+### Implementation for User Story 1
+
+- [ ] T008 [P] [US1] Define `Basic` and `Google` registration, login, and logout acceptance / completion rules, including Flutter Firebase sign-in and backend token verification, in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/auth-flow-contract.md`
+- [ ] T009 [P] [US1] Update baseline membership-flow review order and completion checkpoints, including Flutter-to-backend handoff, in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/quickstart.md`
+- [ ] T010 [US1] Map `AuthAccount`, `VerifiedFirebaseIdentity`, `SessionState`, `RegisterFlowResult`, `LoginFlowResult`, and `LogoutFlowResult` semantics into `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md`
+- [ ] T011 [US1] Align User Story 1 wording, acceptance scenarios, duplicate edge cases, and logout completion wording in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md` with the finalized baseline flows
+
+**Checkpoint**: User Story 1 should define the baseline membership flows independently
+
+---
+
+## Phase 4: User Story 2 - 認証をアプリのコアドメイン外として切り分ける (Priority: P2)
+
+**Goal**: Flutter Auth UI、Firebase Authentication、backend token verification、session 管理、actor / learner resolution、アプリ本体への handoff を分離し、認証詳細をコアドメインへ持ち込まない設計を固定する
+
+**Independent Test**: [auth-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/auth-boundary-contract.md)、[session-handoff-contract.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/session-handoff-contract.md)、[data-model.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md) を読むだけで、Flutter / Firebase / backend の責務分離と actor handoff 条件を第三者が説明できること
+
+### Implementation for User Story 2
+
+- [ ] T012 [P] [US2] Define Flutter Auth UI, Firebase Auth Client Adapter, Backend Token Verifier, Session Manager, Actor Resolver, and App Core Entry responsibilities in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/auth-boundary-contract.md`
+- [ ] T013 [P] [US2] Define Firebase ID token handoff checkpoints, visibility rules, backend actor resolution conditions, and reauthentication expectations in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/session-handoff-contract.md`
+- [ ] T014 [US2] Extend `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md` with `VerifiedFirebaseIdentity`, `ResolvedActorReference` constraints, and session-to-app handoff validation rules
+- [ ] T015 [US2] Align `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md` Domain & Async Impact, FR-004, FR-005, FR-008, FR-009, and FR-010 wording with the finalized Flutter / Firebase / backend split
+- [ ] T016 [US2] Capture the rationale for auth-outside-domain, Firebase token verification, credential hiding, and actor-only handoff in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/research.md`
+
+**Checkpoint**: User Story 2 should make auth-boundary separation and actor handoff independently reviewable
+
+---
+
+## Phase 5: User Story 3 - 条件付き provider 採用方針を定義する (Priority: P3)
+
+**Goal**: `Basic` / `Google` の初期対象と、`Apple ID` / `LINE` の条件付き採用ルール、Firebase 経由の有効化条件、fallback guidance、対象外範囲を運用可能な形で整理する
+
+**Independent Test**: [provider-availability-contract.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/provider-availability-contract.md)、[research.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/research.md)、[quickstart.md](/Users/lihs/workspace/vocastock/specs/008-auth-session-design/quickstart.md) を読むだけで、provider ごとの初期対象 / 条件付き対象 / fallback を第三者が説明できること
+
+### Implementation for User Story 3
+
+- [ ] T017 [P] [US3] Define baseline, conditional, disable, Firebase-based enablement, and fallback rules for each provider in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/provider-availability-contract.md`
+- [ ] T018 [P] [US3] Extend `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md` with `ProviderAvailabilityPolicy` tier, Firebase-based condition, and fallback guidance details
+- [ ] T019 [US3] Align provider availability, out-of-scope, and cost-trigger edge cases in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md` with the finalized provider adoption policy
+- [ ] T020 [US3] Update `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/research.md` and `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/quickstart.md` with provider evaluation order, Firebase dependency notes, deferred-provider guidance, and fallback review steps
+
+**Checkpoint**: User Story 3 should make provider adoption policy independently reviewable
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 複数ストーリーに跨る整合と最終導線を整える
+
+- [ ] T021 [P] Reconcile all 008 artifacts across `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/spec.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/plan.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/research.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md`, and `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/`
+- [ ] T022 [P] Cross-check 008 auth terminology against `/Users/lihs/workspace/vocastock/docs/external/requirements.md`, `/Users/lihs/workspace/vocastock/docs/external/adr.md`, `/Users/lihs/workspace/vocastock/specs/003-architecture-design/`, and `/Users/lihs/workspace/vocastock/specs/004-tech-stack-definition/`
+- [ ] T023 Re-run the review flow in `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/quickstart.md` and reconcile reviewer guidance with the finalized auth design
+- [ ] T024 Update `/Users/lihs/workspace/vocastock/AGENTS.md` and final repository guidance if Flutter / Firebase / backend auth terminology introduces new canonical wording worth surfacing
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on other stories
+- **User Story 2 (P2)**: Can start after Foundational - uses shared Flutter / Firebase / actor vocabulary fixed in Phase 2, so no dependency on US1 remains
+- **User Story 3 (P3)**: Can start after Foundational - uses the same provider vocabulary and Firebase baseline, but remains independently reviewable
+
+### Within Each User Story
+
+- Flow, boundary, handoff, and provider contracts should be fixed before final spec wording adjustments
+- Data-model alignment should follow the corresponding contract decisions
+- Quickstart and reviewer guidance should be finalized after the relevant contracts and policy wording are stable
+
+### Parallel Opportunities
+
+- `T002` and `T003` can run in parallel after `T001`
+- `T005`, `T006`, and `T007` can run in parallel after `T004`
+- In US1, `T008` and `T009` can run in parallel
+- In US2, `T012` and `T013` can run in parallel
+- In US3, `T017` and `T018` can run in parallel
+- Final polish `T021` and `T022` can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch baseline flow-definition tasks together:
+Task: "Define Basic and Google registration, login, and logout rules including Flutter sign-in and backend token verification in /Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/auth-flow-contract.md"
+Task: "Update baseline membership-flow review order including Flutter-to-backend handoff in /Users/lihs/workspace/vocastock/specs/008-auth-session-design/quickstart.md"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch boundary-separation tasks together:
+Task: "Define Flutter Auth UI, Firebase Auth Client Adapter, Backend Token Verifier, Session Manager, Actor Resolver, and App Core Entry responsibilities in /Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/auth-boundary-contract.md"
+Task: "Define Firebase ID token handoff checkpoints in /Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/session-handoff-contract.md"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch provider-policy tasks together:
+Task: "Define provider availability and Firebase-based enablement rules in /Users/lihs/workspace/vocastock/specs/008-auth-session-design/contracts/provider-availability-contract.md"
+Task: "Extend ProviderAvailabilityPolicy details in /Users/lihs/workspace/vocastock/specs/008-auth-session-design/data-model.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate that `Basic` / `Google` membership flows can be reviewed independently
+5. Stop and review before adding boundary-separation and provider-policy refinements
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational to fix source-of-truth references and shared terminology
+2. Add User Story 1 to define the baseline membership flows
+3. Add User Story 2 to fix Flutter / Firebase / backend boundary separation and actor handoff rules
+4. Add User Story 3 to define provider adoption policy and conditional enablement guidance
+5. Finish with cross-cutting reconciliation
+
+### Parallel Team Strategy
+
+1. One contributor handles Setup and Foundational alignment
+2. After Foundation:
+   - Contributor A: User Story 1 baseline flows
+   - Contributor B: User Story 2 boundary separation and handoff
+   - Contributor C: User Story 3 provider policy and deferred-provider guidance
+3. Reconcile all artifacts together in Phase 6
+
+---
+
+## Notes
+
+- [P] tasks target different files and can proceed in parallel after dependencies
+- No standalone test-file tasks were generated because this feature is a design package and independent review is the intended validation mode
+- Keep auth terminology aligned across `Flutter Auth UI`, `Firebase Authentication`, `verified Firebase identity`, `session`, `actor reference`, and provider-tier vocabulary
+- Do not pull password reset, profile management, billing integration, or advanced identity merge into this feature


### PR DESCRIPTION
## Summary
- implement the 005 domain modeling source-of-truth documents
- add backend command design artifacts for 007
- add auth/session design artifacts for 008 with Flutter/Firebase/backend handoff

## Testing
- not run (documentation-only changes)