### PR TITLE
docs: introduce sense-based explanation model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-17
 - Git-managed repository files、設計上で参照する抽象的な auth account store、external identity link store、session store、actor resolution store (008-auth-session-design)
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend (008-auth-session-design)
 - Git-managed repository files、設計上で参照する抽象的な auth account store、external identity link store、session store、actor / learner resolution store、Firebase Authentication user records (008-auth-session-design)
+- Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/` (009-sense-modeling)
 
 - Markdown 1.x, YAML, JSON + Spec Kit workflow, existing domain documents, requirements memo, ADR memo (001-complete-domain-model)
 
@@ -60,9 +61,9 @@ an aggregate's own identifier field must be `identifier`, and related identifier
 fields must use concept names such as `bank`, `entry`, or `image`.
 
 ## Recent Changes
+- 009-sense-modeling: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
 - 008-auth-session-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend
 - 008-auth-session-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
-- 007-backend-command-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/005-domain-modeling/`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/external/adr.md
+++ b/docs/external/adr.md
@@ -3,8 +3,9 @@
 ## UI
 
 - ユーザーが直に触れる部分
-- `VocabularyExpression` の登録、完了済み `Explanation` の閲覧、完了済み `VisualImage` の閲覧を扱う
+- `VocabularyExpression` の登録、`Sense` で整理された完了済み `Explanation` の閲覧、完了済み `VisualImage` の閲覧を扱う
 - 生成中または失敗中は状態のみを表示し、中間生成物は表示しない
+- 画像表示は `Explanation.currentImage` の単一参照に従い、複数 current image を同時公開しない
 
 ## Learner identity resolution
 
@@ -23,6 +24,7 @@
 ## Explanation generation
 
 - `VocabularyExpression` から解説を生成する
+- 完了時は `Explanation` とその配下の `Sense` を返す
 - 生成には指定の AI サービスを利用する
 - 完了時のみ解説 payload を返す
 
@@ -34,12 +36,15 @@
 ## Image generation
 
 - 完了済み `Explanation` から英語表現を視覚的に理解できる画像を生成する
+- 必要に応じて特定の `Sense` を描写対象として受け付ける
 - 完了時のみ画像 payload を返す
+- `Explanation.currentImage` は単一参照のまま維持し、複数 current image は後続 scope とする
 
 ## Asset storage
 
 - 生成した画像を何らかのストレージサービスに永続化する
 - ストレージ上で画像を一意に識別する情報と再取得参照を返す
+- 必要に応じて explanation 全体画像か `Sense` 対応画像かを metadata で区別できる
 
 ## Pronunciation media
 
@@ -50,3 +55,4 @@
 - 認証、account lifecycle、session 管理は auth/session 設計で扱う
 - command 受理、retry / regenerate の dispatch、workflow orchestration は backend command 設計で扱う
 - query model、永続化実装、ベンダー固有 adapter はこの ADR の対象外とする
+- 複数 current image の同時公開、meaning gallery、`Explanation` 直下の裸画像配列は follow-on scope とする

--- a/docs/external/requirements.md
+++ b/docs/external/requirements.md
@@ -7,12 +7,15 @@
   - 重複登録判定は同一学習者内の `NormalizedVocabularyExpressionText` で行う
 - 未登録であれば、登録した `VocabularyExpression` に対して解説生成を行う
   - 時間がかかるため非同期で行う
+- 完了済み `Explanation` は 1 件以上の `Sense` を持ち、多義語でも意味単位ごとに説明できる
+  - 例文とコロケーションは explanation 全体ではなく対応する `Sense` に属する
 - ユーザーは完了済み `Explanation` から視覚的イメージ画像を生成できる
   - 時間がかかるため非同期で行う
   - 生成された画像は何らかのストレージサービスに永続化される
+  - 画像は explanation 全体を代表してもよく、必要に応じて特定の `Sense` に対応してもよい
 - ユーザーには解説と画像の完全な生成結果のみを表示する
   - 生成中または失敗中は状態のみを表示し、中間生成結果は表示しない
-- 画像が生成されている解説は `currentImage` を表示に反映する
+- 画像が生成されている解説は単一の `currentImage` を表示に反映する
 
 ## 要件
 
@@ -22,12 +25,16 @@
 - 学習者ごとの定着度は `LearningState.proficiency` として管理する
   - `Frequency` や `Sophistication` とは異なる概念として扱う
 - `RegistrationStatus`、`ExplanationGenerationStatus`、`ImageGenerationStatus` は別概念として管理する
+- `Sense` は `Explanation` が所有する意味単位として管理し、`Meaning.values` を正本概念として再利用しない
+- `VisualImage` は独立集約のまま維持しつつ、必要に応じてどの `Sense` を描写する画像かを示せる
+- `Explanation.currentImage` は `Sense` の数にかかわらず単一参照のままとする
 
 ## Deferred Scope
 
 - 認証、credential、session 管理は auth/session 設計で扱う
 - command 受理、workflow orchestration、dispatch failure は backend command 設計で扱う
 - query model、永続化実装、外部 vendor adapter 実装は別 feature とする
+- 複数 current image の同時公開や meaning gallery は後続 feature で扱う
 
 ## 開発基盤メモ
 

--- a/docs/internal/domain/common.md
+++ b/docs/internal/domain/common.md
@@ -7,9 +7,17 @@
 | [learner.md](./learner.md) | `Learner`、`AuthenticationSubject` | 学習者の所有境界と外部 identity 境界 |
 | [vocabulary-expression.md](./vocabulary-expression.md) | `VocabularyExpression`、`VocabularyExpressionText`、`NormalizedVocabularyExpressionText` | 学習者が所有する登録対象と解説生成状態 |
 | [learning-state.md](./learning-state.md) | `LearningState`、`Proficiency` | 学習進捗と習熟度 |
-| [explanation.md](./explanation.md) | `Explanation`、`Frequency`、`Sophistication` | 解説本文と画像生成状態 |
-| [visual.md](./visual.md) | `VisualImage`、`StorageReference` | 画像アセットと履歴 |
+| [explanation.md](./explanation.md) | `Explanation`、`Sense`、`Frequency`、`Sophistication` | 解説本文、意味単位、画像生成状態 |
+| [visual.md](./visual.md) | `VisualImage`、`StorageReference` | 画像アセット、意味対応、履歴 |
 | [service.md](./service.md) | external port catalog | 外部責務の境界 |
+
+## Sense 導入レビューアンカー
+
+- `Sense` は `Explanation` が所有する内部エンティティである
+- `Sense` は多義語の意味単位を表し、`Meaning` は移行メモ上の旧表現としてのみ残す
+- `VisualImage` は独立集約のまま維持し、必要に応じて `sense` で意味単位を指せる
+- `Explanation.currentImage` は `Sense` 導入後も 0..1 件の単一 current 参照を維持する
+- 複数 current image の同時公開は follow-on scope とし、この文書群では扱わない
 
 ## 集約関係の概要
 
@@ -18,21 +26,25 @@ classDiagram
     class Learner
     class VocabularyExpression
     class Explanation
+    class Sense
     class VisualImage
     class LearningState
 
     Learner --> VocabularyExpression : owns
     Learner --> LearningState : tracks
     VocabularyExpression --> Explanation : currentExplanation
+    Explanation --> Sense : contains
     Explanation --> VisualImage : currentImage
+    VisualImage --> Sense : depicts
     VisualImage --> VisualImage : previousImage
     LearningState --> VocabularyExpression : vocabularyExpression
 ```
 
 - `Learner` は所有境界であり、認証方式そのものは保持しない
 - `VocabularyExpression` は学習者が所有する登録対象で、単語と連語を同一概念で扱う
-- `Explanation` は `VocabularyExpression` の完了済み解説結果を表す
-- `VisualImage` は `Explanation` に属する独立集約で、履歴を保持する
+- `Explanation` は `VocabularyExpression` の完了済み解説結果を表し、1 件以上の `Sense` を持つ
+- `Sense` は意味、状況、ニュアンス、例文、コロケーションを束ねる `Explanation` 配下の意味単位である
+- `VisualImage` は `Explanation` に属する独立集約で、必要に応じて特定の `Sense` を描写しつつ履歴を保持する
 - `LearningState` は `Learner` と `VocabularyExpression` の関係上にある習熟度専用集約である
 
 ## 正規用語と移行メモ
@@ -43,9 +55,12 @@ classDiagram
 | `LearningState` | `EntryLearningState` | 学習進捗の正規名称 |
 | `VocabularyExpressionText` | `EntryExpressionText` | 登録時の文字列表現 |
 | `NormalizedVocabularyExpressionText` | `NormalizedEntryExpressionText` | 重複判定用の正規化表現 |
+| `Sense` | `Meaning`, `Meaning.values` | `Explanation` 所有の意味単位として再編した正規名称 |
 
 - 旧称はこの移行メモ以外では使わない
 - 外部向け説明で日本語を併記する場合も、英語の正規名称は上表に合わせる
+- `Meaning` は正本概念としては維持せず、`Explanation.senses` へ置き換える
+- explanation 全体を代表する画像は `VisualImage.sense = null` で表し、意味対応のある画像だけ `sense` を持つ
 
 ## 命名規約
 
@@ -54,11 +69,13 @@ classDiagram
 - 他集約や他概念への参照フィールドは `learner`、`vocabularyExpression`、`currentExplanation`、`currentImage` のように概念名そのものを使う
 - 派生命名は `VocabularyExpression*` / `LearningState*` に統一する
 - 文字列表現の値オブジェクト名は `VocabularyExpressionText` と `NormalizedVocabularyExpressionText` を採用する
+- `Sense` の識別子は `SenseIdentifier` とし、関連参照フィールド名は `sense` を使う
 
 ## 概念分離
 
 | 概念 | 所有者 | 混同してはならない対象 |
 |---|---|---|
+| `Sense` | `Explanation` | `Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態 |
 | `Frequency` | `Explanation` | `Sophistication`、`Proficiency`、生成状態 |
 | `Sophistication` | `Explanation` | `Frequency`、`Proficiency`、登録状態 |
 | `Proficiency` | `LearningState` | `Frequency`、`Sophistication`、生成状態 |
@@ -72,10 +89,14 @@ classDiagram
 - regenerate 開始時に `currentExplanation` / `currentImage` を消してはならない
 - 新しい解説または画像が `succeeded` になった時だけ current 参照を切り替える
 - 生成中または失敗中は状態表示だけを行い、不完全な生成物は表示しない
+- `Explanation` が複数の `Sense` を持っていても、表示対象の `currentImage` は常に 0..1 件である
+- `currentImage` が `sense` を持つ場合、その `sense` は同じ `Explanation` に属する意味単位でなければならない
+- explanation 全体を代表する画像は `sense` を持たず、意味ごとの画像と同じ表示ルールに従う
 
 ## Deferred Scope / Follow-on Boundaries
 
 - credential 管理、session 管理、provider ごとの認証導線は auth/session 設計で扱う
 - command 受理、dispatch failure、workflow orchestration は backend command 設計で扱う
 - query model、永続化マッピング、adapter 実装、ベンダー固有 SDK はこの文書群の対象外とする
+- 複数 current image の同時公開、meaning gallery、`Explanation` 直下の裸画像配列は後続 feature で扱う
 - この文書群は project-wide domain language の正本であり、後続 feature はここで固定した概念境界を前提にする

--- a/docs/internal/domain/explanation.md
+++ b/docs/internal/domain/explanation.md
@@ -3,15 +3,17 @@
 ## この文書の役割
 
 - `Explanation` を `VocabularyExpression` に紐づく知識集約として定義する
+- `Sense` を `Explanation` 所有の意味単位として定義する
 - `Frequency` と `Sophistication` の所有者を `Explanation` に固定する
 - `currentImage` と `imageGeneration` の責務を明確化する
+- meaning-to-image mapping の正本を [visual.md](./visual.md) と分担して固定する
 
 ## 関連文書
 
-- [common.md](./common.md)
+- [common.md](./common.md) - project-wide 用語、`Meaning` から `Sense` への移行メモ、単一 `currentImage` ルール
 - [vocabulary-expression.md](./vocabulary-expression.md)
-- [visual.md](./visual.md)
-- [service.md](./service.md)
+- [visual.md](./visual.md) - `VisualImage.sense`、履歴、current handoff 条件
+- [service.md](./service.md) - sense-aware image generation を扱う外部ポート
 
 ## 値オブジェクト
 
@@ -19,6 +21,11 @@
 
 - 解説を一意に識別する値オブジェクト
 - 英語表現そのものではなく、生成済み解説結果を識別する
+
+### SenseIdentifier
+
+- 同一 `Explanation` 内の意味単位を識別する値オブジェクト
+- related-field 命名は `sense` に統一し、`senseId` や `senseIdentifier` を使わない
 
 ### FrequencyLevel
 
@@ -55,20 +62,6 @@
 不変条件:
 
 - `reason` は 1 文字以上 255 文字以下
-
-### Meaning
-
-| フィールド名 | 種別 | 保持数 | 備考 |
-|---|---|---:|---|
-| values | 意味の一覧 | 1..n | 主要な意味の列挙 |
-| situation | 文字列 | 1 | 使用する状況 |
-| nuance | 文字列 | 1 | ニュアンス |
-
-不変条件:
-
-- `values` は 1 件以上
-- `situation` は 1 文字以上 255 文字以下
-- `nuance` は 1 文字以上 255 文字以下
 
 ### PhoneticSymbols
 
@@ -137,23 +130,47 @@
 - `succeeded`
 - `failed`
 
+## エンティティ
+
+### Sense
+
+- `Explanation` が所有する意味単位の内部エンティティ
+- explanation 全体の粗い `Meaning` ではなく、意味、状況、ニュアンス、例文、コロケーションを意味単位で束ねる
+
+| フィールド名 | 種別 | 保持数 | 備考 |
+|---|---|---:|---|
+| identifier | SenseIdentifier | 1 | 同一 `Explanation` 内での意味識別子 |
+| label | 文字列 | 1 | 意味を短く表す代表ラベル |
+| situation | 文字列 | 1 | 使われる状況 |
+| nuance | 文字列 | 1 | ニュアンス |
+| order | 正の整数 | 1 | 表示順序 |
+| collocations | Collocation の一覧 | 0..5 | その意味に結びつくコロケーション |
+| examples | ExampleSentence の一覧 | 0..3 | その意味に結びつく例文 |
+
+不変条件:
+
+- `label` は 1 文字以上 255 文字以下
+- `situation` は 1 文字以上 255 文字以下
+- `nuance` は 1 文字以上 255 文字以下
+- `order` は 1 以上の整数
+- `identifier` と `order` は同一 `Explanation` 内で重複してはならない
+- `collocations` と `examples` は explanation 全体ではなく、その `Sense` の意味に対応していなければならない
+
 ## 集約
 
 ### Explanation
 
 - `VocabularyExpression` に紐づく生成済み解説を表す知識集約
-- ユーザーへ表示する本文と、画像生成の current 参照を保持する
+- 1 件以上の `Sense` を持ち、ユーザーへ表示する本文と画像生成の current 参照を保持する
 
 | フィールド名 | 種別 | 保持数 | 備考 |
 |---|---|---:|---|
 | identifier | ExplanationIdentifier | 1 | 解説識別子 |
 | vocabularyExpression | VocabularyExpressionIdentifier | 1 | 元の登録対象 |
-| meaning | Meaning | 1 | 意味のまとまり |
+| senses | Sense の一覧 | 1..5 | 意味単位の一覧 |
 | pronunciation | Pronunciation | 1 | 発音情報 |
 | frequency | Frequency | 1 | 頻出度 |
 | sophistication | Sophistication | 1 | 知的度 |
-| collocations | Collocation の一覧 | 1..10 | コロケーション |
-| examples | ExampleSentence の一覧 | 1..3 | 例文 |
 | etymology | Etymology | 1 | 語源 |
 | similarities | SimilarExpression の一覧 | 1..5 | 類似表現 |
 | imageGeneration | ImageGenerationStatus | 1 | 画像生成状態 |
@@ -163,10 +180,14 @@
 不変条件:
 
 - `vocabularyExpression` は常に 1 つの `VocabularyExpression` を参照する
+- `senses` は 1 件以上 5 件以下でなければならない
+- `senses` の `identifier` と `order` は同一 `Explanation` 内で一意でなければならない
 - `frequency` と `sophistication` は `Explanation` が所有する
 - `Proficiency` を持ってはならない
 - `currentImage` は同じ `Explanation` に属する完了済み `VisualImage` だけを参照できる
+- `currentImage` が `sense` を持つ画像を指す場合、その `sense` は同じ `Explanation.senses` のいずれかでなければならない
 - `currentImage` が未設定でも、`imageGeneration` は状態を保持できる
+- explanation 全体を代表する画像を current にする場合、`VisualImage.sense` は未設定でよい
 
 ## 画像生成ライフサイクル
 
@@ -176,12 +197,14 @@
 - regenerate 開始時に `currentImage` を消してはならない
 - 新しい画像が `succeeded` になった時だけ `currentImage` を切り替える
 - `failed` 時は、直前の完了済み `currentImage` があれば継続表示してよい
+- 画像生成リクエストは explanation 全体または特定 `Sense` を対象にできるが、current 参照は常に 1 件だけである
 
 ## 表示ルール
 
 - ユーザーへ表示してよい画像は完了済みの `currentImage` のみ
 - 画像生成中または失敗中は状態だけを表示できる
 - 未完了画像、不完全 payload、中間結果は表示してはならない
+- `Explanation` が複数の `Sense` を持っていても、`currentImage` を配列化して複数同時表示してはならない
 
 ## リポジトリ
 

--- a/docs/internal/domain/service.md
+++ b/docs/internal/domain/service.md
@@ -63,7 +63,7 @@
 
 | 入力 | 出力 | 保証 |
 |---|---|---|
-| `explanation`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | 完了時のみ画像成果物を返し、retry / regenerate も同じ契約で扱う |
+| `explanation`, `sense?`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | `sense` を指定する場合は同じ `Explanation` に属する意味単位だけを受け付け、完了時のみ画像成果物を返し、retry / regenerate も同じ契約で扱う |
 
 ### AssetStoragePort
 
@@ -73,7 +73,7 @@
 
 | 入力 | 出力 | 保証 |
 |---|---|---|
-| `binaryOrAssetPayload`, `metadata` | `image`, `storageReference` | 返却された参照で再取得でき、識別子は一意である |
+| `binaryOrAssetPayload`, `metadata(explanation, sense?)` | `image`, `storageReference` | 返却された参照で再取得でき、識別子は一意であり、必要に応じて explanation 全体画像か特定 `Sense` 画像かを後続で追跡できる |
 
 ### PronunciationMediaPort
 
@@ -90,3 +90,4 @@
 - domain は vendor 名、SDK 型、transport 形式を知らない
 - auth provider の credential / session 管理は外部責務であり、この文書では扱わない
 - generator や storage の実装差し替えは port 契約を崩さずに行える必要がある
+- domain は完了済み結果だけを表示対象とし、中間画像 payload の公開可否は `status` と `Explanation.currentImage` で判断する

--- a/docs/internal/domain/visual.md
+++ b/docs/internal/domain/visual.md
@@ -3,6 +3,7 @@
 ## この文書の役割
 
 - `VisualImage` を `Explanation` から独立した画像集約として定義する
+- `VisualImage.sense` による meaning-to-image mapping を定義する
 - `previousImage` による履歴保持と `currentImage` への handoff 条件を固定する
 
 ## 関連文書
@@ -41,14 +42,18 @@
 |---|---|---:|---|
 | identifier | VisualImageIdentifier | 1 | 画像識別子 |
 | explanation | ExplanationIdentifier | 1 | 生成元解説 |
+| sense | SenseIdentifier | 0..1 | 描写する意味単位 |
 | previousImage | VisualImageIdentifier | 0..1 | 同一解説内の直前画像 |
 | storageReference | StorageReference | 1 | 永続化先参照 |
 | timeline | Timeline | 1 | 作成・更新日時 |
 
 不変条件:
 
+- `sense` を持つ場合、その `Sense` は同じ `Explanation` に属していなければならない
 - `previousImage` を持つ場合、その画像は同じ `Explanation` に属していなければならない
 - `previousImage` の循環参照を作ってはならない
+- `previousImage` と現在画像の両方が `sense` を持つ場合、両者は同じ `Sense` を指していなければならない
+- explanation 全体を代表する画像は `sense` を持たなくてよい
 - `VisualImage` 自体は current か history かを持たず、current 判定は `Explanation.currentImage` 側の責務とする
 
 ## currentImage handoff
@@ -56,6 +61,9 @@
 - 新しい `VisualImage` が `succeeded` 相当の完了状態として保存された時だけ `Explanation.currentImage` に採用できる
 - regenerate 中は、直前の完了済み `VisualImage` を `Explanation.currentImage` のまま維持する
 - 以前の画像は `previousImage` を通じて履歴として保持する
+- `Explanation.currentImage` は `Sense` の数にかかわらず 0..1 件であり、複数 current image を同時に採用してはならない
+- 特定 `Sense` の再生成では、`previousImage` は同じ `sense` を持つ履歴へ接続しなければならない
+- explanation 全体の代表画像を再生成する場合は、`sense = null` のまま履歴を接続する
 
 ## リポジトリ
 

--- a/specs/005-domain-modeling/checklists/requirements.md
+++ b/specs/005-domain-modeling/checklists/requirements.md
@@ -1,7 +1,7 @@
-# Specification Quality Checklist: ドメインモデリング
+# Specification Quality Checklist: ドメインモデリング - Sense導入差分
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning  
-**Created**: 2026-04-15  
+**Created**: 2026-04-17  
 **Feature**: [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md)
 
 ## Content Quality
@@ -31,7 +31,7 @@
 
 ## Notes
 
-- 2026-04-16 に clarification を反映し、project-wide scope、`Entry` 概念、`VisualImage` 独立集約を確定した
-- 2026-04-16 に `Domain Models Affected` を更新し、`learner.md`、`vocabulary-expression.md`、`learning-state.md` を対象文書へ追加して `plan.md` / `tasks.md` と整合させた
-- planning に進める状態である
+- 2026-04-17 に `005-domain-modeling` を `Sense` 導入差分へ更新し、`plan.md` / `tasks.md` と scope を整合させた
+- `Sense` は `Explanation` 所有の意味単位、`VisualImage` は独立集約維持、`currentImage` は単一参照維持を前提にした
+- 複数 current image の同時公開は後続 feature scope として明記した
 - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/005-domain-modeling/contracts/async-visibility-contract.md
+++ b/specs/005-domain-modeling/contracts/async-visibility-contract.md
@@ -18,6 +18,13 @@
 | `succeeded` | 生成完了 | `currentImage` を表示してよい |
 | `failed` | 生成失敗 | `currentImage` があれば直前の完了済み画像を維持してよく、未存在なら画像は表示しない |
 
+## Sense-aware Visibility Rules
+
+- `Explanation` が複数の `Sense` を持っていても、この phase でユーザーへ見せてよい current image は単一の `currentImage` のみ
+- `currentImage` が `sense` を持つ場合、その画像がどの意味を補助するかは説明できなければならない
+- 画像生成中または失敗中でも、未完了の sense-specific image は表示してはならない
+- `Sense` の導入は current image の単一参照ルールを破ってはならない
+
 ## Retry and Regeneration Rules
 
 - `failed -> pending` は explanation / image の retry として許可する
@@ -32,4 +39,4 @@
 
 - ユーザーへ見せてよい生成物は、常に完了済みの `currentExplanation` / `currentImage` のみ
 - 生成中または失敗中は状態表示のみ可能であり、新規の未完了生成物は見せない
-- 冪等 retry により同じ依頼が再送されても、ユーザーへ不完全結果を見せない
+- `Sense` が増えても、冪等 retry により不完全結果を見せない保証は維持される

--- a/specs/005-domain-modeling/contracts/concept-separation-contract.md
+++ b/specs/005-domain-modeling/contracts/concept-separation-contract.md
@@ -4,10 +4,11 @@
 
 | Concept | Meaning | Must Not Be Mixed With |
 |--------|---------|------------------------|
-| `Frequency` | 英語表現がどの程度よく使われるか | `Proficiency`, `Sophistication`, generation status |
-| `Sophistication` | 英語表現の知的・語彙的な難度 | `Frequency`, `Proficiency`, registration status |
-| `Proficiency` | 学習者がどれだけ定着したか | `Frequency`, `Sophistication`, generation status |
-| `RegistrationStatus` | 学習者がその表現を追跡中かどうか | explanation / image generation status |
+| `Sense` | `Explanation` 内の意味単位 | `VocabularyExpression`, `LearningState`, generation status |
+| `Frequency` | 英語表現がどの程度よく使われるか | `Proficiency`, `Sophistication`, `Sense`, generation status |
+| `Sophistication` | 英語表現の知的・語彙的な難度 | `Frequency`, `Proficiency`, `Sense`, registration status |
+| `Proficiency` | 学習者がどれだけ定着したか | `Frequency`, `Sophistication`, `Sense`, generation status |
+| `RegistrationStatus` | 学習者がその表現を追跡中かどうか | explanation / image generation status, `Sense` |
 | `ExplanationGenerationStatus` | 解説生成の進行状態 | image generation status, registration status |
 | `ImageGenerationStatus` | 画像生成の進行状態 | explanation generation status, proficiency |
 
@@ -15,6 +16,7 @@
 
 | Concept | Owner |
 |--------|-------|
+| `Sense` | `Explanation` |
 | `Frequency` | `Explanation` |
 | `Sophistication` | `Explanation` |
 | `Proficiency` | `LearningState` |
@@ -24,8 +26,8 @@
 
 ## Guarantees
 
-- 語彙自体の属性と学習進捗を同一フィールド群へ統合しない
-- `Explanation` は `Proficiency` を持たない
-- `LearningState` は `Frequency` と `Sophistication` を持たない
-- `VocabularyExpression` は `ImageGenerationStatus` を持たず、画像生成の current / history は `Explanation` と `VisualImage` の責務で扱う
+- 語彙自体の属性、意味単位、学習進捗を同一フィールド群へ統合しない
+- `Explanation` は `Sense` を持つが、`Proficiency` は持たない
+- `LearningState` は `Frequency`、`Sophistication`、`Sense` を持たない
+- `VocabularyExpression` は `Sense` を直接持たず、意味の構造化は `Explanation` の責務で扱う
 - `ExplanationGenerationStatus` と `ImageGenerationStatus` は同じ語彙を使っても別状態として扱う

--- a/specs/005-domain-modeling/contracts/domain-port-catalog.md
+++ b/specs/005-domain-modeling/contracts/domain-port-catalog.md
@@ -34,11 +34,11 @@
 
 ## ImageGenerationPort
 
-**Purpose**: 完了済み `Explanation` に基づく画像生成を依頼し、画像生成状態を返す。
+**Purpose**: 完了済み `Explanation` と必要に応じて対象 `Sense` に基づく画像生成を依頼し、画像生成状態を返す。
 
 | Input | Output | Guarantees |
 |-------|--------|------------|
-| `explanation`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | 完了時のみ画像成果物を返し、再生成も同じ契約で扱う |
+| `explanation`, `sense?`, `imagePromptContext` | `requestIdentifier`, `status`, `imagePayload?`, `failureReason?` | 完了時のみ画像成果物を返し、意味単位を指定する場合は同一 `Explanation` 配下の `Sense` だけを受理し、再生成も同じ契約で扱う |
 
 ## AssetStoragePort
 

--- a/specs/005-domain-modeling/contracts/sense-image-mapping-contract.md
+++ b/specs/005-domain-modeling/contracts/sense-image-mapping-contract.md
@@ -1,0 +1,34 @@
+# Contract: Sense Image Mapping
+
+## Sense Ownership
+
+| Concept | Rule |
+|--------|------|
+| `Sense` | `Explanation` が所有する内部エンティティである |
+| `VisualImage.sense` | 指定する場合は、同じ `Explanation` に属する `Sense` だけを参照できる |
+| `Explanation.currentImage` | 常に完了済み `VisualImage` を 0..1 件だけ参照する |
+
+## Meaning-to-Image Mapping
+
+| Case | Allowed | Notes |
+|------|---------|-------|
+| `VisualImage.sense = null` | Yes | explanation 全体を代表する画像として扱える |
+| `VisualImage.sense = SenseIdentifier` | Yes | 特定の意味単位を描写する画像として扱える |
+| `VisualImage.sense` が他 explanation の `Sense` を指す | No | ownership boundary を壊すため禁止 |
+| 1 explanation に意味対応なしの裸画像を複数 current として並べる | No | この phase の scope 外 |
+
+## Example and Collocation Ownership
+
+| Artifact | Owner |
+|---------|-------|
+| `ExampleSentence` | `Sense` |
+| `Collocation` | `Sense` |
+| `Pronunciation` | `Explanation` |
+| `Frequency` | `Explanation` |
+| `Sophistication` | `Explanation` |
+
+## Guarantees
+
+- 画像枚数より先に意味単位と画像単位の対応関係を明示する
+- `Sense` を導入しても `Explanation.currentImage` の単一 current 参照は維持する
+- 多義語の画像化は、少なくとも domain 上では「どの意味の画像か」を説明できる

--- a/specs/005-domain-modeling/contracts/vocabulary-expression-identity-contract.md
+++ b/specs/005-domain-modeling/contracts/vocabulary-expression-identity-contract.md
@@ -6,8 +6,9 @@
 |--------|------|------------|-------|
 | `Learner` | 学習者 identity 境界、所有関係 | `VocabularyExpression`, `LearningState` | 認証そのものは持たず、外部 identity を参照する |
 | `VocabularyExpression` | 登録対象の識別、登録状態、解説生成状態 | `Learner`, `currentExplanation` | 単語と連語を同一概念で扱う学習者所有集約 |
-| `Explanation` | 解説本文、頻出度、知的度、画像 generation 状態 | `VocabularyExpression`, `currentImage` | current な表示結果を指す知識集約 |
-| `VisualImage` | 画像アセット参照、履歴 | `Explanation`, `previousImage` | `Explanation` から独立した集約 |
+| `Explanation` | 解説本文、意味単位、頻出度、知的度、画像 generation 状態 | `VocabularyExpression`, `currentImage` | current な表示結果を指す知識集約 |
+| `Sense` | 意味単位、意味別の例文とコロケーション | `Explanation` | `Explanation` が所有する内部エンティティ |
+| `VisualImage` | 画像アセット参照、履歴 | `Explanation`, `sense`, `previousImage` | `Explanation` から独立した集約 |
 | `LearningState` | 習熟度 | `Learner`, `VocabularyExpression` | 学習進捗だけを扱う |
 
 ## Identifier Rules
@@ -17,7 +18,8 @@
 | `Learner` | `LearnerIdentifier` | `identifier` | none |
 | `VocabularyExpression` | `VocabularyExpressionIdentifier` | `identifier` | `learner`, `currentExplanation` |
 | `Explanation` | `ExplanationIdentifier` | `identifier` | `vocabularyExpression`, `currentImage` |
-| `VisualImage` | `VisualImageIdentifier` | `identifier` | `explanation`, `previousImage` |
+| `Sense` | `SenseIdentifier` | `identifier` | none |
+| `VisualImage` | `VisualImageIdentifier` | `identifier` | `explanation`, `sense`, `previousImage` |
 | `LearningState` | `LearningStateIdentifier` | `identifier` | `learner`, `vocabularyExpression` |
 
 ## VocabularyExpression Kind
@@ -32,12 +34,14 @@
 | Scope | Uniqueness Rule | Notes |
 |------|------------------|-------|
 | Same `Learner` | `normalizedVocabularyExpressionText` は一意 | 重複登録は拒否または更新判断の対象になる |
+| Same `Explanation` | `Sense.identifier` と `Sense.order` は一意 | 意味単位は explanation 内だけで識別する |
 | Different `Learner` | 同じ表現でも共存可能 | 学習者間で `VocabularyExpression` を共有しない |
 
 ## Guarantees
 
 - `VocabularyExpression` は単語と連語を統一した学習者所有の登録対象概念である
 - 同じ英語表現の重複判定は同一学習者内でのみ行う
+- `Sense` は `VocabularyExpression` や `LearningState` の代替概念ではなく、`Explanation` の意味単位である
 - `ExplanationIdentifier` や `VisualImageIdentifier` を登録対象の識別子として使わない
 - `VisualImage` は `Explanation` の内部値ではなく独立集約として扱う
 - `LearningState` は `Frequency` や `Sophistication` を持たず、習熟度のみを扱う

--- a/specs/005-domain-modeling/data-model.md
+++ b/specs/005-domain-modeling/data-model.md
@@ -28,19 +28,33 @@ classDiagram
         <<Aggregate>>
         +ExplanationIdentifier identifier
         +VocabularyExpressionIdentifier vocabularyExpression
-        +Meaning meaning
+        +Sense[] senses
         +Pronunciation pronunciation
         +Frequency frequency
         +Sophistication sophistication
+        +Etymology etymology
+        +SimilarExpression[] similarities
         +ImageGenerationStatus imageGeneration
         +VisualImageIdentifier currentImage
         +Timeline timeline
+    }
+
+    class Sense {
+        <<Entity>>
+        +SenseIdentifier identifier
+        +string label
+        +string situation
+        +string nuance
+        +int order
+        +Collocation[] collocations
+        +ExampleSentence[] examples
     }
 
     class VisualImage {
         <<Aggregate>>
         +VisualImageIdentifier identifier
         +ExplanationIdentifier explanation
+        +SenseIdentifier sense
         +VisualImageIdentifier previousImage
         +StorageReference storageReference
         +Timeline timeline
@@ -95,8 +109,10 @@ classDiagram
     Learner "1" --> "0..*" LearningState : tracks
     VocabularyExpression "1" --> "0..*" Explanation : has history
     VocabularyExpression --> "0..1" Explanation : currentExplanation
+    Explanation "1" --> "1..5" Sense : contains
     Explanation "1" --> "0..*" VisualImage : has history
     Explanation --> "0..1" VisualImage : currentImage
+    VisualImage --> "0..1" Sense : depicts
     VisualImage --> "0..1" VisualImage : previousImage
     LearningState --> "1" VocabularyExpression : vocabularyExpression
     VocabularyExpression --> VocabularyExpressionKind : kind
@@ -106,10 +122,10 @@ classDiagram
     LearningState --> Proficiency : proficiency
 ```
 
-- `VocabularyExpression` は学習者が所有する登録対象で、表示上は `currentExplanation` だけを参照する
-- `Explanation` は解説本文の集約で、表示上は `currentImage` だけを参照する
-- `VisualImage.previousImage` によって、同一解説内の画像履歴を辿る
-- `LearningState` は `Learner` と `VocabularyExpression` の関係上にある習熟度専用の集約
+- `Sense` は `Explanation` が所有する意味単位の内部エンティティである
+- `VisualImage` は `Explanation` と `sense?` の両方を参照できる独立集約である
+- `Explanation.currentImage` はこの phase では単一の current 参照を維持する
+- `Learner`、`VocabularyExpression`、`LearningState` の ownership boundary は変えない
 
 ## Aggregate: Learner
 
@@ -158,18 +174,16 @@ classDiagram
 
 ## Aggregate: Explanation
 
-**Purpose**: `VocabularyExpression` に紐づく生成済み解説を表す知識集約。現在表示中画像の参照を持つ。
+**Purpose**: `VocabularyExpression` に紐づく生成済み解説を表す知識集約。意味単位として `Sense` を持ち、現在表示中画像の参照を持つ。
 
 | Field | Type | Cardinality | Description |
 |-------|------|-------------|-------------|
 | identifier | ExplanationIdentifier | 1 | 解説識別子 |
 | vocabularyExpression | VocabularyExpressionIdentifier | 1 | 元の登録対象 |
-| meaning | Meaning | 1 | 意味のまとまり |
+| senses | Sense[] | 1..5 | 意味単位の一覧 |
 | pronunciation | Pronunciation | 1 | 発音と発音記号 |
 | frequency | Frequency | 1 | 頻出度と理由 |
 | sophistication | Sophistication | 1 | 知的度と理由 |
-| collocations | Collocation[] | 1..10 | コロケーション |
-| examples | ExampleSentence[] | 1..3 | 例文 |
 | etymology | Etymology | 1 | 語源 |
 | similarities | SimilarExpression[] | 1..5 | 類似表現 |
 | imageGeneration | ImageGenerationStatus | 1 | 画像生成状態 |
@@ -179,12 +193,13 @@ classDiagram
 **Validation rules**:
 
 - `vocabularyExpression` は常に 1 つの `VocabularyExpressionIdentifier` を参照する
-- `meaning.values` は 1 件以上
-- `collocations` は 1 件以上 10 件以下
-- `examples` は 1 件以上 3 件以下
-- `similarities` は 1 件以上 5 件以下
+- `senses` は 1 件以上 5 件以下
+- `senses.order` は同一 `Explanation` 内で重複してはならない
+- `senses.identifier` は同一 `Explanation` 内で一意でなければならない
 - `currentImage` は同じ `Explanation` に属する完了済み `VisualImage` だけを参照できる
+- `currentImage` が `sense` を持つ画像を指す場合、その `sense` は同じ `Explanation.senses` のいずれかでなければならない
 - 画像再生成中または再生成失敗時でも、直前の完了済み画像がある場合は `currentImage` を保持してよい
+- `frequency` と `sophistication` は `Explanation` が所有し、`Sense` や `LearningState` へ移してはならない
 
 **State transitions**:
 
@@ -192,14 +207,39 @@ classDiagram
 - `imageGeneration`: `failed -> pending` を retry として許可
 - `imageGeneration`: `succeeded -> running` を regenerate として許可
 
+## Entity: Sense
+
+**Purpose**: `Explanation` が所有する意味単位。意味ごとの説明、状況、ニュアンス、例文、コロケーションをまとめる。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| identifier | SenseIdentifier | 1 | 同一 `Explanation` 内での意味識別子 |
+| label | string | 1 | 意味を短く表す代表ラベル |
+| situation | string | 1 | 使われる状況 |
+| nuance | string | 1 | ニュアンス |
+| order | positive integer | 1 | 表示順序 |
+| collocations | Collocation[] | 0..5 | その意味に結びつくコロケーション |
+| examples | ExampleSentence[] | 0..3 | その意味に結びつく例文 |
+
+**Validation rules**:
+
+- `label` は 1 文字以上 255 文字以下
+- `situation` は 1 文字以上 255 文字以下
+- `nuance` は 1 文字以上 255 文字以下
+- `order` は 1 以上の整数
+- `collocations` は 5 件以下
+- `examples` は 3 件以下
+- `examples` と `collocations` は `Explanation` 全体ではなく、その `Sense` の意味に対応していなければならない
+
 ## Aggregate: VisualImage
 
-**Purpose**: `Explanation` に基づく視覚的表現を表す画像集約。独立した保存先参照と履歴を持つ。
+**Purpose**: `Explanation` に基づく視覚的表現を表す画像集約。独立した保存先参照と履歴を持ち、必要に応じて特定の `Sense` を描写する。
 
 | Field | Type | Cardinality | Description |
 |-------|------|-------------|-------------|
 | identifier | VisualImageIdentifier | 1 | 画像識別子 |
 | explanation | ExplanationIdentifier | 1 | 生成元解説 |
+| sense | SenseIdentifier | 0..1 | 画像が描写する意味単位 |
 | previousImage | VisualImageIdentifier | 0..1 | 同一解説内の直前画像履歴 |
 | storageReference | StorageReference | 1 | 永続化先の再取得参照 |
 | timeline | Timeline | 1 | 作成・更新日時 |
@@ -209,7 +249,9 @@ classDiagram
 - `storageReference` は安定した取得参照でなければならない
 - 同一 `identifier` は 1 つの保存先だけを指す
 - `previousImage` を持つ場合、その `VisualImage` は同じ `Explanation` に属していなければならない
+- `sense` を持つ場合、その `Sense` は同じ `Explanation` に属していなければならない
 - `previousImage` の循環参照を作ってはならない
+- `previousImage` が `sense` を持つ画像で、現在画像も `sense` を持つ場合、両者は同じ `Sense` を指していなければならない
 
 ## Aggregate: LearningState
 
@@ -258,119 +300,10 @@ classDiagram
 ### Existing value objects retained
 
 - `AuthenticationSubject`
-- `VocabularyExpressionText`
-- `NormalizedVocabularyExpressionText`
-- `Frequency`
-- `FrequencyLevel`
-- `Sophistication`
-- `SophisticationLevel`
-- `Meaning`
-- `PhoneticSymbols`
 - `Pronunciation`
+- `Frequency`
+- `Sophistication`
 - `Collocation`
 - `ExampleSentence`
 - `SimilarExpression`
 - `Etymology`
-- `Proficiency`
-- `Timeline`
-- `StorageReference`
-
-## Relationships
-
-- `Learner` 1 : n `VocabularyExpression`
-- `Learner` 1 : n `LearningState`
-- `VocabularyExpression` 1 : n `Explanation`, ただし `currentExplanation` は 0..1
-- `Explanation` 1 : n `VisualImage`, ただし `currentImage` は 0..1
-- `LearningState` は `Learner` と `VocabularyExpression` の関係上でのみ存在できる
-- `VisualImage.previousImage` は同一 `Explanation` の履歴を辿る
-
-## Domain Events
-
-### VocabularyExpressionRegistered
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 所有学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 登録された表現 |
-| occurredAt | DateTime | 発生日時 |
-
-### ExplanationGenerated
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 所有学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 対象登録表現 |
-| explanation | ExplanationIdentifier | 完了した解説 |
-| occurredAt | DateTime | 発生日時 |
-
-### ExplanationGenerationFailed
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 所有学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 対象登録表現 |
-| reason | FailureReason | 失敗理由 |
-| occurredAt | DateTime | 発生日時 |
-
-### ExplanationRegenerated
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 所有学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 対象登録表現 |
-| beforeExplanation | ExplanationIdentifier | 以前の解説 |
-| afterExplanation | ExplanationIdentifier | 新しい解説 |
-| occurredAt | DateTime | 発生日時 |
-
-### ImageGenerated
-
-| Field | Type | Description |
-|-------|------|-------------|
-| explanation | ExplanationIdentifier | 対象解説 |
-| image | VisualImageIdentifier | 完了した画像 |
-| occurredAt | DateTime | 発生日時 |
-
-### ImageRegenerated
-
-| Field | Type | Description |
-|-------|------|-------------|
-| explanation | ExplanationIdentifier | 対象解説 |
-| beforeImage | VisualImageIdentifier | 以前の画像 |
-| afterImage | VisualImageIdentifier | 新しい画像 |
-| occurredAt | DateTime | 発生日時 |
-
-### ProficiencyChanged
-
-| Field | Type | Description |
-|-------|------|-------------|
-| learner | LearnerIdentifier | 対象学習者 |
-| vocabularyExpression | VocabularyExpressionIdentifier | 対象登録表現 |
-| before | Proficiency | 変更前の習熟度 |
-| after | Proficiency | 変更後の習熟度 |
-| occurredAt | DateTime | 発生日時 |
-
-## Repository Contracts
-
-- `LearnerRepository`
-  - `find(identifier)`
-  - `findByAuthenticationSubject(authenticationSubject)`
-  - `persist(learner)`
-- `VocabularyExpressionRepository`
-  - `find(identifier)`
-  - `findByLearnerAndNormalizedText(learner, normalizedText)`
-  - `listByLearner(learner)`
-  - `persist(vocabularyExpression)`
-  - `archive(identifier)`
-- `ExplanationRepository`
-  - `find(identifier)`
-  - `findCurrentByVocabularyExpression(vocabularyExpression)`
-  - `listByVocabularyExpression(vocabularyExpression)`
-  - `persist(explanation)`
-- `VisualImageRepository`
-  - `find(identifier)`
-  - `findCurrentByExplanation(explanation)`
-  - `listByExplanation(explanation)`
-  - `persist(image)`
-- `LearningStateRepository`
-  - `findByLearnerAndVocabularyExpression(learner, vocabularyExpression)`
-  - `persist(state)`

--- a/specs/005-domain-modeling/plan.md
+++ b/specs/005-domain-modeling/plan.md
@@ -1,47 +1,48 @@
 # Implementation Plan: ドメインモデリング
 
-**Branch**: `005-domain-modeling` | **Date**: 2026-04-16 | **Spec**: [/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md)
+**Branch**: `009-sense-modeling` | **Date**: 2026-04-17 | **Spec**: [/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md)
 **Input**: Feature specification from `/specs/005-domain-modeling/spec.md`
 
 **Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
-vocastock プロジェクト全体のドメインを、`Learner` を所有境界、`VocabularyExpression` を
-学習者が所有する登録対象として再整理する。単語と連語は同一の `VocabularyExpression`
-概念で扱い、`Explanation` は現在表示中の解説参照、`VisualImage` は履歴を保持する独立集約、
-`LearningState` は習熟度専用集約として設計する。あわせて、`VocabularyExpression*` /
-`LearningState*` 命名、完了済み結果のみ表示する非同期規則、外部 identity を含む port 境界を
-project-wide の source of truth に落とし込める設計成果物を生成する。
+vocastock project-wide domain language を維持したまま、`Explanation` に `Sense` を導入する。
+`Sense` は多義語の意味単位を表す `Explanation` 所有の内部エンティティとし、意味、状況、
+ニュアンス、例文、コロケーションを意味単位で保持できるようにする。`VisualImage` は
+独立集約のまま維持しつつ、必要に応じてどの `Sense` を描写する画像かを示せるようにする。
+一方で、非同期表示ルールと `currentImage` の単一 current 参照は維持し、意味と画像の対応を
+明確にしながら中間生成物を見せない設計成果物を生成する。
 
 ## Technical Context
 
 **Language/Version**: Markdown 1.x, YAML/JSON reference documents  
 **Primary Dependencies**: 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`  
 **Storage**: Git-managed repository files、設計上で参照する抽象的な learner store、explanation store、image asset store  
-**Testing**: spec / constitution / ADR / domain docs の手動クロスレビュー、所有境界レビュー、一意性レビュー、状態遷移レビュー、識別子命名レビュー  
+**Testing**: spec / constitution / ADR / domain docs の手動クロスレビュー、sense ownership review、image mapping review、非同期表示レビュー、識別子命名レビュー  
 **Target Platform**: Flutter client、Rust command/query runtime、Haskell workflow runtime をまたぐ project-wide domain language  
 **Project Type**: documentation / domain design  
-**Performance Goals**: レビュー担当者が 5 分以内に主要概念、所有境界、不変条件を説明できること、非同期状態とユーザー表示ルールを 5 分以内に判定できること、source-of-truth 文書の参照先を 3 分以内に辿れること  
-**Constraints**: product code は追加しない、完了済み結果のみをユーザーへ表示する、頻出度・知的度・習熟度・登録状態・解説生成状態・画像生成状態を統合しない、`Learner` は独立集約、`VocabularyExpression` は学習者所有、重複判定は同一学習者内で行う、`VisualImage` は独立集約として履歴を保持する、認証そのものは外部責務として扱う、外部依存はポート越しに接続する、派生命名は `VocabularyExpression*` / `LearningState*` に統一する、識別子命名は憲章に従う  
-**Scale/Scope**: 5 つの中心集約、6 つの状態/指標概念、4 つの契約文書、`docs/internal/domain/` の新規追加 3 件と更新 4 件を想定する
+**Performance Goals**: レビュー担当者が 5 分以内に `Sense` と `Explanation` / `VisualImage` の責務差分を説明できること、画像と意味の対応ルールを 5 分以内に判定できること、source-of-truth 文書の参照先を 3 分以内に辿れること  
+**Constraints**: product code は追加しない、完了済み結果のみをユーザーへ表示する、頻出度・知的度・習熟度・登録状態・解説生成状態・画像生成状態を統合しない、`Sense` は `Explanation` 所有の内部エンティティとして扱う、`VisualImage` は独立集約として履歴を保持する、`Explanation.currentImage` はこの feature では単一 current 参照のまま維持する、画像を複数枚扱う場合も意味との対応なしに `Explanation` 直下へ裸の配列を足さない、外部依存はポート越しに接続する、派生命名は `VocabularyExpression*` / `LearningState*` に統一する、識別子命名は憲章に従う  
+**Scale/Scope**: 5 つの中心集約、1 つの内部エンティティ、6 つの状態/指標概念、5 つの契約文書、`docs/internal/domain/` の更新 3 件以上と `docs/external/*.md` の整合更新を想定する
 
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-- [x] Domain impact is identified. `docs/internal/domain/common.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/service.md`、`docs/internal/domain/visual.md` を更新対象とし、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md` を新規 source-of-truth 候補として扱う。
-- [x] Async generation flows define `pending`、`running`、`succeeded`、`failed`、再試行、再生成、表示可否を分けて扱い、不完全な生成物をユーザーへ見せない。再生成中も直前の完了済み `currentExplanation` / `currentImage` は保持し、新しい成功時だけ参照を切り替える。
-- [x] 単語検証、重複登録判定、学習者 identity 解決、解説生成、画像生成、アセット保存、発音参照はすべて external port として扱い、ドメインモデルへベンダー固有実装を持ち込まない。
-- [x] User stories are independently reviewable. project-wide scope、非同期表示、文書横断整合は research / data-model / contracts で別々に検証できる。
-- [x] 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態は別概念として維持し、どれも代替概念として扱わない。
-- [x] Identifier naming follows the constitution: `LearnerIdentifier`、`VocabularyExpressionIdentifier`、`ExplanationIdentifier`、`VisualImageIdentifier`、`LearningStateIdentifier` を使い、self identifier は `identifier`、関連参照は `learner`、`vocabularyExpression`、`currentImage` のような概念名で持つ。
+- [x] Domain impact is identified. `docs/internal/domain/common.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md` を主要更新対象とし、必要に応じて `docs/external/requirements.md` と `docs/external/adr.md` の用語整合も更新対象とする。
+- [x] Async generation flows define `pending`、`running`、`succeeded`、`failed`、再試行、再生成、表示可否を分けて扱い、不完全な生成物をユーザーへ見せない。`Sense` を導入しても `currentImage` は新しい成功時だけ切り替え、再生成中は直前の完了済み画像を維持する。
+- [x] 画像生成、解説生成、アセット保存、発音参照、単語検証はすべて external port として扱い、`Sense` 導入によってもベンダー固有実装をドメインモデルへ持ち込まない。
+- [x] User stories are independently reviewable. concept boundary、sense-image mapping、文書横断整合は research / data-model / contracts で別々に検証できる。
+- [x] 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態は別概念として維持し、`Sense` は意味単位として追加されるが評価指標へ吸収しない。
+- [x] Identifier naming follows the constitution: `SenseIdentifier` を含むすべての識別子型は `XxxIdentifier` を使い、self identifier は `identifier`、関連参照は `vocabularyExpression`、`currentImage`、`sense` のような概念名で持つ。
 
 Post-design re-check: PASS. Verified against `research.md`, `data-model.md`,
 `contracts/vocabulary-expression-identity-contract.md`,
 `contracts/concept-separation-contract.md`,
 `contracts/async-visibility-contract.md`,
-and `contracts/domain-port-catalog.md`.
+`contracts/domain-port-catalog.md`,
+and `contracts/sense-image-mapping-contract.md`.
 
 ## Project Structure
 
@@ -57,6 +58,7 @@ specs/005-domain-modeling/
 │   ├── async-visibility-contract.md
 │   ├── concept-separation-contract.md
 │   ├── domain-port-catalog.md
+│   ├── sense-image-mapping-contract.md
 │   └── vocabulary-expression-identity-contract.md
 └── tasks.md
 ```
@@ -72,11 +74,11 @@ docs/
     └── domain/
         ├── common.md
         ├── explanation.md
-        ├── learner.md                 # planned source-of-truth
-        ├── learning-state.md          # planned source-of-truth
+        ├── learner.md
+        ├── learning-state.md
         ├── service.md
         ├── visual.md
-        └── vocabulary-expression.md   # planned source-of-truth
+        └── vocabulary-expression.md
 
 specs/
 ├── 001-complete-domain-model/
@@ -86,11 +88,11 @@ specs/
 ```
 
 **Structure Decision**: 実装時の正本は `docs/internal/domain/*.md` と
-`docs/external/requirements.md` / `docs/external/adr.md` に置く。`specs/005-domain-modeling/`
-は、project-wide なドメイン再整理の根拠、所有境界、状態契約、ポート契約、review 導線を
-保持する設計パッケージとして扱う。`Learner`、`VocabularyExpression`、`LearningState`
-を独立した source-of-truth に切り出し、現行の `Explanation` / `VisualImage` 中心の記述を
-学習者所有の登録対象中心へ移行する。
+`docs/external/requirements.md` / `docs/external/adr.md` に置く。`Sense` は
+`Explanation` 配下の内部エンティティとして扱い、意味単位の説明責務を `Explanation`
+本体から切り出す。一方で `VisualImage` は独立集約のまま維持し、必要に応じて
+どの `Sense` を描写する画像かを示す。`Explanation.currentImage` は単一 current 参照のまま
+維持し、複数 current image の導入は follow-on scope とする。
 
 ## Complexity Tracking
 

--- a/specs/005-domain-modeling/quickstart.md
+++ b/specs/005-domain-modeling/quickstart.md
@@ -2,30 +2,29 @@
 
 ## 1. planning artifact を確認する
 
-- [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md) で対象範囲、`Learner`、学習者所有の `VocabularyExpression`、`VisualImage` 独立集約を確認する
-- [research.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/research.md) で所有境界、一意性境界、current 参照、命名統一の判断を確認する
-- [data-model.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/data-model.md) で aggregate、value object、状態遷移、履歴保持を確認する
-- `contracts/` で識別子、概念分離、非同期表示、外部ポートの契約を確認する
+- [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md) で 005 の project-wide domain 境界を確認する
+- [plan.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/plan.md) で `Sense` を `Explanation` 内部エンティティとして導入する設計判断を確認する
+- [research.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/research.md) で meaning-image mapping、単一 current image 維持、説明責務再編の判断を確認する
+- [data-model.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/data-model.md) で aggregate、entity、value object、状態遷移、履歴保持を確認する
+- `contracts/` で識別子、概念分離、非同期表示、外部ポート、sense-image mapping の契約を確認する
 
 ## 2. repository-level source of truth を更新する
 
-- `docs/internal/domain/learner.md` を新規追加し、`Learner` の source-of-truth にする
-- `docs/internal/domain/vocabulary-expression.md` を新規追加し、学習者所有の `VocabularyExpression` と学習者内一意性の正本にする
-- `docs/internal/domain/learning-state.md` を新規追加し、`LearningState` と `Proficiency` 分離の正本にする
-- `docs/internal/domain/explanation.md` で `VocabularyExpression.currentExplanation` と `Explanation.currentImage` の責務を明確化する
-- `docs/internal/domain/visual.md` で `VisualImage` の履歴保持と `previousImage` 規則を明確化する
-- `docs/internal/domain/service.md` を learner identity を含む external port catalog に整合させる
-- `docs/external/requirements.md` と `docs/external/adr.md` の語彙差分を埋める
+- `docs/internal/domain/common.md` に `Sense` を project-wide 用語として追加し、`Meaning` からの移行メモを明記する
+- `docs/internal/domain/explanation.md` で `Explanation.senses`、`Sense`、例文とコロケーションの ownership を正本化する
+- `docs/internal/domain/visual.md` で `VisualImage.sense` と `previousImage` の整合条件を正本化する
+- `docs/external/requirements.md` と `docs/external/adr.md` に、多義語の意味単位と画像対応の前提を同期する
 
 ## 3. cross-review を行う
 
-- `Learner` が所有境界、`VocabularyExpression` が登録対象、`LearningState` が学習進捗として分離されているか確認する
-- `normalizedText` の一意性が同一学習者内に閉じているか確認する
-- `Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態が混同されていないか確認する
+- `Sense` が `Explanation` 所有の内部エンティティとして定義されているか確認する
+- `Learner`、`VocabularyExpression`、`LearningState` の ownership boundary が `Sense` 導入で変わっていないか確認する
+- `Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態が `Sense` と混同されていないか確認する
+- 例文とコロケーションが explanation 全体ではなく対応する `Sense` に結びついているか確認する
+- `VisualImage.sense` が同一 `Explanation` 配下の意味だけを指せるか確認する
 - explanation / image の regenerate 中も、直前の完了済み `currentExplanation` / `currentImage` だけが表示可能になっているか確認する
-- 外部責務が `LearnerIdentityPort`、`WordValidationPort`、`RegistrationLookupPort`、`ExplanationGenerationPort`、`ImageGenerationPort`、`AssetStoragePort`、`PronunciationMediaPort` に整理されているか確認する
 
 ## 4. 次フェーズへ渡す
 
-- `/speckit.tasks` では source-of-truth の新規追加、既存文書の再編、用語整合、契約整合を task 化する
+- `/speckit.tasks` では `Sense` 用語導入、`Explanation` / `VisualImage` 再編、外部文書整合、契約整合を task 化する
 - `/speckit.implement` では docs-first で `docs/internal/domain/*.md` と `docs/external/*.md` を同一変更セットで更新する

--- a/specs/005-domain-modeling/research.md
+++ b/specs/005-domain-modeling/research.md
@@ -1,107 +1,85 @@
 # Research: ドメインモデリング
 
-## Decision: `Learner` を所有境界とし、`VocabularyExpression` は学習者が所有する登録対象として扱う
+## Decision: `Sense` を `Explanation` 所有の内部エンティティとして導入する
 
-**Rationale**: 習熟度が学習者ごとに変わる以上、語彙登録の境界も学習者側に寄せる方が自然である。
-`VocabularyExpression` を共有語彙にすると、重複登録判定、登録状態、生成状態、学習進捗の責務が
-再び混ざる。`Learner` を独立集約とし、その配下に `VocabularyExpression` を置くことで、
-語彙自体の概念と学習者の所有責務を同時に明確化できる。
-
-**Alternatives considered**:
-
-- `VocabularyExpression` を project-wide 共有語彙として扱う
-- `Learner` を domain に持たず、外部 identity のみを参照する
-
-## Decision: 英単語と連語は同一の `VocabularyExpression` 概念で扱う
-
-**Rationale**: 登録、検証、解説生成、画像生成、学習進捗は単語と連語で大きく変わらない。
-別概念に分けると、一意性判定、状態遷移、ポート契約、文書更新が二重化する。
-`VocabularyExpression` に `VocabularyExpressionKind` を持たせる方が、学習者所有の登録対象として
-一貫したルールを保ちやすい。
+**Rationale**: 多義語の「意味の数」と「画像の数」を直接結びつける前に、意味単位そのものを
+明示する必要がある。`Sense` を `Explanation` 配下に置くと、語彙登録対象や学習状態の境界は
+変えずに、意味、状況、ニュアンス、例文、コロケーションを意味単位で整理できる。
+`Sense` を独立集約にすると、`Explanation` から切り離された更新順序や参照整合が必要になり、
+現時点の domain complexity に対して過剰である。
 
 **Alternatives considered**:
 
-- 単一英単語だけを対象にする
-- 単語と連語を別々の集約として扱う
+- `Meaning.values` のまま文字列一覧だけを維持する
+- `Sense` を `Explanation` から独立した集約にする
 
-## Decision: `VocabularyExpression` の重複登録判定は同一学習者内の `NormalizedVocabularyExpressionText` で行う
+## Decision: `Explanation.meaning` を coarse-grained な意味の塊ではなく、`Explanation.senses` へ置き換える
 
-**Rationale**: 学習者所有モデルでは、同じ英語表現でも別学習者なら独立して存在できる。
-一方で同一学習者内の重複は登録状態や生成状態を分岐させるため避けたい。
-`NormalizedVocabularyExpressionText` を一意キーに使うと、表記揺れを吸収しつつ学習者境界の
-内側だけで重複を制御できる。
-
-**Alternatives considered**:
-
-- システム全体で英語表現を一意にする
-- 同一学習者内でも重複登録を許可する
-
-## Decision: `Proficiency` は `LearningState` に分離し、`Learner` と `VocabularyExpression` の関係上で扱う
-
-**Rationale**: 頻出度と知的度は語彙や解説の属性であり、習熟度は学習者の状態である。
-`Proficiency` を `VocabularyExpression` や `Explanation` に置くと、客観属性と主観進捗が混ざる。
-`LearningState` を独立集約にすると、学習者所有の語彙であっても評価軸を分離できる。
+**Rationale**: 既存の `Meaning.values + situation + nuance` では、複数意味がある場合でも
+状況やニュアンスが explanation 全体で 1 つに潰れてしまう。`Sense` に `label`、
+`situation`、`nuance` を持たせると、意味ごとの差分を domain 上で保てる。
+多義語に対して「どの例文がどの意味か」を説明しやすくなる。
 
 **Alternatives considered**:
 
-- `Proficiency` を `VocabularyExpression` の内部フィールドにする
-- `Proficiency` を `Explanation` の属性として扱う
+- `Meaning.values` に補足文字列を追記して疑似的に意味を増やす
+- 画像だけ複数にして意味の構造化は行わない
 
-## Decision: `Explanation` は `VocabularyExpression` の current 参照を持つ知識集約とし、再生成中は直前の完了済み結果を保持する
+## Decision: 例文とコロケーションは `Sense` に属させ、発音・語源・頻出度・知的度は `Explanation` に残す
 
-**Rationale**: 解説生成は `VocabularyExpression` 単位で進むが、ユーザーへ見せるのは常に完了済み結果のみである。
-そのため `VocabularyExpression.currentExplanation` を明示し、再生成開始時にこれを消さず、
-新しい成功時だけ差し替える設計が一貫する。これにより中間結果を見せず、再生成失敗時も
-最後の正常結果を維持できる。
-
-**Alternatives considered**:
-
-- 解説を常に最新ジョブ 1 件だけに上書きする
-- 解説生成中は過去の完了済み解説も隠す
-
-## Decision: `VisualImage` は `Explanation` から独立した集約とし、`currentImage` と履歴を分ける
-
-**Rationale**: 画像は生成タイミング、保存先参照、再生成履歴が解説本文と異なる。`Explanation` が
-`currentImage` を参照し、各 `VisualImage` が `previousImage` で同一解説内の履歴を辿れるようにすると、
-現在表示中の画像と履歴画像の責務が分離される。再生成中も現在画像を維持し、新しい成功時だけ
-参照を切り替えられる。
+**Rationale**: 例文とコロケーションは意味ごとの使われ方に強く依存する。一方で発音、語源、
+頻出度、知的度は表現全体の説明として扱う方が自然であり、意味ごとに分割すると重複や
+説明のばらつきが増える。これにより、説明全体の共通情報と意味別の局所情報を分離できる。
 
 **Alternatives considered**:
 
-- `Explanation` が画像 URL を直接持つ
-- 画像を `Explanation` の子エンティティとして扱う
-- 画像再生成時に過去画像を破棄する
+- 例文、コロケーション、発音、語源をすべて `Sense` に移す
+- 例文、コロケーションも explanation 全体の配列のままにする
 
-## Decision: `Learner` は独立集約だが、認証そのものは外部責務として `AuthenticationSubject` 参照だけを持つ
+## Decision: `VisualImage` は独立集約のまま維持し、必要に応じて `sense` 参照を持つ
 
-**Rationale**: 学習者は domain 上の所有者として明示したいが、認証方式や credential まで domain に
-持ち込むべきではない。`Learner` が外部 identity を表す `AuthenticationSubject` を保持し、
-認証・セッション管理自体は外部ポートに委ねる方が architecture / tech stack と整合する。
-
-**Alternatives considered**:
-
-- `Learner` を auth provider の実装詳細ごと domain に持ち込む
-- 学習者 identity を domain 外に完全に追い出し、所有境界も external に依存する
-
-## Decision: external responsibility は learner identity を含む port catalog として整理する
-
-**Rationale**: 単語存在確認、重複登録判定、学習者 identity 解決、解説生成、画像生成、アセット保存、
-発音参照はすべて外部依存であり、project-wide domain に実装詳細を持ち込むべきではない。
-ドメインでは入力、出力、保証事項だけを定義し、adapter 実装は後続 feature に委ねる。
+**Rationale**: 画像は非同期生成、保存先参照、再生成履歴の責務を持つため、`Explanation` の
+内部値へ戻すべきではない。ただし意味と画像の対応は domain 上で明示したいので、
+`VisualImage` が `Explanation` と同時に `sense?` を持てるようにする。
+これにより、「この画像はどの意味を描いているか」を示せる。
 
 **Alternatives considered**:
 
-- auth provider や AI vendor 名をドメインサービスへ埋め込む
-- ポート定義を作らず実装時に都度判断する
+- `VisualImage` を `Explanation` の子エンティティとして扱う
+- 画像と意味の対応を持たず、画像説明テキストだけで補う
 
-## Decision: source-of-truth は `learner.md`、`vocabulary-expression.md`、`learning-state.md` を追加して再編する
+## Decision: この phase では `Explanation.currentImage` を単一 current 参照のまま維持する
 
-**Rationale**: 現行 `explanation.md` と `visual.md` だけでは、学習者所有、一意性境界、
-習熟度分離、命名統一を表現しきれない。`Learner`、`VocabularyExpression`、`LearningState`
-を独立した source-of-truth に切り出し、既存文書はそれらとの関係へ再配置する方が、
-後続 feature の task と review 導線を明確にできる。
+**Rationale**: `Sense` の導入目的は、まず意味単位と画像単位の対応関係を明示することであり、
+current image を複数 current image へ拡張することではない。単一 current 参照を維持すると、
+既存の async visibility rule、retry / regenerate rule、UI 表示契約を壊さずに導入できる。
+複数 current image は follow-on scope として、`Sense` の運用が固まってから判断する方が安全である。
 
 **Alternatives considered**:
 
-- 既存 4 文書だけを追記して拡張する
-- `Explanation` 文書内に `Learner` と `VocabularyExpression` と学習進捗を内包する
+- `Explanation.currentImages` を直ちに複数化する
+- 画像 current 参照を廃止し、履歴配列から都度選ぶ
+
+## Decision: 画像枚数より意味対応の明確さを優先する
+
+**Rationale**: 学習体験では画像数の多さより、「どの意味を補助する画像か」が明確であることが
+重要である。`Sense` 導入により、画像を増やす前に meaning-image mapping を安定化できる。
+これにより、意味と無関係な装飾画像や、複数意味を曖昧に代表する画像の乱用を避けられる。
+
+**Alternatives considered**:
+
+- 意味構造を持たずに画像だけ増やす
+- 画像を 1 枚に固定したまま多義語の意味区別を model しない
+
+## Decision: source-of-truth は `explanation.md` と `visual.md` を中心に `common.md` を更新して再編する
+
+**Rationale**: `Sense` は `Explanation` の責務再編であり、既存の `Learner`、
+`VocabularyExpression`、`LearningState` の ownership boundary を変えるものではない。
+そのため正本の中心は `explanation.md` と `visual.md` であり、project-wide 用語差分は
+`common.md` で吸収するのが最小変更である。必要な外部文書整合は `requirements.md` と
+`adr.md` に限定できる。
+
+**Alternatives considered**:
+
+- `sense.md` を独立 source-of-truth として新設する
+- 既存文書を変えず、spec artifacts だけで `Sense` を説明する

--- a/specs/005-domain-modeling/spec.md
+++ b/specs/005-domain-modeling/spec.md
@@ -1,133 +1,123 @@
-# Feature Specification: ドメインモデリング
+# Feature Specification: ドメインモデリング - Sense導入差分
 
-**Feature Branch**: `005-domain-modeling`  
-**Created**: 2026-04-15  
+**Feature Branch**: `009-sense-modeling`  
+**Created**: 2026-04-17  
 **Status**: Draft  
-**Input**: User description: "ドメインモデリングを行う。私と議論しながら進めていきましょう。"
+**Input**: User description: "005をSense導入差分へ更新する"
 
 ## Clarifications
 
-### Session 2026-04-16
+### Session 2026-04-17
 
-- Q: 習熟度 (`Proficiency`) は誰に属する状態として扱うか → A: 学習者ごとの状態として扱う
-- Q: 学習者 identity は今回のドメインモデルでどう扱うか → A: 学習者を独立集約として扱う
-- Q: `VocabularyExpression` は誰に属する概念として扱うか → A: 各学習者が自分の `VocabularyExpression` を所有する
-- Q: 同じ英語表現の重複登録はどの粒度で禁止するか → A: 同一学習者内だけ一意にする
-- Q: 画像再生成時、以前の `VisualImage` はどう扱うか → A: 履歴として保持し、現在画像だけ別参照で示す
-- Q: `Entry` の標準名を何にするか → A: `VocabularyExpression` を標準名にする
-- Q: `EntryLearningState` の置き換え名を何にするか → A: `LearningState` を標準名にする
-- Q: `VocabularyExpression` への派生名をどう扱うか → A: 識別子型、repository、値オブジェクトを含めて `VocabularyExpression*` / `LearningState*` に全面改名する
-- Q: `EntryExpression` 系の値オブジェクト名を何にするか → A: `VocabularyExpressionText` / `NormalizedVocabularyExpressionText` を標準名にする
+- Q: 多義語の意味単位はどこに置くか → A: `Sense` を `Explanation` 所有の内部エンティティとして導入する
+- Q: `VisualImage` は複数意味を扱うために `Explanation` の内部値へ戻すか → A: 独立集約のまま維持し、必要に応じて `sense` を参照する
+- Q: `Sense` 導入時に `currentImage` は複数化するか → A: 今回は単一 `currentImage` を維持し、複数 current image は後続 scope とする
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - 主要概念の境界を定める (Priority: P1)
+### User Story 1 - 意味単位を明確化する (Priority: P1)
 
-ドメイン設計者として、vocastock の主要概念とその境界を一貫した言葉で整理したい。そうすることで、
-後続の設計、実装、レビューで同じ言葉を同じ意味で使えるようにしたい。
+ドメイン設計者として、多義語の解説を意味単位で整理したい。そうすることで、意味、状況、
+ニュアンス、例文、コロケーションがどの意味に属するかを一貫した言葉で説明できるようにしたい。
 
-**Why this priority**: 概念境界が曖昧なままでは、集約、状態、責務の切り方がぶれ続けるため。
+**Why this priority**: `Sense` を定義しないまま画像や例文を増やすと、どの意味を補助しているかが曖昧になるため。
 
-**Independent Test**: 第三者が設計成果物だけを読み、主要概念、責務境界、不変条件を 5 分以内に説明できれば成立する。
+**Independent Test**: 第三者が設計成果物だけを読み、`Sense`、`Explanation`、`VisualImage` の責務差分を 5 分以内に説明できれば成立する。
 
 **Acceptance Scenarios**:
 
-1. **Given** 既存文書に概念の重複や不足がある, **When** ドメインモデリング結果を確認する, **Then** 主要概念、責務、関係が一貫した用語で定義されている
-2. **Given** 新しい実装担当者が成果物を読む, **When** 英単語登録、解説生成、画像生成、学習状態管理の関係を確認する, **Then** 追加説明なしで概念の境界を理解できる
+1. **Given** 1 つの英語表現に複数の意味がある, **When** ドメインモデリング結果を確認する, **Then** 意味ごとの説明単位として `Sense` が定義されている
+2. **Given** 例文やコロケーションを確認する, **When** どの意味に属するかを見る, **Then** explanation 全体ではなく対応する `Sense` に結びついている
 
 ---
 
-### User Story 2 - 非同期生成の業務意味を定める (Priority: P2)
+### User Story 2 - 意味と画像の対応を定義する (Priority: P2)
 
-実装担当者として、解説生成と画像生成の状態、再試行、再生成、表示可否をドメインの言葉で整理したい。
-そうすることで、完了済み結果のみを表示するルールを壊さずに設計できる。
+実装担当者として、`Sense` 導入後も画像生成の current 参照、再試行、再生成、表示可否を壊さずに、
+どの画像がどの意味を補助するかをドメインの言葉で整理したい。
 
-**Why this priority**: 非同期生成の扱いが曖昧だと、中間結果の誤表示や重複処理の不整合が起きやすいため。
+**Why this priority**: 画像と意味の対応が曖昧だと、多義語で誤った画像を表示しても domain 上で検出できないため。
 
-**Independent Test**: レビュー担当者が成果物だけを読み、生成依頼から完了・失敗・再生成までの状態遷移と表示ルールを説明できれば成立する。
+**Independent Test**: レビュー担当者が成果物だけを読み、sense-aware image generation と単一 `currentImage` の業務意味を説明できれば成立する。
 
 **Acceptance Scenarios**:
 
-1. **Given** 解説生成または画像生成を扱う設計レビューを行う, **When** 成果物を確認する, **Then** `pending`、`running`、`succeeded`、`failed` と再試行条件が定義されている
-2. **Given** ユーザー表示ルールを確認する, **When** 生成途中または失敗時の扱いを見る, **Then** 中間生成結果は表示せず状態のみが見えることが定義されている
+1. **Given** `Explanation` に複数の `Sense` がある, **When** 画像生成ルールを確認する, **Then** `VisualImage` が必要に応じて対応する `Sense` を参照できる
+2. **Given** 画像再生成中または失敗中である, **When** ユーザー表示ルールを確認する, **Then** 直前の完了済み `currentImage` だけを維持し、中間生成結果は表示しない
 
 ---
 
-### User Story 3 - 文書横断で用語を統一する (Priority: P3)
+### User Story 3 - 差分導入の境界を周辺文書へ反映する (Priority: P3)
 
-レビュー担当者として、要件、ADR、既存ドメイン文書の前提が揃った状態にしたい。そうすることで、
-後続の architecture、tech stack、実装計画と矛盾しない土台を持ちたい。
+レビュー担当者として、`Sense` 導入が既存の 005 全体設計を壊さず、どこまでが今回の対象で、
+どこからが後続 scope かを周辺文書から一貫して確認したい。
 
-**Why this priority**: ドメイン文書だけが正しくても、周辺文書と食い違うと設計判断が再びぶれるため。
+**Why this priority**: `Sense` 導入差分と既存 005 全体スコープの境界が曖昧だと、plan と tasks が spec とずれ続けるため。
 
-**Independent Test**: 要件文書、ADR、ドメイン文書を横断して、主要概念と責務境界の矛盾がないと第三者が判定できれば成立する。
+**Independent Test**: 要件文書、ADR、共通 glossary を横断して、`Sense` 導入、meaning-to-image mapping、後続 scope が矛盾なく説明できれば成立する。
 
 **Acceptance Scenarios**:
 
-1. **Given** 要件文書とドメイン文書を比較する, **When** 頻出度、知的度、習熟度、生成状態を確認する, **Then** 概念の違いと関係が矛盾なく説明できる
-2. **Given** ADR とドメイン文書を比較する, **When** 外部サービスとの責務分担を確認する, **Then** ドメイン内責務と外部依存責務の境界が一貫している
+1. **Given** 要件文書とドメイン文書を比較する, **When** `Sense`、`Meaning`、画像対応を確認する, **Then** 用語差分と移行方針が矛盾なく説明できる
+2. **Given** ADR とドメイン文書を比較する, **When** 単一 `currentImage` の維持と複数 current image の後続 scope を確認する, **Then** 今回の対象範囲と後続範囲が一貫している
 
 ---
 
 ### Edge Cases
 
-- 既存文書で `Explanation` が画像を直接持つ定義と `VisualImage` を独立概念として扱う定義が競合する場合
-- 単語と連語を同じ識別子体系で扱うか、別概念として扱うかで不変条件が変わる場合
-- 同一学習者が同じ英語表現を再登録しようとした場合に、重複として拒否するか更新として扱うかが曖昧な場合
-- 画像再生成時に、過去画像を破棄するのか履歴として保持するのかが曖昧な場合
-- 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態が混同される場合
-- 同じ解説に対して画像生成が重複依頼されたとき、何を同一依頼とみなすか曖昧な場合
-- 外部の単語検証、解説生成、画像生成、アセット保存の責務がドメイン内に入り込む場合
+- 単一の `Explanation` に `Sense` が 1 件しかない場合でも、`Sense` 導入によって説明が過剰に複雑にならないこと
+- `VisualImage` が explanation 全体を代表する画像であり、特定の `Sense` に結びつかない場合を許可するかどうかが曖昧な場合
+- 画像再生成時に `previousImage` と `sense` の関係が崩れ、異なる意味の画像履歴を誤って連結してしまう場合
+- `Meaning.values` の旧表現が残り、`Sense` と explanation-wide meaning の二重管理になる場合
+- `Sense` を導入したことにより、`Frequency`、`Sophistication`、`Proficiency` が意味単位へ吸収されたように誤読される場合
+- `currentImage` を複数 current image と誤解し、完了済み結果のみ表示する rule が崩れる場合
 
 ## Domain & Async Impact *(mandatory when applicable)*
 
-- **Domain Models Affected**: `docs/internal/domain/common.md`, `docs/internal/domain/explanation.md`, `docs/internal/domain/service.md`, `docs/internal/domain/visual.md`, `docs/internal/domain/learner.md`, `docs/internal/domain/vocabulary-expression.md`, `docs/internal/domain/learning-state.md`
-- **Invariants / Terminology**: 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態は別概念として保ち、相互変換や代替関係として扱わない。正規名称は `VocabularyExpression` と `LearningState` を使い、識別子型、repository、値オブジェクトなどの派生名も `VocabularyExpression*` / `LearningState*` に統一する。文字列表現の値オブジェクトは `VocabularyExpressionText` と `NormalizedVocabularyExpressionText` を正規名称とする
-- **Async Lifecycle**: 解説生成と画像生成は少なくとも `pending`、`running`、`succeeded`、`failed` を持ち、再試行と再生成は冪等性を壊さない前提で定義する
-- **User Visibility Rule**: ユーザーに見せる生成物は完了済み結果のみとし、生成中・失敗時は状態のみを表示対象とする
-- **Identifier Naming Rule**: 識別子型は `XxxIdentifier`、集約自身の識別子フィールドは `identifier`、関連識別子フィールドは概念名で定義し、`id`、`ID`、`xxxId`、`xxxIdentifier` は使わない
-- **External Ports / Adapters**: 単語存在確認、登録済み判定、解説生成、画像生成、アセット保存、外部発音リソース参照をドメイン外責務として整理する
+- **Domain Models Affected**: `docs/internal/domain/common.md`, `docs/internal/domain/explanation.md`, `docs/internal/domain/service.md`, `docs/internal/domain/visual.md`
+- **Invariants / Terminology**: `Sense` は `Explanation` 所有の意味単位であり、頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態とは別概念として保つ。`ExampleSentence` と `Collocation` は `Sense` に属し、`Frequency` と `Sophistication` は引き続き `Explanation` に属する。`currentImage` は単一参照のままとする
+- **Async Lifecycle**: 解説生成と画像生成は少なくとも `pending`、`running`、`succeeded`、`failed` を持ち、再試行と再生成は冪等性を壊さない前提で定義する。`Sense` を導入しても、画像生成は新しい成功時だけ `currentImage` を切り替える
+- **User Visibility Rule**: ユーザーに見せる生成物は完了済みの `currentExplanation` と `currentImage` のみとし、生成中・失敗時は状態のみを表示対象とする。`Explanation` が複数の `Sense` を持っていても、今回の current image は 1 件のみ表示対象とする
+- **Identifier Naming Rule**: 識別子型は `XxxIdentifier`、集約自身の識別子フィールドは `identifier`、関連識別子フィールドは概念名で定義し、`id`、`ID`、`xxxId`、`xxxIdentifier` は使わない。`Sense` を導入する場合は `SenseIdentifier` を使う
+- **External Ports / Adapters**: 解説生成、画像生成、アセット保存、外部発音リソース参照をドメイン外責務として整理する。画像生成は必要に応じて対象 `Sense` を指定できるが、ベンダー固有実装は持ち込まない
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: 成果物は、vocastock プロジェクト全体のドメインを対象とし、core flow、学習管理、周辺サブドメインを含む全体境界を明示しなければならない
-- **FR-002**: 成果物は、対象範囲に含まれる主要概念について、意味、責務、関係、不変条件、用語上の区別を定義しなければならない
-- **FR-003**: 成果物は、英単語と連語を同一の `VocabularyExpression` 概念として扱い、その識別、分類、不変条件の共通ルールを定義しなければならない。`VocabularyExpression` は各学習者が所有する登録対象として扱わなければならない
-- **FR-003a**: 成果物は、同じ英語表現の `VocabularyExpression` を同一学習者内で一意に扱い、重複登録判定は学習者境界の内側で行うことを定義しなければならない
-- **FR-004**: 成果物は、頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態を別概念として定義し、その関係と非関係を明文化しなければならない。特に習熟度は学習者ごとに所有される状態として扱わなければならない
-- **FR-005**: 成果物は、解説生成と画像生成について、依頼、進行、完了、失敗、再試行、再生成の業務意味を定義しなければならない
-- **FR-006**: 成果物は、`VisualImage` を `Explanation` とは独立した集約として扱い、生成、再生成、保存先参照、現在表示中画像との関係を定義しなければならない
-- **FR-006a**: 成果物は、画像再生成時に以前の `VisualImage` を履歴として保持し、現在表示中の画像だけを別参照で示す関係を定義しなければならない
-- **FR-007**: 成果物は、ユーザーに見せてよい情報と内部状態を区別し、中間生成結果を表示しないルールを定義しなければならない
-- **FR-008**: 成果物は、単語検証、生成、保存などの外部責務をドメイン内概念と区別し、ポート越しに扱う前提を定義しなければならない
-- **FR-009**: 成果物は、要件、ADR、既存ドメイン文書の用語差分を整理し、どの用語を正として採用するかを示さなければならない。特に `VocabularyExpression` と `LearningState` を正規名称とし、識別子型、repository、値オブジェクトなどの派生名も同じ語幹へ統一しなければならない。文字列表現の値オブジェクト名は `VocabularyExpressionText` と `NormalizedVocabularyExpressionText` を採用しなければならない
-- **FR-010**: 成果物は、学習者を独立集約として定義し、`VocabularyExpression` および学習進捗との関係、および外部 identity / 認証責務との境界を示さなければならない
-- **FR-011**: 成果物は、今回扱わない論点を明示し、後続 feature へ委ねる範囲を示さなければならない
+- **FR-001**: 成果物は、既存の 005 ドメインモデルを前提とした差分機能として、`Explanation` への `Sense` 導入範囲を明示しなければならない
+- **FR-002**: 成果物は、`Sense` を `Explanation` 所有の意味単位として定義し、その意味、責務、関係、不変条件、用語上の区別を示さなければならない
+- **FR-003**: 成果物は、`ExampleSentence` と `Collocation` を explanation-wide の配列ではなく、対応する `Sense` に属する情報として定義しなければならない
+- **FR-004**: 成果物は、`Frequency`、`Sophistication`、`Proficiency`、登録状態、解説生成状態、画像生成状態を `Sense` と混同しないように定義しなければならない
+- **FR-005**: 成果物は、`VisualImage` を `Explanation` とは独立した集約として維持しつつ、必要に応じてどの `Sense` を描写する画像かを示す関係を定義しなければならない
+- **FR-006**: 成果物は、`Explanation.currentImage` を単一の current 参照として維持し、`Sense` 導入だけを理由に複数 current image を導入してはならない
+- **FR-006a**: 成果物は、画像再生成時に以前の `VisualImage` を履歴として保持し、`previousImage` と `sense` の関係が矛盾しない条件を定義しなければならない
+- **FR-007**: 成果物は、`Sense` を導入した後も、ユーザーに見せてよい生成物と内部状態を区別し、中間生成結果を表示しないルールを維持しなければならない
+- **FR-008**: 成果物は、sense-aware な画像生成と保存の責務をドメイン内概念と区別し、外部ポート越しに扱う前提を定義しなければならない
+- **FR-009**: 成果物は、`Meaning` から `Sense` への用語差分と移行メモを整理し、要件、ADR、既存ドメイン文書でどの用語を正として採用するかを示さなければならない
+- **FR-010**: 成果物は、`Learner`、`VocabularyExpression`、`LearningState` の既存 ownership boundary を再定義せず、今回の差分が `Explanation` / `VisualImage` 中心の変更であることを明示しなければならない
+- **FR-011**: 成果物は、今回扱わない論点として「複数 current image を同時に公開する設計」を明示し、後続 feature へ委ねる範囲を示さなければならない
 
 ### Key Entities *(include if feature involves data)*
 
-- **VocabularyExpression**: 学習者が所有する登録対象となる英語表現を表す中心概念であり、単語または連語の扱いを定義対象とし、同一学習者内で一意に管理される。以前は `Entry` と呼んでいた概念の正規名称とする
-- **Learner**: 学習者本人を表す独立集約であり、自身が所有する `VocabularyExpression` と学習進捗の起点となる
-- **Explanation**: 登録対象に対する解説を表す概念であり、意味、発音、頻出度、知的度、例文、類似表現、語源との関係を持つ
-- **VisualImage**: 解説に対応する視覚的表現を表す概念であり、画像生成状態、保存先参照、再生成後の履歴保持の責務境界を持つ
-- **LearningState**: 学習者ごとの習熟状態を表す概念であり、`Learner` と `VocabularyExpression` の関係上で語彙自体の属性と分離された学習進捗を担う。以前は `EntryLearningState` と呼んでいた概念の正規名称とする
-- **Learning Indicators**: 頻出度、知的度、習熟度など、学習上の異なる評価軸を表す概念群であり、習熟度は `LearningState` 側で扱う
-- **Generation State**: 解説生成と画像生成の依頼から完了までを表す業務状態概念であり、表示可否と再試行条件の判断基準になる
+- **Explanation**: `VocabularyExpression` に対する解説を表す概念であり、`Sense`、発音、頻出度、知的度、類似表現、語源、画像生成状態、現在表示中画像との関係を持つ
+- **Sense**: `Explanation` が所有する意味単位であり、意味ラベル、状況、ニュアンス、意味ごとの例文、意味ごとのコロケーションを担う
+- **VisualImage**: 解説に対応する視覚的表現を表す独立集約であり、画像生成状態、保存先参照、再生成後の履歴保持、必要に応じた `Sense` 参照の責務境界を持つ
+- **Meaning-to-Image Mapping**: どの画像が explanation 全体を代表するか、またはどの `Sense` を補助するかを表す関係概念であり、単一 `currentImage` を維持したまま意味対応を説明する判断基準になる
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: 成果物を読んだ第三者が、対象範囲内の主要概念、責務境界、不変条件を 5 分以内に説明できる
-- **SC-002**: 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態の混同に関する文書上の矛盾が 0 件になる
-- **SC-003**: 解説生成と画像生成について、状態遷移、再試行条件、ユーザー表示ルールをレビュー担当者が曖昧さなく判定できる
-- **SC-004**: 要件文書、ADR、ドメイン文書を横断確認したとき、主要概念と責務境界の食い違いが 0 件になる
+- **SC-001**: 成果物を読んだ第三者が、`Sense`、`Explanation`、`VisualImage` の責務差分と ownership boundary を 5 分以内に説明できる
+- **SC-002**: `Sense`、`Meaning`、`Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態の混同に関する文書上の矛盾が 0 件になる
+- **SC-003**: レビュー担当者が、sense-aware image generation と単一 `currentImage` の表示ルールを 5 分以内に判定できる
+- **SC-004**: 要件文書、ADR、ドメイン文書を横断確認したとき、`Sense` 導入差分と後続 scope の食い違いが 0 件になる
 
 ## Assumptions
 
-- 今回の主要成果物はプロジェクト全体のドメインモデル文書とその整合整理であり、アプリケーションコードの実装変更は含まない
-- 既存の architecture / tech stack の決定は所与とし、今回はその上でドメイン言語と責務境界を整理する
+- 005 の既存 docs-first 実装は完了しており、今回はそのうち `Explanation` / `VisualImage` / glossary 周辺の差分更新を行う
+- `Learner`、`VocabularyExpression`、`LearningState` の ownership boundary と命名統一は既存 005 の成果物を正本として再利用する
 - 完了済み結果のみをユーザーに表示するルールは前提として維持する
-- 外部サービスの具体製品選定や API 詳細は扱わず、業務責務とポート境界のみを整理対象とする
+- 外部サービスの具体製品選定や API 詳細は扱わず、sense-aware な業務責務とポート境界のみを整理対象とする
+- 複数 current image の同時公開は今回の scope 外であり、`Sense` 導入後の follow-on feature で扱う

--- a/specs/005-domain-modeling/tasks.md
+++ b/specs/005-domain-modeling/tasks.md
@@ -1,9 +1,9 @@
 # Tasks: ドメインモデリング
 
-**Input**: Design documents from `/Users/lihs/workspace/vocastock/specs/005-domain-modeling/`
+**Input**: Design documents from `/Users/lihs/workspace/vocastock/specs/005-domain-modeling/`  
 **Prerequisites**: [plan.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/plan.md), [spec.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/spec.md), [research.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/research.md), [data-model.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/data-model.md), [quickstart.md](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/quickstart.md), [contracts/](/Users/lihs/workspace/vocastock/specs/005-domain-modeling/contracts)
 
-**Tests**: 自動テストは明示要求されていないため生成しない。各 user story は spec.md の独立テスト条件と quickstart の cross-review 手順で検証する。
+**Tests**: 自動テストは追加しない。各 user story は spec.md の独立テスト条件と quickstart の cross-review 手順で検証する。
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 
@@ -15,23 +15,23 @@
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-**Purpose**: 新しい source-of-truth 文書の受け皿を作る
+**Purpose**: `Sense` 導入で触る正本文書の受け皿を整える
 
-- [X] T001 [P] Create learner source-of-truth skeleton in docs/internal/domain/learner.md
-- [X] T002 [P] Create vocabulary expression source-of-truth skeleton in docs/internal/domain/vocabulary-expression.md
-- [X] T003 [P] Create learning state source-of-truth skeleton in docs/internal/domain/learning-state.md
+- [X] T001 Create `Sense` review anchors and migration-note placeholders in /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
+- [X] T002 [P] Create `Sense` section placeholders for aggregate/entity updates in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md and /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md
 
 ---
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-**Purpose**: すべての user story で共有する命名規約と導線を固める
+**Purpose**: すべての user story で共有する用語、識別子、mapping 前提を固める
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [X] T004 Define canonical glossary, deprecated-name crosswalk, and naming rules in docs/internal/domain/common.md
-- [X] T005 Add source-of-truth index and aggregate relationship overview in docs/internal/domain/common.md
-- [X] T006 Add backlinks from docs/internal/domain/explanation.md, docs/internal/domain/visual.md, and docs/internal/domain/service.md to the new source-of-truth files
+- [X] T003 Define canonical `Sense` terminology, `Meaning` migration note, and project-wide mapping rules in /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
+- [X] T004 [P] Align `SenseIdentifier` naming, ownership language, and related-field naming across /Users/lihs/workspace/vocastock/docs/internal/domain/common.md, /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md, and /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md
+- [X] T005 [P] Document the single-current-image rule and meaning-to-image mapping baseline in /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
+- [X] T006 Add `Sense`-aware image generation and storage port vocabulary in /Users/lihs/workspace/vocastock/docs/internal/domain/service.md
 
 **Checkpoint**: Foundation ready - user story implementation can now begin in parallel
 
@@ -39,17 +39,17 @@
 
 ## Phase 3: User Story 1 - 主要概念の境界を定める (Priority: P1) 🎯 MVP
 
-**Goal**: `Learner`、`VocabularyExpression`、`LearningState`、`Explanation` の責務境界を一貫した用語で定義する
+**Goal**: `Sense` を `Explanation` 所有の意味単位として定義し、`Explanation` / `VisualImage` との責務差分を明確化する
 
-**Independent Test**: 第三者が docs/internal/domain/learner.md、docs/internal/domain/vocabulary-expression.md、docs/internal/domain/learning-state.md、docs/internal/domain/explanation.md、docs/internal/domain/common.md だけを読み、主要概念、所有境界、不変条件を 5 分以内に説明できること
+**Independent Test**: 第三者が /Users/lihs/workspace/vocastock/docs/internal/domain/common.md、/Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md、/Users/lihs/workspace/vocastock/docs/internal/domain/visual.md だけを読み、`Sense`、`Explanation`、`VisualImage` の責務と不変条件を 5 分以内に説明できること
 
 ### Implementation for User Story 1
 
-- [X] T007 [US1] Define `Learner` aggregate, external identity boundary, and ownership semantics in docs/internal/domain/learner.md
-- [X] T008 [P] [US1] Define `VocabularyExpression` aggregate, uniqueness scope, `VocabularyExpressionText`, `NormalizedVocabularyExpressionText`, and `currentExplanation` in docs/internal/domain/vocabulary-expression.md
-- [X] T009 [P] [US1] Define `LearningState` aggregate, `Proficiency` ownership, and relations to `Learner` / `VocabularyExpression` in docs/internal/domain/learning-state.md
-- [X] T010 [US1] Reframe `Explanation` domain narrative around `VocabularyExpression` references in docs/internal/domain/explanation.md
-- [X] T011 [US1] Add relationship cross-links across docs/internal/domain/learner.md, docs/internal/domain/vocabulary-expression.md, docs/internal/domain/learning-state.md, and docs/internal/domain/explanation.md
+- [X] T007 [US1] Define `Sense` as an `Explanation`-owned internal entity with fields, order, and invariants in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
+- [X] T008 [P] [US1] Replace coarse `Meaning` ownership with `Explanation.senses` language in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
+- [X] T009 [P] [US1] Move example and collocation ownership from explanation-wide wording to sense-specific wording in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
+- [X] T010 [US1] Add cross-links from /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md to /Users/lihs/workspace/vocastock/docs/internal/domain/common.md and /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md for `Sense` semantics
+- [X] T011 [US1] Reconcile `Explanation` aggregate summary and invariants with the `Sense` model in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
 
 **Checkpoint**: User Story 1 should be independently understandable and reviewable
 
@@ -57,47 +57,44 @@
 
 ## Phase 4: User Story 2 - 非同期生成の業務意味を定める (Priority: P2)
 
-**Goal**: 解説生成と画像生成の状態、再試行、再生成、表示可否を domain language で明文化する
+**Goal**: `Sense` 導入後も画像生成の current 参照、retry、regenerate、表示可否を壊さないようにする
 
-**Independent Test**: レビュー担当者が docs/internal/domain/vocabulary-expression.md、docs/internal/domain/explanation.md、docs/internal/domain/visual.md、docs/internal/domain/service.md だけを読み、生成依頼から完了・失敗・再生成までの状態遷移と表示ルールを説明できること
+**Independent Test**: レビュー担当者が /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md、/Users/lihs/workspace/vocastock/docs/internal/domain/visual.md、/Users/lihs/workspace/vocastock/docs/internal/domain/service.md だけを読み、sense-aware image generation と単一 `currentImage` の業務意味を説明できること
 
 ### Implementation for User Story 2
 
-- [X] T012 [P] [US2] Document `VocabularyExpression` explanation-generation lifecycle, retry/regenerate rules, and `currentExplanation` visibility in docs/internal/domain/vocabulary-expression.md
-- [X] T013 [P] [US2] Document `Explanation` image-generation lifecycle and `currentImage` visibility in docs/internal/domain/explanation.md
-- [X] T014 [P] [US2] Document `VisualImage` history, `previousImage` chain, and current-image handoff in docs/internal/domain/visual.md
-- [X] T015 [US2] Align generation, storage, and failure responsibilities with external ports in docs/internal/domain/service.md
-- [X] T016 [US2] Reconcile async visibility language across docs/internal/domain/vocabulary-expression.md, docs/internal/domain/explanation.md, docs/internal/domain/visual.md, and docs/internal/domain/service.md
+- [X] T012 [P] [US2] Document `currentImage` as a single completed image even when multiple `Sense` values exist in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md
+- [X] T013 [P] [US2] Define `VisualImage.sense`, same-explanation ownership, and same-sense regeneration constraints in /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md
+- [X] T014 [P] [US2] Update image generation port wording to accept `sense?` and preserve completion-only visibility in /Users/lihs/workspace/vocastock/docs/internal/domain/service.md
+- [X] T015 [US2] Reconcile retry/regenerate and visibility language across /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md, /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md, and /Users/lihs/workspace/vocastock/docs/internal/domain/service.md
 
-**Checkpoint**: User Story 2 should be independently reviewable without relying on intermediate generated results
+**Checkpoint**: User Story 2 should be independently reviewable without exposing intermediate results
 
 ---
 
 ## Phase 5: User Story 3 - 文書横断で用語と deferred scope を統一する (Priority: P3)
 
-**Goal**: 要件、ADR、既存 domain docs の用語と out-of-scope / deferred 範囲を `VocabularyExpression` / `LearningState` 前提で整合させる
+**Goal**: 要件、ADR、共通 glossary を `Sense` 前提へ揃え、複数 current image を後続 scope として明示する
 
-**Independent Test**: docs/external/requirements.md、docs/external/adr.md、docs/internal/domain/common.md を横断して、主要概念、責務境界、今回扱わない論点が矛盾なく整理されていると第三者が判定できること
+**Independent Test**: /Users/lihs/workspace/vocastock/docs/external/requirements.md、/Users/lihs/workspace/vocastock/docs/external/adr.md、/Users/lihs/workspace/vocastock/docs/internal/domain/common.md を横断して、`Sense` 導入、meaning-to-image mapping、follow-on scope が矛盾なく説明できること
 
 ### Implementation for User Story 3
 
-- [X] T017 [P] [US3] Replace `Entry` terminology with `VocabularyExpression` terms in docs/external/requirements.md
-- [X] T018 [P] [US3] Replace `Entry` / `EntryLearningState` terminology and port names in docs/external/adr.md
-- [X] T019 [US3] Add canonical terminology and deprecated synonym guidance in docs/internal/domain/common.md
-- [X] T020 [US3] Normalize `VocabularyExpressionText` and `NormalizedVocabularyExpressionText` naming in docs/external/requirements.md and docs/external/adr.md
-- [X] T021 [US3] Add out-of-scope / deferred scope guidance and follow-on feature boundaries in docs/internal/domain/common.md and docs/external/adr.md
-- [X] T022 [US3] Cross-check terminology consistency and deferred scope alignment across docs/external/requirements.md, docs/external/adr.md, and docs/internal/domain/common.md
+- [X] T016 [P] [US3] Add `Sense` terminology and meaning-unit language to /Users/lihs/workspace/vocastock/docs/external/requirements.md
+- [X] T017 [P] [US3] Add `Sense` boundary, single-current-image decision, and follow-on scope notes to /Users/lihs/workspace/vocastock/docs/external/adr.md
+- [X] T018 [US3] Update deferred-scope guidance for multi-image-per-explanation follow-on work in /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
+- [X] T019 [US3] Cross-check `Sense`, `Meaning`, and image mapping terminology across /Users/lihs/workspace/vocastock/docs/external/requirements.md, /Users/lihs/workspace/vocastock/docs/external/adr.md, and /Users/lihs/workspace/vocastock/docs/internal/domain/common.md
 
-**Checkpoint**: User Story 3 should make the external docs and glossary align on the same canonical terms and deferred boundaries
+**Checkpoint**: User Story 3 should make external docs and glossary align on `Sense` and follow-on boundaries
 
 ---
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-**Purpose**: 最終整合確認と残差分の除去
+**Purpose**: 最終整合確認と旧表現の残差分除去
 
-- [X] T023 Validate specs/005-domain-modeling/quickstart.md against docs/internal/domain/learner.md, docs/internal/domain/vocabulary-expression.md, docs/internal/domain/learning-state.md, docs/internal/domain/explanation.md, docs/internal/domain/visual.md, docs/internal/domain/service.md, docs/external/requirements.md, and docs/external/adr.md
-- [X] T024 Remove leftover deprecated-name references beyond the allowed migration note across docs/internal/domain/*.md and docs/external/*.md
+- [X] T020 Validate /Users/lihs/workspace/vocastock/specs/005-domain-modeling/quickstart.md and /Users/lihs/workspace/vocastock/specs/005-domain-modeling/contracts/sense-image-mapping-contract.md against /Users/lihs/workspace/vocastock/docs/internal/domain/common.md, /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md, /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md, /Users/lihs/workspace/vocastock/docs/internal/domain/service.md, /Users/lihs/workspace/vocastock/docs/external/requirements.md, and /Users/lihs/workspace/vocastock/docs/external/adr.md
+- [X] T021 Remove leftover explanation-wide `Meaning.values` wording and ambiguous multi-image wording beyond intentional migration notes across /Users/lihs/workspace/vocastock/docs/internal/domain/*.md and /Users/lihs/workspace/vocastock/docs/external/*.md
 
 ---
 
@@ -118,40 +115,41 @@
 
 ### Within Each User Story
 
-- Shared terminology and backlinks from Foundational must exist first
-- Source-of-truth files before cross-links that reference them
-- Aggregate definitions before cross-document reconciliation
-- Story completion before Polish validation
+- Shared terminology, identifier rules, and mapping baselines from Foundational must exist first
+- `Explanation` aggregate updates before cross-links that depend on `Sense`
+- `VisualImage.sense` rules before async reconciliation that references them
+- External-doc alignment before final terminology cleanup
 
 ### Parallel Opportunities
 
-- T001, T002, T003 can run in parallel
+- T002 can run in parallel with T001
+- T004 and T005 can run in parallel
 - T008 and T009 can run in parallel
 - T012, T013, and T014 can run in parallel
-- T017, T018, and T021 can run in parallel
+- T016 and T017 can run in parallel
 
 ---
 
 ## Parallel Example: User Story 1
 
 ```bash
-Task: "Define `VocabularyExpression` aggregate in docs/internal/domain/vocabulary-expression.md"
-Task: "Define `LearningState` aggregate in docs/internal/domain/learning-state.md"
+Task: "Replace coarse `Meaning` ownership with `Explanation.senses` language in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md"
+Task: "Move example and collocation ownership to sense-specific wording in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md"
 ```
 
 ## Parallel Example: User Story 2
 
 ```bash
-Task: "Document `VocabularyExpression` explanation-generation lifecycle in docs/internal/domain/vocabulary-expression.md"
-Task: "Document `Explanation` image-generation lifecycle in docs/internal/domain/explanation.md"
-Task: "Document `VisualImage` history in docs/internal/domain/visual.md"
+Task: "Document single `currentImage` behavior in /Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md"
+Task: "Define `VisualImage.sense` constraints in /Users/lihs/workspace/vocastock/docs/internal/domain/visual.md"
+Task: "Update sense-aware image generation port wording in /Users/lihs/workspace/vocastock/docs/internal/domain/service.md"
 ```
 
 ## Parallel Example: User Story 3
 
 ```bash
-Task: "Replace terminology in docs/external/requirements.md"
-Task: "Replace terminology in docs/external/adr.md"
+Task: "Add `Sense` terminology to /Users/lihs/workspace/vocastock/docs/external/requirements.md"
+Task: "Add `Sense` boundary and follow-on scope notes to /Users/lihs/workspace/vocastock/docs/external/adr.md"
 ```
 
 ---
@@ -163,20 +161,20 @@ Task: "Replace terminology in docs/external/adr.md"
 1. Complete Phase 1: Setup
 2. Complete Phase 2: Foundational
 3. Complete Phase 3: User Story 1
-4. **STOP and VALIDATE**: Review the concept boundaries independently before proceeding
+4. **STOP and VALIDATE**: Review the `Sense` / `Explanation` / `VisualImage` boundaries independently before proceeding
 
 ### Incremental Delivery
 
 1. Complete Setup + Foundational
-2. Deliver User Story 1 and verify concept boundaries
-3. Deliver User Story 2 and verify async lifecycle / visibility rules
+2. Deliver User Story 1 and verify `Sense` boundary
+3. Deliver User Story 2 and verify sense-aware async visibility rules
 4. Deliver User Story 3 and verify cross-document terminology alignment
-5. Run Polish validation against quickstart and remove leftover old names
+5. Run Polish validation against quickstart and contracts, then remove leftover old wording
 
 ### Parallel Team Strategy
 
-1. One writer prepares the three new source-of-truth files in Phase 1
-2. A second writer stabilizes glossary and backlinks in Phase 2
+1. One writer prepares glossary anchors and placeholders in Phase 1
+2. A second writer stabilizes identifier and mapping rules in Phase 2
 3. After Foundational:
    - Writer A: User Story 1
    - Writer B: User Story 2
@@ -189,5 +187,5 @@ Task: "Replace terminology in docs/external/adr.md"
 - [P] tasks = different files, no dependencies
 - [US1], [US2], [US3] labels map tasks to user stories for traceability
 - Each user story is independently reviewable with its own document set
-- Keep deprecated names only where the migration note explicitly calls them out once
+- Keep `currentImage` singular in this feature; multi-current-image support is follow-on scope
 - Commit after each logical group of document changes


### PR DESCRIPTION
## Summary
- introduce `Sense` as an internal entity under `Explanation`
- define meaning-to-image mapping via `VisualImage.sense`
- keep `Explanation.currentImage` as a single current reference and sync related docs

## Testing
- docs cross-review only
- verified `specs/005-domain-modeling/tasks.md` is 21/21 complete
- searched for leftover `Meaning.values` wording outside migration notes