### PR TITLE
docs: define component boundaries

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/005-domain-modeling"
+  "feature_directory": "specs/009-component-boundaries"
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/009-component-boundaries"
+  "feature_directory": "specs/010-subscription-component-boundaries"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # vocastock Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-18
+Auto-generated from all feature plans. Last updated: 2026-04-19
 
 ## Active Technologies
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/development/*.md` (003-architecture-design)
@@ -21,6 +21,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-18
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/` (009-sense-modeling)
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/` (010-component-boundaries)
 - Git-managed repository files、設計上で参照する抽象的な command state store、query read store、asset store、auth/session boundary outputs (010-component-boundaries)
+- Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/service.md`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/`、`specs/009-component-boundaries/` (010-component-boundaries)
+- Git-managed repository files、設計上で参照する抽象的な subscription state store、purchase state store、entitlement store、usage metering store、store purchase artifact / notification ingest store (010-component-boundaries)
 
 - Markdown 1.x, YAML, JSON + Spec Kit workflow, existing domain documents, requirements memo, ADR memo (001-complete-domain-model)
 
@@ -63,9 +65,8 @@ an aggregate's own identifier field must be `identifier`, and related identifier
 fields must use concept names such as `bank`, `entry`, or `image`.
 
 ## Recent Changes
+- 010-component-boundaries: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/service.md`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/`、`specs/009-component-boundaries/`
 - 010-component-boundaries: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/`
-- 010-component-boundaries: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/`
-- 009-sense-modeling: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # vocastock Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-17
+Auto-generated from all feature plans. Last updated: 2026-04-18
 
 ## Active Technologies
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/development/*.md` (003-architecture-design)
@@ -19,6 +19,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-17
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend (008-auth-session-design)
 - Git-managed repository files、設計上で参照する抽象的な auth account store、external identity link store、session store、actor / learner resolution store、Firebase Authentication user records (008-auth-session-design)
 - Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/` (009-sense-modeling)
+- Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/` (010-component-boundaries)
+- Git-managed repository files、設計上で参照する抽象的な command state store、query read store、asset store、auth/session boundary outputs (010-component-boundaries)
 
 - Markdown 1.x, YAML, JSON + Spec Kit workflow, existing domain documents, requirements memo, ADR memo (001-complete-domain-model)
 
@@ -61,9 +63,9 @@ an aggregate's own identifier field must be `identifier`, and related identifier
 fields must use concept names such as `bank`, `entry`, or `image`.
 
 ## Recent Changes
+- 010-component-boundaries: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/`
+- 010-component-boundaries: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/`
 - 009-sense-modeling: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/internal/domain/*.md`、`docs/external/requirements.md`、`docs/external/adr.md`、`specs/001-complete-domain-model/`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
-- 008-auth-session-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、Flutter client auth UI、Firebase Authentication、Firebase ID token verification on backend
-- 008-auth-session-design: Added Markdown 1.x, YAML/JSON reference documents + 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/external/adr.md
+++ b/docs/external/adr.md
@@ -1,58 +1,185 @@
 # コンポーネント
 
-## UI
+## 主軸アーキテクチャ
 
-- ユーザーが直に触れる部分
-- `VocabularyExpression` の登録、`Sense` で整理された完了済み `Explanation` の閲覧、完了済み `VisualImage` の閲覧を扱う
-- 生成中または失敗中は状態のみを表示し、中間生成物は表示しない
-- 画像表示は `Explanation.currentImage` の単一参照に従い、複数 current image を同時公開しない
+- 主軸はオニオンアーキテクチャとする
+- `Domain Core` と `Application Coordination` は内側基盤として明示し、外から見える component catalog には混ぜない
+- 外から見える top-level responsibility は `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` に固定する
+- `auth/session` は outer boundary として分離し、009 では利用点だけを定義する
+- `Explanation Generation Workflow` と `Image Generation Workflow` は `Async Generation` 配下の別 component とする
+- ユーザーに公開してよい生成物は完了済み結果のみとし、生成中または失敗中は状態のみを表示する
 
-## Learner identity resolution
+## 内側基盤
 
-- 外部 identity を `Learner` へ解決する
-- 認証そのものは扱わず、domain には学習者解決結果だけを渡す
+### Domain Core
 
-## VocabularyExpression validation
+- `Learner`、`VocabularyExpression`、`LearningState`、`Explanation`、`VisualImage`、`Sense` の用語と不変条件を保持する
+- UI、auth/session detail、vendor API detail は持たない
 
-- 登録対象の英語表現が本当に存在するのかを判定する
-- `VocabularyExpressionText` を `NormalizedVocabularyExpressionText` へ正規化する
+### Application Coordination
 
-## Registration lookup
+- domain を使って actor handoff、command intake、query read、async workflow を接続する依存規則を保持する
+- top-level responsibility の代替カテゴリとしては扱わない
 
-- 同一学習者内で、すでに登録済みの `VocabularyExpression` かを判定する
+## Top-Level Responsibilities
 
-## Explanation generation
+### Presentation
 
-- `VocabularyExpression` から解説を生成する
-- 完了時は `Explanation` とその配下の `Sense` を返す
-- 生成には指定の AI サービスを利用する
-- 完了時のみ解説 payload を返す
+#### `UI`
 
-## Explanation reader
+- `VocabularyExpression` 登録入力を扱う
+- 完了済み `Explanation` と完了済み `VisualImage` を表示する
+- 生成中または失敗中は状態のみを表示する
+- `Explanation.currentImage` の単一参照に従って表示する
+- workflow 実行、vendor API 呼び出し、auth account lifecycle は扱わない
 
-- `VocabularyExpression.currentExplanation` に対応する完了済み解説を取得する
-- 必要に応じて解説履歴を取得する
+### Actor/Auth Boundary
 
-## Image generation
+#### `Learner Identity Resolution`
 
-- 完了済み `Explanation` から英語表現を視覚的に理解できる画像を生成する
-- 必要に応じて特定の `Sense` を描写対象として受け付ける
-- 完了時のみ画像 payload を返す
-- `Explanation.currentImage` は単一参照のまま維持し、複数 current image は後続 scope とする
+- 外部 identity から `Learner` 参照へ正規化する
+- provider sign-in、session issuance、token verification は扱わない
 
-## Asset storage
+#### `Actor Session Handoff`
 
-- 生成した画像を何らかのストレージサービスに永続化する
-- ストレージ上で画像を一意に識別する情報と再取得参照を返す
-- 必要に応じて explanation 全体画像か `Sense` 対応画像かを metadata で区別できる
+- auth/session 境界の completed output を command / query 向け actor reference へ handoff する
+- raw token、provider credential、domain aggregate mutation は扱わない
 
-## Pronunciation media
+### Command Intake
 
-- 発音サンプルを参照可能な形で返す
+#### `Vocabulary Expression Registration Intake`
+
+- 登録要求受理の起点を担う
+- completed result 読み取りと workflow 実行本体は扱わない
+
+#### `Vocabulary Expression Validation Policy`
+
+- `VocabularyExpressionText` の正規化と validation orchestration を担う
+- vendor lexicon API への直接接続は扱わない
+
+#### `Registration Lookup`
+
+- 同一学習者内の duplicate registration check を担う
+- auth/session detail と completed explanation / image の読み取りは扱わない
+
+#### `Explanation Generation Request Intake`
+
+- 解説生成要求の受理を担う
+- provider 呼び出し本体は扱わない
+
+#### `Image Generation Request Intake`
+
+- 完了済み `Explanation` と optional `Sense` を前提に画像生成要求を受理する
+- provider 呼び出し本体と asset 保存本体は扱わない
+
+### Query Read
+
+#### `Explanation Reader`
+
+- completed `Explanation` と履歴取得を担う
+- workflow 起動と provider 呼び出しは扱わない
+
+#### `Visual Image Reader`
+
+- completed `VisualImage` と `Explanation.currentImage` 解決を担う
+- asset 永続化と workflow 起動は扱わない
+
+#### `Generation Status Reader`
+
+- explanation / image generation status の取得を担う
+- incomplete payload の公開は行わない
+
+#### `Pronunciation Media Reader`
+
+- 発音サンプル参照の app-facing read を担う
+- media source 直結と credential 管理は扱わない
+
+### Async Generation
+
+#### `Explanation Generation Workflow`
+
+- `VocabularyExpression` から completed `Explanation` と `Sense` を生成する長時間処理を担う
+- request acceptance、UI 表示、completed result の read API は扱わない
+
+#### `Image Generation Workflow`
+
+- completed `Explanation` と optional `Sense` から `VisualImage` を生成し、必要な storage handoff を行う長時間処理を担う
+- request acceptance、UI 表示、asset access 解決は扱わない
+
+### External Adapters
+
+#### `Vocabulary Expression Validation Adapter`
+
+- 英語表現存在確認の外部接続を担う
+- validation policy の最終判断は持たない
+
+#### `Explanation Generation Provider Adapter`
+
+- explanation provider との接続を担う
+- request acceptance と read-side 表示は扱わない
+
+#### `Image Generation Provider Adapter`
+
+- image provider との接続を担う
+- request acceptance と completed image 表示は扱わない
+
+#### `Asset Storage Adapter`
+
+- 画像保存と stable asset reference 発行を担う
+- user-facing image read は扱わない
+
+#### `Asset Access Adapter`
+
+- stored asset の再取得参照解決を担う
+- asset 永続化判断と workflow 起動は扱わない
+
+#### `Pronunciation Media Adapter`
+
+- media source から音声参照を取得する
+- reader の app-facing contract 定義は扱わない
+
+## 主要フロー
+
+### `VocabularyExpression` 登録
+
+- `Actor Session Handoff`
+- `Vocabulary Expression Registration Intake`
+- `Vocabulary Expression Validation Policy`
+- `Vocabulary Expression Validation Adapter`
+- `Registration Lookup`
+- `Generation Status Reader` または `Explanation Reader`
+
+### 完了済み `Explanation` 閲覧
+
+- `Actor Session Handoff`
+- `Explanation Reader`
+- `Generation Status Reader`
+- `Pronunciation Media Reader`
+- `Pronunciation Media Adapter`
+
+### 画像生成
+
+- `Actor Session Handoff`
+- `Image Generation Request Intake`
+- `Image Generation Workflow`
+- `Image Generation Provider Adapter`
+- `Asset Storage Adapter`
+- `Visual Image Reader`
+- `Asset Access Adapter`
+- `Generation Status Reader`
+
+## 依存方向ルール
+
+- `Presentation` は `Async Generation` を直接起動してはならず、`Command Intake` または `Query Read` を経由する
+- `Command Intake` は completed payload を返す reader を内包してはならない
+- `Query Read` は workflow 起動や retry dispatch を own してはならない
+- `Async Generation` は incomplete payload を user-facing contract として返してはならない
+- `External Adapters` は最終的な受理判断や表示判断を持ってはならない
 
 ## Deferred Scope
 
-- 認証、account lifecycle、session 管理は auth/session 設計で扱う
-- command 受理、retry / regenerate の dispatch、workflow orchestration は backend command 設計で扱う
-- query model、永続化実装、ベンダー固有 adapter はこの ADR の対象外とする
-- 複数 current image の同時公開、meaning gallery、`Explanation` 直下の裸画像配列は follow-on scope とする
+- auth account lifecycle、provider sign-in、session invalidation detail は `specs/008-auth-session-design/` を正本とする
+- command acceptance semantics、retry / regenerate、dispatch failure、workflow start rule は `specs/007-backend-command-design/` を正本とする
+- query model schema / persistence implementation は後続 feature を正本とする
+- vendor-specific adapter implementation は後続実装で具体化する
+- multiple current image / meaning gallery は follow-on scope とし、現時点では単一 `Explanation.currentImage` 前提を維持する

--- a/docs/external/adr.md
+++ b/docs/external/adr.md
@@ -183,3 +183,76 @@
 - query model schema / persistence implementation は後続 feature を正本とする
 - vendor-specific adapter implementation は後続実装で具体化する
 - multiple current image / meaning gallery は follow-on scope とし、現時点では単一 `Explanation.currentImage` 前提を維持する
+
+## サブスクリプションコンポーネント
+
+### Top-Level Responsibilities
+
+#### `Presentation`
+
+- `Subscription Paywall UI` は購入導線、upsell、purchase pending の状態表示を担う
+- `Subscription Status UI` は subscription state、entitlement、usage allowance の表示を担う
+- `Presentation` は authoritative subscription state を保持せず、同期済み mirror だけを参照する
+
+#### `Actor/Auth Boundary`
+
+- `Actor Session Handoff` は auth/session 境界の completed output を subscription 判定用 actor reference へ handoff する
+- auth lifecycle、token verification、session invalidation detail は 008 の正本を再定義しない
+
+#### `Command Intake`
+
+- `Purchase Result Intake` は storefront 完了後の purchase artifact 提出受付を担う
+- `Restore Purchase Intake` は restore 要求の受理を担う
+- `Subscription Status Refresh Intake` は manual refresh と cross-device 再同期の起点を担う
+- `Command Intake` は premium unlock の最終確定を持たない
+
+#### `Query Read`
+
+- `Subscription Status Reader` は authoritative subscription state の app-facing read を担う
+- `Entitlement Reader` は synced entitlement mirror を返す
+- `Usage Allowance Reader` は quota 状態を返す
+- `Subscription Feature Gate Reader` は feature gate result を返す
+
+#### `Async Subscription Reconciliation`
+
+- `Purchase Verification Workflow` は purchase artifact の照合と state 更新を担う
+- `Store Notification Reconciliation Workflow` は store notification による state / entitlement 再計算を担う
+- reconciliation workflow は UI 表示責務を持たない
+
+#### `External Adapters`
+
+- `Mobile Storefront Adapter` は App Store / Google Play などの購入接続を担う
+- `Purchase Verification Adapter` は receipt / token 検証接続を担う
+- `Store Notification Adapter` は store notification の受信と正規化を担う
+- `External Adapters` は entitlement policy や unlock 判定を最終決定してはならない
+
+### Inner Policy Components
+
+- `Entitlement Policy` は authoritative subscription state と plan から entitlement を導出する
+- `Subscription Feature Gate` は entitlement と feature key から allow / limited / deny を決定する
+- `Usage Metering / Quota Gate` は利用回数、無料枠、期間上限を評価する
+- entitlement の付与と quota 消費判定は同じ責務へ潰してはならない
+
+### Authority And State Rules
+
+- 課金状態の最終正本は backend authoritative subscription state が持つ
+- app core と UI は authoritative backend source から同期済みの entitlement mirror だけを参照する
+- authoritative subscription state は `active`、`grace`、`expired`、`pending-sync`、`revoked` を区別する
+- `grace` は通常の paid entitlement を維持する
+- `pending-sync` は状態表示してよいが premium unlock の根拠にしてはならない
+- purchase state は `initiated`、`submitted`、`verifying`、`verified`、`rejected` を区別し、subscription state と混同しない
+- `verified` 以前の purchase state は premium unlock の根拠にしてはならない
+
+### Reconciliation And Resilience Rules
+
+- purchase / restore / refresh は command intake を起点とし、verification / notification 反映は async reconciliation で扱う
+- `Mobile Storefront Adapter` の timeout では purchase state を `initiated` または `submitted` のまま保持し、retry 導線だけを返す
+- `Purchase Verification Adapter` の timeout では purchase state を `verifying` に留め、authoritative subscription state を新規 paid へ進めない
+- `Store Notification Adapter` の障害では既存 mirror を維持してよいが、新しい paid entitlement を付与してはならない
+
+### Deferred Scope
+
+- pricing catalog、tax、refund policy、store-specific dashboard setup は mobile storefront / business policy / operational policy を正本とする
+- vendor SDK detail は後続実装で具体化する
+- protected feature の command semantics は `specs/007-backend-command-design/` を正本とする
+- auth / account / session lifecycle は `specs/008-auth-session-design/` を正本とする

--- a/docs/external/requirements.md
+++ b/docs/external/requirements.md
@@ -36,6 +36,14 @@
 - query model、永続化実装、外部 vendor adapter 実装は別 feature とする
 - 複数 current image の同時公開や meaning gallery は後続 feature で扱う
 
+## 設計正本メモ
+
+- コンポーネント境界、top-level responsibility、canonical component catalog の正本は `docs/external/adr.md` の「コンポーネント」節とする
+- domain terminology の正本は `docs/internal/domain/*.md` とし、component 定義はそれらの意味論を変更しない
+- auth/session の責務境界と actor handoff の behavioral contract は `specs/008-auth-session-design/` を正本とする
+- command 受理、retry / regenerate、dispatch rule の behavioral contract は `specs/007-backend-command-design/` を正本とする
+- query model schema / persistence と vendor-specific adapter 実装は後続 feature の正本へ委ねる
+
 ## 開発基盤メモ
 
 - 開発時の host baseline、CI runner 境界、version governance は `docs/development/*.md` と `tooling/versions/approved-components.md` を正とする

--- a/docs/external/requirements.md
+++ b/docs/external/requirements.md
@@ -39,10 +39,14 @@
 ## 設計正本メモ
 
 - コンポーネント境界、top-level responsibility、canonical component catalog の正本は `docs/external/adr.md` の「コンポーネント」節とする
+- サブスクリプション境界、authoritative subscription state、purchase state、entitlement、feature gate、quota gate の正本は `docs/external/adr.md` の「サブスクリプションコンポーネント」節と `specs/010-subscription-component-boundaries/` とする
 - domain terminology の正本は `docs/internal/domain/*.md` とし、component 定義はそれらの意味論を変更しない
 - auth/session の責務境界と actor handoff の behavioral contract は `specs/008-auth-session-design/` を正本とする
 - command 受理、retry / regenerate、dispatch rule の behavioral contract は `specs/007-backend-command-design/` を正本とする
 - query model schema / persistence と vendor-specific adapter 実装は後続 feature の正本へ委ねる
+- 課金状態の最終正本は backend authoritative subscription state とし、app core と UI は同期済み entitlement mirror のみを参照する
+- purchase / restore の受付状態は `initiated`、`submitted`、`verifying`、`verified`、`rejected` の canonical purchase state model に従い、`verified` になるまで premium unlock の根拠にしない
+- pricing catalog、tax、refund policy、vendor SDK detail は subscription component boundary の対象外とし、mobile storefront または後続実装を正本とする
 
 ## 開発基盤メモ
 

--- a/references/vocalibrary/src/.prettierignore
+++ b/references/vocalibrary/src/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+coverage
+package-lock.json

--- a/specs/009-component-boundaries/checklists/requirements.md
+++ b/specs/009-component-boundaries/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: 機能別コンポーネント定義
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- チェック時点で未解決の clarification はありません。現行コンポーネント一覧の責務棚卸し、境界分離、deferred scope 明示を docs-first feature として計画可能です。

--- a/specs/009-component-boundaries/contracts/actor-boundary-contract.md
+++ b/specs/009-component-boundaries/contracts/actor-boundary-contract.md
@@ -1,0 +1,35 @@
+# Contract: Actor Boundary
+
+## Purpose
+
+`Actor/Auth Boundary` の component を定義し、auth/session 設計と product 内 component catalog の接続点を固定する。
+
+## Boundary Components
+
+| Component | Owns | Must Not Own | Source of Truth |
+|-----------|------|--------------|-----------------|
+| `Learner Identity Resolution` | verified actor / identity から `Learner` 参照へ解決する | provider sign-in、session issuance、token verification | 009 component taxonomy + `docs/internal/domain/learner.md` |
+| `Actor Session Handoff` | auth/session 境界の completed output を command/query 向け actor reference へ handoff する | raw token 保持、provider credential 管理、domain aggregate mutation | 009 component taxonomy + `specs/008-auth-session-design/` |
+
+## Boundary Rules
+
+- `Learner Identity Resolution` は auth/session の内部状態を再実装してはならない
+- `Actor Session Handoff` が app core 側へ渡してよいのは、正規化済み actor reference と最小限の利用可否状態だけである
+- `Presentation`、`Command Intake`、`Query Read`、`Async Generation` は Firebase token、provider token、password、session store detail を直接受け取ってはならない
+- auth/session implementation detail は `specs/008-auth-session-design/` を正本とし、009 では boundary placement だけを記述する
+
+## Handoff Relationships
+
+| Upstream | Boundary Component | Downstream |
+|----------|--------------------|------------|
+| auth/session completed result | `Actor Session Handoff` | `Command Intake`, `Query Read` |
+| verified actor / identity reference | `Learner Identity Resolution` | `Command Intake`, `Query Read`, `Async Generation` |
+
+## Deferred Areas
+
+- provider availability policy
+- account registration / login / logout contract
+- session invalidation semantics
+- Firebase Authentication specific verification rules
+
+These areas are deferred to `specs/008-auth-session-design/`.

--- a/specs/009-component-boundaries/contracts/architecture-topology-contract.md
+++ b/specs/009-component-boundaries/contracts/architecture-topology-contract.md
@@ -1,0 +1,38 @@
+# Contract: Architecture Topology
+
+## Purpose
+
+component boundary 定義における主軸アーキテクチャ、内側基盤、top-level 責務、依存方向を固定する。
+
+## Inner Foundation Layers
+
+| Layer | Owns | Must Not Own | Depends On |
+|-------|------|--------------|------------|
+| `Domain Core` | `Learner`、`VocabularyExpression`、`LearningState`、`Explanation`、`VisualImage`、`Sense` の用語と不変条件 | UI、auth/session detail、vendor API | none |
+| `Application Coordination` | domain を使った use-case 協調、boundary ごとの依存規則 | top-level catalog の代替表現、vendor 固有 credential | `Domain Core`、port contracts |
+
+## Top-Level Responsibilities
+
+| Responsibility | Owns | Must Not Own | Depends On |
+|----------------|------|--------------|------------|
+| `Presentation` | user input、completed result 表示、status 表示 | workflow 実行、vendor API、auth account lifecycle | `Actor/Auth Boundary`、`Command Intake`、`Query Read` |
+| `Actor/Auth Boundary` | `Learner` 解決、actor handoff | auth/session 実装全体、domain aggregate 更新 | `Application Coordination`、auth/session outputs |
+| `Command Intake` | request acceptance、validation orchestration、duplicate lookup | completed result read、workflow 本体、UI rendering | `Application Coordination`、`External Adapters` |
+| `Query Read` | completed result / history / status read | request acceptance、workflow orchestration | `Application Coordination`、`External Adapters` |
+| `Async Generation` | long-running workflow execution | direct UI rendering、raw auth handling、request acceptance | `Application Coordination`、`External Adapters` |
+| `External Adapters` | validation / generation / storage / media との接続 | domain 判断、UI interaction、component allocation の最終判断 | external services only |
+
+## Dependency Rules
+
+- `Presentation` は `Async Generation` を直接起動してはならず、`Command Intake` または `Query Read` を経由しなければならない
+- `Actor/Auth Boundary` は auth/session 境界の出力を正規化してよいが、token verification や provider policy 自体を再定義してはならない
+- `Command Intake` は `Query Read` の completed result contract を内包してはならない
+- `Query Read` は workflow 起動や retry dispatch を own してはならない
+- `Async Generation` は incomplete payload を user-facing contract として返してはならない
+- `External Adapters` は top-level responsibility として単独で存在するが、最終的な受理判断や表示判断は持ってはならない
+
+## Architecture Style Rule
+
+- 主軸はオニオンアーキテクチャであり、top-level 責務は外から見える component catalog である
+- `Domain Core` と `Application Coordination` は foundation layer として明示するが、現行 component の割り当て先としては使わない
+- `auth/session` は outer boundary として 009 から分離し、境界の利用点だけを `Actor/Auth Boundary` に表す

--- a/specs/009-component-boundaries/contracts/async-generation-boundary-contract.md
+++ b/specs/009-component-boundaries/contracts/async-generation-boundary-contract.md
@@ -1,0 +1,45 @@
+# Contract: Async Generation Boundary
+
+## Purpose
+
+`Explanation generation` と `Image generation` の long-running workflow を、request acceptance、workflow execution、result reading、adapter connection に分離して固定する。
+
+## Explanation Flow Boundary
+
+| Concern | Component | Responsibility |
+|---------|-----------|----------------|
+| request acceptance | `Explanation Generation Request Intake` | 解説生成要求を受け付け、workflow 起動要求へ変換する |
+| workflow execution | `Explanation Generation Workflow` | `VocabularyExpression` から completed `Explanation` / `Sense` を生成する |
+| provider connection | `Explanation Generation Provider Adapter` | explanation provider との接続を担う |
+| completed result read | `Explanation Reader` | completed `Explanation` と履歴を返す |
+| status read | `Generation Status Reader` | `pending` / `running` / `succeeded` / `failed` を返す |
+
+## Image Flow Boundary
+
+| Concern | Component | Responsibility |
+|---------|-----------|----------------|
+| request acceptance | `Image Generation Request Intake` | completed `Explanation` と optional `Sense` を前提に画像生成要求を受け付ける |
+| workflow execution | `Image Generation Workflow` | completed `Explanation` から `VisualImage` を生成し、必要な storage handoff を行う |
+| provider connection | `Image Generation Provider Adapter` | image provider との接続を担う |
+| asset persist | `Asset Storage Adapter` | 画像保存と stable asset reference 発行を担う |
+| asset access | `Asset Access Adapter` | stored asset の read reference 解決を担う |
+| completed result read | `Visual Image Reader` | completed `VisualImage` と `Explanation.currentImage` 解決を返す |
+| status read | `Generation Status Reader` | image generation status を返す |
+
+## Workflow Rules
+
+- `Explanation Generation Workflow` と `Image Generation Workflow` は別 component として定義しなければならない
+- `Async Generation` 配下の component は UI と直接通信してはならず、completed result の user-facing return を own してはならない
+- incomplete generated result は workflow 内部状態としてのみ存在し、user-facing read contract へ現れてはならない
+- `Generation Status Reader` は status を返してよいが、incomplete explanation payload や incomplete image payload を返してはならない
+
+## Optional Sense Rule
+
+- `Image Generation Request Intake` は optional `Sense` 指定を受け付けてよい
+- `Image Generation Workflow` は `Sense` 指定がある場合でも completed `Explanation` を前提に動かなければならない
+- `Explanation Generation Workflow` は `Sense` を completed output の一部として返してよいが、`Image Generation Workflow` の existence を前提にしてはならない
+
+## Visibility Rule
+
+- `Presentation` が参照してよいのは `Explanation Reader`、`Visual Image Reader`、`Generation Status Reader` の contract のみである
+- `Async Generation` 配下の component 名を UI state の代替概念として使ってはならない

--- a/specs/009-component-boundaries/contracts/component-allocation-contract.md
+++ b/specs/009-component-boundaries/contracts/component-allocation-contract.md
@@ -1,0 +1,42 @@
+# Contract: Component Allocation
+
+## Purpose
+
+現行のフラットな component 一覧を canonical component catalog へ割り当て、keep / split / add / defer を固定する。
+
+## Current-to-Canonical Mapping
+
+| Current Item | Canonical Component(s) | Top-Level Responsibility | Action | Notes |
+|--------------|------------------------|--------------------------|--------|-------|
+| `UI` | `UI` | `Presentation` | keep | completed `Explanation` / `VisualImage` と status の表示だけを担う |
+| `Learner identity resolution` | `Learner Identity Resolution` | `Actor/Auth Boundary` | narrow | auth/session 実装詳細を除外し、`Learner` 解決だけへ責務を絞る |
+| _(missing)_ | `Actor Session Handoff` | `Actor/Auth Boundary` | add | auth/session 境界の出力を product 内へ渡す明示 component を追加する |
+| `VocabularyExpression validation` | `Vocabulary Expression Validation Policy` + `Vocabulary Expression Validation Adapter` | `Command Intake` + `External Adapters` | split | normalization / policy と external lexicon check を分離する |
+| `Registration lookup` | `Registration Lookup` | `Command Intake` | keep | 同一学習者内の duplicate registration check を担う |
+| _(missing)_ | `Vocabulary Expression Registration Intake` | `Command Intake` | add | 登録要求受理の起点を明示する |
+| `Explanation generation` | `Explanation Generation Request Intake` + `Explanation Generation Workflow` + `Explanation Generation Provider Adapter` | `Command Intake` + `Async Generation` + `External Adapters` | split | request acceptance、workflow、provider call を分離する |
+| `Explanation reader` | `Explanation Reader` + `Generation Status Reader` | `Query Read` | split | completed result / history read と status read を分離する |
+| `Image generation` | `Image Generation Request Intake` + `Image Generation Workflow` + `Image Generation Provider Adapter` | `Command Intake` + `Async Generation` + `External Adapters` | split | optional `Sense` 指定を受理しつつ workflow は別 component とする |
+| _(missing)_ | `Visual Image Reader` | `Query Read` | add | completed `VisualImage` と current image 解決を reader として明示する |
+| `Asset storage` | `Asset Storage Adapter` + `Asset Access Adapter` | `External Adapters` | split | asset persist と access/reference resolution を分離する |
+| `Pronunciation media` | `Pronunciation Media Reader` + `Pronunciation Media Adapter` | `Query Read` + `External Adapters` | split | app-facing read と external media fetch を分離する |
+
+## Allocation Rules
+
+- 現行の 1 項目が request acceptance / workflow / read / adapter を跨ぐ場合、single component のまま残してはならない
+- `Command Intake` に属する component は completed payload を返す reader として扱ってはならない
+- `Query Read` に属する component は workflow 起動や duplicate lookup を担ってはならない
+- `External Adapters` に属する component は user-facing contract 名で current list に現れていても、必要に応じて app-facing reader と分離しなければならない
+
+## New Components Added By This Feature
+
+- `Actor Session Handoff`
+- `Vocabulary Expression Registration Intake`
+- `Visual Image Reader`
+- `Generation Status Reader`
+- `Asset Access Adapter`
+
+## Explicit Non-Allocations
+
+- auth account lifecycle、provider sign-in、session invalidation detail は `specs/008-auth-session-design/` の責務であり、009 の canonical component としては保持しない
+- retry / regenerate semantics、dispatch failure、workflow start rule は `specs/007-backend-command-design/` の責務であり、009 では component placement だけを定義する

--- a/specs/009-component-boundaries/contracts/deferred-scope-contract.md
+++ b/specs/009-component-boundaries/contracts/deferred-scope-contract.md
@@ -1,0 +1,30 @@
+# Contract: Deferred Scope
+
+## Purpose
+
+この feature が ownership を持つ component definition と、別 feature が正本を持つ責務を切り分ける。
+
+## Ownership Matrix
+
+| Concern | Owned By 009? | Authoritative Source | Notes |
+|---------|---------------|----------------------|-------|
+| top-level responsibility taxonomy | Yes | `specs/009-component-boundaries/` | 6 つの top-level 責務と内側基盤の表現を定義する |
+| current-list to canonical allocation | Yes | `specs/009-component-boundaries/` | keep / split / add / defer を定義する |
+| auth/session implementation detail | No | `specs/008-auth-session-design/` | 009 は `Actor/Auth Boundary` の配置だけを扱う |
+| command acceptance semantics | No | `specs/007-backend-command-design/` | 009 は `Command Intake` の placement だけを扱う |
+| retry / regenerate / dispatch rules | No | `specs/007-backend-command-design/` | async workflow の意味論は 007 側が正本 |
+| query model schema / persistence | No | future query feature, `docs/external/adr.md` | 009 は `Query Read` component の存在だけを定義する |
+| vendor-specific adapter implementation | No | future implementation | 009 は adapter boundary のみ定義する |
+| multiple current image / meaning gallery | No | follow-on scope | 009 は単一 `Explanation.currentImage` 前提を維持する |
+
+## Scope Rules
+
+- 009 は component placement と dependency direction を定義してよいが、既存 feature の behavioral contract を上書きしてはならない
+- deferred concern を current component catalog へ取り込む場合は、対応する正本 feature の更新を伴わなければならない
+- `docs/external/adr.md` 更新時も、007 / 008 / domain docs の責務境界と矛盾してはならない
+
+## Follow-On Items
+
+- query model 実装 feature で `Query Read` 配下の storage / schema / projection detail を具体化する
+- implementation feature で `External Adapters` 配下の vendor-specific SDK / API choice を具体化する
+- follow-on image feature で multiple current image / gallery 化を検討する場合は、009 の single-current 前提を明示的に更新する

--- a/specs/009-component-boundaries/data-model.md
+++ b/specs/009-component-boundaries/data-model.md
@@ -1,0 +1,265 @@
+# Data Model: 機能別コンポーネント定義
+
+## Component Boundary Overview
+
+```mermaid
+classDiagram
+    class InternalFoundationLayer {
+        <<Foundation>>
+        +InternalFoundationLayerName name
+        +string purpose
+    }
+
+    class TopLevelResponsibility {
+        <<BoundaryGroup>>
+        +TopLevelResponsibilityName name
+        +string purpose
+    }
+
+    class ComponentDefinition {
+        <<DesignEntity>>
+        +string name
+        +TopLevelResponsibilityName responsibility
+        +string primaryInputs
+        +string primaryOutputs
+        +string owns
+        +string mustNotOwn
+    }
+
+    class FlowAssignment {
+        <<DesignEntity>>
+        +string flowName
+        +string actorBoundaryStep
+        +string commandStep
+        +string readStep
+        +string workflowStep
+    }
+
+    class DeferredScopeItem {
+        <<DesignEntity>>
+        +string concern
+        +string sourceOfTruth
+        +string reason
+    }
+
+    TopLevelResponsibility --> "1..*" ComponentDefinition : groups
+    FlowAssignment --> "1..*" ComponentDefinition : references
+```
+
+## Foundation Layer: Domain Core
+
+**Purpose**: `Learner`、`VocabularyExpression`、`LearningState`、`Explanation`、
+`VisualImage`、`Sense` など、既存の domain language と不変条件を保持する内側基盤。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| name | InternalFoundationLayerName | 1 | `domain-core` |
+| purpose | string | 1 | 用語、不変条件、識別子命名、学習概念の境界維持 |
+
+**Validation rules**:
+
+- UI、auth/session、vendor adapter の詳細を直接保持してはならない
+- component taxonomy の都合で frequency / sophistication / proficiency などの概念を統合してはならない
+
+## Foundation Layer: Application Coordination
+
+**Purpose**: domain を使って command intake、query read、async workflow、actor handoff を
+つなぐ内側基盤。top-level 責務一覧とは別枠で、依存方向の基準だけを提供する。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| name | InternalFoundationLayerName | 1 | `application-coordination` |
+| purpose | string | 1 | domain core と outer boundary / adapter の接続規則を保持する |
+
+**Validation rules**:
+
+- top-level responsibility の代替カテゴリとして使ってはならない
+- workflow orchestration や actor handoff の存在を説明しても、vendor 固有 API や token detail を公開してはならない
+
+## Entity: TopLevelResponsibility
+
+**Purpose**: 外から見える component catalog の最上位分類を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| name | TopLevelResponsibilityName | 1 | `Presentation` などの分類名 |
+| purpose | string | 1 | その分類が何を担うか |
+
+**Validation rules**:
+
+- すべての component はちょうど 1 つの top-level responsibility に属さなければならない
+- `Domain Core` と `Application Coordination` は top-level responsibility として扱ってはならない
+
+## Entity: ComponentDefinition
+
+**Purpose**: 1 つの component の名前、所属責務、入出力、ownership、非責務を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| name | string | 1 | canonical component 名 |
+| responsibility | TopLevelResponsibilityName | 1 | 所属する top-level responsibility |
+| primaryInputs | string | 1 | 主要入力 |
+| primaryOutputs | string | 1 | 主要出力 |
+| owns | string | 1 | この component が主責務として持つもの |
+| mustNotOwn | string | 1 | 持ってはいけない責務 |
+
+**Validation rules**:
+
+- `ComponentDefinition` は top-level responsibility をまたいではならない
+- `Async Generation` 配下の component は request acceptance や direct UI rendering を own してはならない
+- `External Adapters` 配下の component は domain や UI の判断責務を own してはならない
+
+## Entity: FlowAssignment
+
+**Purpose**: 主要 user flow に対して、どの component がどの工程を担うかを示す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| flowName | string | 1 | 例: register vocabulary / read explanation / generate image |
+| actorBoundaryStep | string | 0..1 | actor/auth boundary が関与する工程 |
+| commandStep | string | 0..1 | request acceptance / validation / lookup の工程 |
+| readStep | string | 0..1 | completed result / status / history の取得工程 |
+| workflowStep | string | 0..1 | 長時間 workflow の工程 |
+
+**Validation rules**:
+
+- completed result の read は `Query Read` component でなければならない
+- long-running execution を伴う工程は `Async Generation` component へ割り当てなければならない
+- auth/session 詳細を要する工程は `Actor/Auth Boundary` から先へ raw token を渡してはならない
+
+## Entity: DeferredScopeItem
+
+**Purpose**: この feature が ownership を持たない責務と、その正本を示す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| concern | string | 1 | deferred concern 名 |
+| sourceOfTruth | string | 1 | 正本となる feature または文書 |
+| reason | string | 1 | この feature で実装・再定義しない理由 |
+
+**Validation rules**:
+
+- deferred とした責務は、対応する source-of-truth を必ず持たなければならない
+- in-scope component definition と deferred scope が同じ責務を二重定義してはならない
+
+## Canonical Top-Level Responsibilities
+
+| Responsibility | Purpose |
+|----------------|---------|
+| `Presentation` | ユーザー入力、completed result 表示、状態表示、interaction の起点を担う |
+| `Actor/Auth Boundary` | auth/session 境界の出力を product 内へ正規化し、`Learner` 解決と actor handoff を担う |
+| `Command Intake` | request acceptance、validation orchestration、duplicate lookup、workflow 起動要求の受付を担う |
+| `Query Read` | completed result、履歴、status を取得し、presentation へ返す |
+| `Async Generation` | long-running explanation / image workflow 実行を担う |
+| `External Adapters` | validation、generation provider、asset storage/access、media access など外部依存接続を担う |
+
+## Canonical Component Catalog
+
+### Presentation
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `UI` | `VocabularyExpression` 登録入力、completed `Explanation` / `VisualImage` 表示、status 表示 | auth account lifecycle、workflow 実行、vendor API 呼び出し |
+
+### Actor/Auth Boundary
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Learner Identity Resolution` | 外部 identity から `Learner` 参照へ正規化する | 認証そのもの、session lifecycle 全体、query / workflow 実装 |
+| `Actor Session Handoff` | auth/session 境界の結果を command/query 向け actor reference へ handoff する | token verification、provider credential 保持、学習データ更新 |
+
+### Command Intake
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Vocabulary Expression Registration Intake` | 登録要求受理の起点 | completed result 読み取り、workflow 実行本体 |
+| `Vocabulary Expression Validation Policy` | 正規化と validation orchestration | vendor lexicon API 直結、UI rendering |
+| `Registration Lookup` | 同一学習者内の重複確認 | auth/session、completed explanation/image 読み取り |
+| `Explanation Generation Request Intake` | 解説生成要求受理 | explanation provider 呼び出し本体 |
+| `Image Generation Request Intake` | 画像生成要求受理、optional `Sense` 入力の受理 | image provider 呼び出し本体、asset 保存本体 |
+
+### Query Read
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Explanation Reader` | completed `Explanation` と履歴取得 | workflow 起動、provider 呼び出し |
+| `Visual Image Reader` | completed `VisualImage` と current image 解決 | asset 永続化、workflow 起動 |
+| `Generation Status Reader` | explanation/image generation status の取得 | incomplete payload の公開 |
+| `Pronunciation Media Reader` | 発音サンプル参照要求の app-facing read | media source 直結、credential 管理 |
+
+### Async Generation
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Explanation Generation Workflow` | `VocabularyExpression` から `Explanation` / `Sense` を生成する長時間処理 | request acceptance、UI 表示、completed result 読み出し API |
+| `Image Generation Workflow` | completed `Explanation` と optional `Sense` から `VisualImage` を生成・保存する長時間処理 | request acceptance、UI 表示、asset access 解決 |
+
+### External Adapters
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Vocabulary Expression Validation Adapter` | 英語表現存在確認の外部接続 | validation policy の最終判断 |
+| `Explanation Generation Provider Adapter` | explanation provider との接続 | request acceptance、read-side 表示 |
+| `Image Generation Provider Adapter` | image provider との接続 | request acceptance、completed image 表示 |
+| `Asset Storage Adapter` | 画像保存と stable reference 発行 | user-facing image read |
+| `Asset Access Adapter` | stored image の再取得参照解決 | asset 永続化判断、workflow 起動 |
+| `Pronunciation Media Adapter` | media source から音声参照を取得 | reader の app-facing contract 定義 |
+
+## Flow Assignments
+
+### Flow: Register Vocabulary Expression
+
+| Step | Component |
+|------|-----------|
+| actor handoff | `Actor Session Handoff` |
+| request acceptance | `Vocabulary Expression Registration Intake` |
+| normalization / validation | `Vocabulary Expression Validation Policy` + `Vocabulary Expression Validation Adapter` |
+| duplicate lookup | `Registration Lookup` |
+| status / current result read | `Generation Status Reader` または `Explanation Reader` |
+
+### Flow: Read Completed Explanation
+
+| Step | Component |
+|------|-----------|
+| actor handoff | `Actor Session Handoff` |
+| completed explanation read | `Explanation Reader` |
+| status fallback | `Generation Status Reader` |
+| pronunciation access | `Pronunciation Media Reader` + `Pronunciation Media Adapter` |
+
+### Flow: Generate Image
+
+| Step | Component |
+|------|-----------|
+| actor handoff | `Actor Session Handoff` |
+| request acceptance | `Image Generation Request Intake` |
+| workflow execution | `Image Generation Workflow` |
+| provider call | `Image Generation Provider Adapter` |
+| asset persist | `Asset Storage Adapter` |
+| completed image read | `Visual Image Reader` + `Asset Access Adapter` |
+| status read | `Generation Status Reader` |
+
+## Deferred Scope Items
+
+| Concern | Source of Truth | Reason |
+|---------|-----------------|--------|
+| auth/session implementation details | `specs/008-auth-session-design/` | 本 feature は actor/auth boundary の配置だけを扱い、credential、session lifecycle、provider policy の詳細は再定義しない |
+| command acceptance semantics、retry / regenerate、dispatch rules | `specs/007-backend-command-design/` | component taxonomy だけを扱い、mutation contract 自体は 007 の正本に従う |
+| query model schema / persistence implementation | future query feature, current `docs/external/adr.md` | query read component の存在を定義するが、具体 storage や schema は対象外 |
+| vendor-specific adapter implementation | future implementation | adapter の責務境界だけを定義し、SDK や API 詳細は後続実装に委ねる |
+| multiple current image / meaning gallery | follow-on scope | 009 では単一 `Explanation.currentImage` を前提にし、gallery 化は対象外 |
+
+## Enumerations
+
+### InternalFoundationLayerName
+
+- `domain-core`
+- `application-coordination`
+
+### TopLevelResponsibilityName
+
+- `presentation`
+- `actor-auth-boundary`
+- `command-intake`
+- `query-read`
+- `async-generation`
+- `external-adapters`

--- a/specs/009-component-boundaries/plan.md
+++ b/specs/009-component-boundaries/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: 機能別コンポーネント定義
+
+**Branch**: `010-component-boundaries` | **Date**: 2026-04-17 | **Spec**: [/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md)
+**Input**: Feature specification from `/specs/009-component-boundaries/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+vocastock の既存コンポーネント一覧を、フラットな機能名の列挙ではなく、オニオン
+アーキテクチャを主軸にした component boundary package へ再編する。内側の
+`Domain Core` と `Application Coordination` は top-level 責務一覧と分離した基盤として
+扱い、外側の top-level 責務は `Presentation`、`Actor/Auth Boundary`、
+`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` に固定する。
+`auth/session` は outer boundary として分離し、長時間処理である `Explanation generation`
+と `Image generation` は `Async Generation` 配下の別 workflow component として定義する。
+あわせて、現在の一覧に不足している `Actor Session Handoff`、`Visual Image Reader`、
+`Generation Status Reader`、`Asset Access Adapter` などを追加し、request acceptance /
+workflow orchestration / result reading / external adapter の責務差分を contract として
+固定したうえで、最終的な canonical topology と allocation を
+`/Users/lihs/workspace/vocastock/docs/external/adr.md` の「コンポーネント」節へ同期する。
+`/Users/lihs/workspace/vocastock/docs/external/requirements.md` は source-of-truth 参照導線の
+同期対象とし、`docs/internal/domain/*.md` は用語 cross-check のみを行い、domain semantics
+自体は変更しない。
+
+## Technical Context
+
+**Language/Version**: Markdown 1.x, YAML/JSON reference documents  
+**Primary Dependencies**: 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/vocabulary-expression.md`、`docs/internal/domain/learning-state.md`、`docs/internal/domain/explanation.md`、`docs/internal/domain/visual.md`、`docs/internal/domain/service.md`、`specs/003-architecture-design/`、`specs/004-tech-stack-definition/`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/`  
+**Storage**: Git-managed repository files、設計上で参照する抽象的な command state store、query read store、asset store、auth/session boundary outputs  
+**Testing**: spec / constitution / architecture の手動クロスレビュー、component allocation review、flow tracing review、deferred scope review、dependency direction review  
+**Target Platform**: Flutter client UI、GraphQL command/query entry、auth/session boundary handoff、非同期 explanation/image workflow、外部 validation / generation / storage / media adapter boundary  
+**Project Type**: documentation / architecture component design  
+**Performance Goals**: レビュー担当者が 5 分以内に top-level 責務 6 分類を説明できること、10 分以内に登録・解説閲覧・画像生成の 3 フローを component 単位で追跡できること、3 分以内に任意の変更要求を in-scope component または deferred scope へ割り当てられること  
+**Constraints**: product code は追加しない、主軸はオニオンアーキテクチャとする、`Domain Core` と `Application Coordination` は内側基盤として別枠で扱う、`auth/session` は outer boundary として分離する、`Explanation generation` と `Image generation` は別 workflow とする、未完了生成物を user-visible result として扱わない、vendor 固有詳細は external adapter の外へ漏らさない、既存の auth/session と backend command feature が持つ責務を再定義しない、識別子命名は憲章に従う、domain docs は terminology cross-check のみとし semantics を再定義しない  
+**Scale/Scope**: 6 つの top-level 責務、2 つの内側基盤レイヤ、12 から 16 の canonical component、3 つの主要 user flow、5 つの contract 文書に加え、`/Users/lihs/workspace/vocastock/docs/external/adr.md` の component 正本更新と `/Users/lihs/workspace/vocastock/docs/external/requirements.md` の source-of-truth 参照同期を含む docs-first の boundary design package を対象とする
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Domain impact is identified. 本 feature は `docs/internal/domain/*.md` を terminology source として cross-check するが、aggregate、value object、repository contract 自体は変更しない。コンポーネント境界のみを再編し、domain semantics は更新しない docs-first feature として扱う。
+- [x] Async generation flows keep lifecycle and visibility rules. `Explanation generation` と `Image generation` は request acceptance、workflow execution、result reading を分離し、完了済み結果以外を UI 公開しない前提で contract 化する。
+- [x] External dependencies remain behind ports/adapters. validation、generation provider、asset storage、asset access、pronunciation media は external adapter として整理し、domain や UI へ vendor detail を持ち込まない。
+- [x] User stories are independently reviewable. 現行一覧の棚卸し、責務分離、deferred scope の境界固定は、それぞれ別の成果物レビューで確認できる。
+- [x] 学習概念を混同しない。frequency、sophistication、proficiency、登録状態、解説生成状態、画像生成状態は component 定義によって統合せず、read-side と async workflow の責務分離でも区別を維持する。
+- [x] Identifier naming follows the constitution. 本 feature は新しい domain identifier を追加しないが、参照する既存用語と contract 名では `XxxIdentifier` / `identifier` / 概念名参照の規約を崩さない。
+
+Post-design re-check: PASS. Verified against `research.md`, `data-model.md`,
+`contracts/architecture-topology-contract.md`,
+`contracts/component-allocation-contract.md`,
+`contracts/actor-boundary-contract.md`,
+`contracts/async-generation-boundary-contract.md`, and
+`contracts/deferred-scope-contract.md`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-component-boundaries/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── actor-boundary-contract.md
+│   ├── architecture-topology-contract.md
+│   ├── async-generation-boundary-contract.md
+│   ├── component-allocation-contract.md
+│   └── deferred-scope-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+docs/
+├── development/
+│   ├── ci-policy.md
+│   ├── flutter-environment.md
+│   └── security-version-review.md
+├── external/
+│   ├── adr.md
+│   └── requirements.md
+└── internal/
+    └── domain/
+        ├── common.md
+        ├── explanation.md
+        ├── learner.md
+        ├── learning-state.md
+        ├── service.md
+        ├── visual.md
+        └── vocabulary-expression.md
+
+specs/
+├── 003-architecture-design/
+├── 004-tech-stack-definition/
+├── 007-backend-command-design/
+├── 008-auth-session-design/
+└── 009-component-boundaries/
+```
+
+**Structure Decision**: 最終的なプロダクト横断の component definition 正本は
+`docs/external/adr.md` の「コンポーネント」節とし、本 feature では
+`specs/009-component-boundaries/` を設計パッケージ兼レビュー導線として整備したうえで、
+確定した canonical topology と allocation を ADR へ同期する。併せて
+`docs/external/requirements.md` では component-boundary の source-of-truth 参照導線だけを
+更新する。用語の正本は `docs/internal/domain/*.md` に置き、`auth/session` の責務境界は
+`specs/008-auth-session-design/`、command intake と retry / dispatch semantics は
+`specs/007-backend-command-design/` を参照する。009 では、それらの既存正本を
+置き換えずに、component taxonomy、dependency direction、current-list allocation、
+deferred scope の整理と外部文書への同期だけを担う。domain docs は terminology
+cross-check の対象に留め、意味論は変更しない。
+
+## Complexity Tracking
+
+> No constitution violations requiring justification were identified.

--- a/specs/009-component-boundaries/quickstart.md
+++ b/specs/009-component-boundaries/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: 機能別コンポーネント定義
+
+## 1. アーキテクチャの主軸を確認する
+
+最初に [architecture-topology-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/architecture-topology-contract.md) を読み、オニオンアーキテクチャの内側基盤と、外から見える top-level 責務 6 分類を確認する。
+
+確認ポイント:
+
+- `Domain Core` と `Application Coordination` が top-level 一覧に混ざっていないこと
+- `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` の依存方向が明示されていること
+
+## 2. 現行一覧を canonical component へ割り当てる
+
+次に [component-allocation-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/component-allocation-contract.md) を読み、現行のフラット一覧を keep / rename / split / add のいずれかへ割り当てる。
+
+確認ポイント:
+
+- `Explanation generation` と `Image generation` が request intake / workflow / adapter に分割されていること
+- `Asset storage` と `Pronunciation media` が read-side と adapter-side に分離されていること
+- `Actor Session Handoff`、`Visual Image Reader`、`Generation Status Reader` が追加 component として定義されていること
+
+## 3. auth/session 境界を照合する
+
+[actor-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/actor-boundary-contract.md) を読み、`Actor/Auth Boundary` が `specs/008-auth-session-design/` と矛盾しないことを確認する。
+
+確認ポイント:
+
+- `Learner Identity Resolution` が auth/session 実装詳細を持っていないこと
+- `Actor Session Handoff` が app core へ raw token や provider credential を渡さないこと
+
+## 4. 非同期生成フローを確認する
+
+[async-generation-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/async-generation-boundary-contract.md) を読み、Explanation と Image の workflow が別 component であり、completed result の read-side が独立していることを確認する。
+
+確認ポイント:
+
+- `Explanation Generation Workflow` と `Image Generation Workflow` の依存 adapter が異なること
+- `Generation Status Reader` が incomplete payload を返さず、status のみを返すこと
+
+## 5. deferred scope を確認する
+
+最後に [deferred-scope-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/deferred-scope-contract.md) を読み、どこまでが本 feature の ownership で、どこから先が 007 / 008 など別 feature の正本かを確認する。
+
+確認ポイント:
+
+- auth/session 実装詳細は 008、command semantics は 007 を参照すること
+- query model 実装、vendor adapter 実装、multiple current image は 009 の対象外であること
+
+## Review Sequence
+
+1. [spec.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md)
+2. [plan.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md)
+3. [data-model.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md)
+4. [architecture-topology-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/architecture-topology-contract.md)
+5. [component-allocation-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/component-allocation-contract.md)
+6. [actor-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/actor-boundary-contract.md)
+7. [async-generation-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/async-generation-boundary-contract.md)
+8. [deferred-scope-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/deferred-scope-contract.md)

--- a/specs/009-component-boundaries/research.md
+++ b/specs/009-component-boundaries/research.md
@@ -1,0 +1,79 @@
+# Research: 機能別コンポーネント定義
+
+## Decision: 主軸はオニオンアーキテクチャとし、`Domain Core` と `Application Coordination` を top-level 責務一覧と分離する
+
+**Rationale**: この feature は単なる機能一覧ではなく、依存方向と責務境界をレビュー可能な
+形で固定する必要がある。オニオンアーキテクチャを主軸にすると、domain language を内側に
+保ちつつ、外側の UI、auth/session、command、query、workflow、adapter を明示的に
+配置できる。`Domain Core` と `Application Coordination` を top-level 責務一覧へ混ぜると、
+「外から見える component catalog」と「内側基盤」が混線するため、別枠で表現する。
+
+**Alternatives considered**:
+
+- 単純なレイヤードアーキテクチャとして UI / Application / Infrastructure の 3 層だけで整理する
+- feature ごとのフラットな component 一覧を維持し、不足項目だけ追加する
+
+## Decision: 外から見える top-level 責務は `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` に固定する
+
+**Rationale**: 現行一覧は「機能名」と「責務層」が混在しており、`Explanation generation` の
+ような長時間処理と `Explanation reader` のような read-side が同じ粒度で並んでいる。
+top-level 責務を固定すると、どの component が user-facing、boundary-facing、
+write-side、read-side、workflow-facing、adapter-facing なのかを一目で判定できる。
+
+**Alternatives considered**:
+
+- `UI`、`generation`、`storage` のような粒度の異なるカテゴリを継続利用する
+- `Presentation`、`Application`、`Infrastructure` の 3 層だけを top-level とし、細分化は各自に委ねる
+
+## Decision: `auth/session` は outer boundary として分離し、product 内では `Learner Identity Resolution` と `Actor Session Handoff` のみを扱う
+
+**Rationale**: 認証そのものは `specs/008-auth-session-design/` で設計済みであり、今回の
+feature が再定義すると責務が二重化する。product component として必要なのは、auth/session
+実装そのものではなく、外部 identity から `Learner` を解決し、正規化済み actor reference を
+command/query へ渡す境界だけである。そのため `Actor/Auth Boundary` には
+`Learner Identity Resolution` と `Actor Session Handoff` を置き、auth account lifecycle や
+token verification は deferred scope に留める。
+
+**Alternatives considered**:
+
+- `Learner identity resolution` を domain core 側へ寄せる
+- auth/session 実装詳細も current component catalog に含める
+
+## Decision: write-side、read-side、async workflow は同じ機能名の中に押し込まず分離する
+
+**Rationale**: `Explanation generation` と `Image generation` は要求受理、実行、結果取得が
+異なるタイミングで起こる。これを 1 つの component として定義すると、command acceptance、
+workflow orchestration、provider invocation、completed result read が混線する。登録系も
+同様に、validation や duplicate lookup は command intake 側、completed result の取得は
+query read 側として切り分ける方が、`specs/007-backend-command-design/` と整合する。
+
+**Alternatives considered**:
+
+- `Explanation generation` / `Image generation` を 1 component のまま扱う
+- `Explanation reader` を query read と status read の両方を含む曖昧な component として残す
+
+## Decision: `Async Generation` 配下は `Explanation Generation Workflow` と `Image Generation Workflow` の 2 component に分ける
+
+**Rationale**: 両者はどちらも長時間処理だが、入力、完了条件、依存 adapter、履歴の扱いが
+異なる。`Image generation` は completed `Explanation` と optional `Sense` を前提にし、
+さらに `AssetStoragePort` を介した保存が必要である。一方 `Explanation generation` は
+`VocabularyExpression` から `Explanation` / `Sense` を生成する。親カテゴリは共有しつつ、
+workflow component は分けた方が責務と follow-on scope を明確にできる。
+
+**Alternatives considered**:
+
+- `Async Generation` を 1 つの共通 workflow component として扱う
+- `Explanation generation` と `Image generation` を top-level 責務へ昇格させる
+
+## Decision: `Asset storage` と `asset access/retrieval` は別 adapter として定義し、read-side には `Visual Image Reader` と `Pronunciation Media Reader` を置く
+
+**Rationale**: 現行一覧では `Asset storage` が保存責務だけでなく、再取得参照の解決まで
+暗黙に背負っている。保存と取得を分離しないと、storage metadata の責務と user-facing read
+path の責務が混ざる。同じ問題は `Pronunciation media` にもあり、アプリから見える reader と、
+外部 media source へ接続する adapter は分離した方が、query read と external adapter の
+境界が明確になる。
+
+**Alternatives considered**:
+
+- `Asset storage` が保存と取得の両方を持つ
+- `Pronunciation media` を単一 component として残し、reader と adapter を分けない

--- a/specs/009-component-boundaries/spec.md
+++ b/specs/009-component-boundaries/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: 機能別コンポーネント定義
+
+**Feature Branch**: `010-component-boundaries`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "機能ごとのコンポーネント定義を行う。現状は以下だが不足しているもの・コンテキストが正しく分割できていないものなどがないか議論したい"
+
+## Clarifications
+
+### Session 2026-04-17
+
+- Q: `auth/session` 分離と生成系分離を含めて採用する主軸アーキテクチャは何か → A: オニオンアーキテクチャを主軸にし、`auth/session` を外側境界、`Explanation generation` / `Image generation` を非同期別コンポーネントとして分離する
+- Q: オニオン主軸での top-level 責務分割はどうするか → A: `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` を top-level 責務として明示する
+- Q: `Async Generation` 配下の分割粒度はどうするか → A: `Async Generation` を top-level に置き、その配下に `Explanation Generation Workflow` と `Image Generation Workflow` の 2 コンポーネントを置く
+- Q: オニオン内側の `Domain` / `Application` の見せ方はどうするか → A: `Domain Core` と `Application Coordination` はアーキテクチャの内側として明示しつつ、top-level 責務一覧とは別枠で表現する
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 現行コンポーネント境界を棚卸しする (Priority: P1)
+
+アーキテクチャレビュー担当者として、現行のコンポーネント一覧を見たときに、
+どの責務が既に定義されていて、どの責務が欠けているか、どこが複数コンテキストを
+またいで混ざっているかを説明したい。
+
+**Why this priority**: 現行の責務境界が曖昧なままだと、後続実装で write / read / identity /
+workflow の責務が混線し、議論の前提が揃わないため。
+
+**Independent Test**: レビュー担当者が成果物だけを読み、現行コンポーネント一覧の不足項目、
+責務重複、文脈混在を 5 分以内に指摘できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 現行のコンポーネント一覧がある, **When** レビュー担当者が責務の一覧を見る, **Then** 各コンポーネントの主責務と所属コンテキストが明示されている
+2. **Given** 現行一覧に責務が抜けているまたは混ざっている箇所がある, **When** コンポーネント定義を確認する, **Then** 追加すべき項目または分割すべき項目が明示されている
+3. **Given** 全体アーキテクチャの方針を確認する, **When** コンポーネント定義を見る, **Then** オニオンアーキテクチャを主軸に outer boundary と非同期コンポーネントの位置づけが示されている
+
+---
+
+### User Story 2 - コンテキストごとの責務を分離する (Priority: P2)
+
+実装担当者として、UI、学習者解決、登録、解説生成、画像生成、読み取り、非同期実行、
+外部アダプタの責務を混同せずに扱いたい。そうすることで、ある変更がどのコンポーネントへ
+入るべきかを迷わず判断したい。
+
+**Why this priority**: コンポーネントが「機能名」だけで定義されていると、command 受理、
+workflow orchestration、provider 呼び出し、read-side 取得が 1 つの箱へ潰れてしまうため。
+
+**Independent Test**: 第三者が成果物だけを読み、登録、解説閲覧、画像生成の各フローについて、
+write-side、read-side、identity/session handoff、async execution の責務分離を説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 登録や生成要求のフローを確認する, **When** どこで受理し、どこで実行し、どこで結果を読むかを見る, **Then** command 受理、workflow 実行、結果取得の責務が分離されている
+2. **Given** 学習者 identity と認証まわりの整理を確認する, **When** 外部 identity、session、actor handoff、`Learner` 解決を見る, **Then** auth/session の責務と domain 内の学習者解決が混同されていない
+3. **Given** top-level の責務分割を確認する, **When** コンポーネント一覧を見る, **Then** `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` の責務差分が明示されている
+4. **Given** 非同期生成の整理を確認する, **When** `Async Generation` 配下を見る, **Then** `Explanation Generation Workflow` と `Image Generation Workflow` が別コンポーネントとして定義されている
+5. **Given** オニオンの内側構造を確認する, **When** コンポーネント定義を見る, **Then** `Domain Core` と `Application Coordination` が内側の基盤として別枠で説明されている
+
+---
+
+### User Story 3 - 後続 feature との境界を固定する (Priority: P3)
+
+将来の変更担当者として、ある機能変更がこのコンポーネント定義の対象か、それとも
+auth/session、backend command、query model、vendor adapter など別 feature に属するかを
+一貫して判断したい。
+
+**Why this priority**: コンポーネント定義と周辺設計の境界が曖昧だと、同じ責務を複数文書で
+別名で持ち、後続 feature のスコープが崩れるため。
+
+**Independent Test**: 将来の担当者が成果物だけを読み、任意の変更要求を 1 つ以上の
+コンポーネントまたは deferred scope へ 5 分以内に割り当てられれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 認証、session、workflow orchestration、query model の話題がある, **When** コンポーネント定義を見る, **Then** 何が今回の対象で何が周辺 feature の責務かが明示されている
+2. **Given** 新しい機能変更を検討する, **When** 変更影響を確認する, **Then** どのコンポーネントを更新すべきか、またはどの deferred scope に属するかを判断できる
+
+---
+
+### Edge Cases
+
+- 1 つのコンポーネントが UI と application service と external adapter を同時に担っているように見える場合
+- `Learner identity resolution` が auth/session と `Learner` 解決を両方含んでしまう場合
+- `Explanation generation` や `Image generation` が command 受理、workflow orchestration、provider invocation をまとめて表してしまう場合
+- `Explanation reader` が query model、current result 取得、履歴取得、状態表示責務を曖昧にまとめてしまう場合
+- `Asset storage` が保存責務だけでなく再取得、配信、URL 解決まで含むかが曖昧な場合
+- 現状の一覧に存在しないが、end-to-end の説明には必要なコンポーネントが暗黙のまま残る場合
+
+## Domain & Async Impact *(mandatory when applicable)*
+
+- **Domain Models Affected**: None
+- **Invariants / Terminology**: `Frequency`、`Sophistication`、`Proficiency`、登録状態、解説生成状態、画像生成状態の区別は維持し、コンポーネント定義によって domain 概念を統合しない
+- **Async Lifecycle**: 非同期生成を扱うコンポーネントは、要求受理、状態管理、workflow 実行、完了結果取得を区別して説明しなければならない。`Async Generation` 配下では `Explanation Generation Workflow` と `Image Generation Workflow` を別コンポーネントとして扱う
+- **User Visibility Rule**: どのコンポーネント分割を採用しても、ユーザーに見せてよい生成物は完了済み結果のみであり、生成中・失敗中は状態のみを表示対象とする
+- **Identifier Naming Rule**: 既存の識別子命名規約を変更せず、新しいコンポーネント定義でも `XxxIdentifier`、`identifier`、概念名参照のルールを前提にする
+- **External Ports / Adapters**: identity provider、validation、generation provider、asset storage、media access など外部依存は、コンポーネント定義の中でも domain 外責務として区別する
+- **Architecture Style**: 主軸はオニオンアーキテクチャとし、内側の基盤として `Domain Core` と `Application Coordination` を別枠で示す。top-level 責務は `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` に整理し、`auth/session` は outer boundary、`Explanation generation` / `Image generation` は非同期コンポーネントとして扱う
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 成果物は、現行のコンポーネント一覧を review し、各項目の主責務と所属コンテキストを定義しなければならない
+- **FR-002**: 成果物は、1 つのコンポーネントが複数コンテキストをまたいで責務を持つ場合、その混在を指摘し、分割または境界明示の方針を示さなければならない
+- **FR-003**: 成果物は、end-to-end の説明に必要だが現行一覧では暗黙になっているコンポーネントを追加候補として明示しなければならない
+- **FR-004**: 成果物は、`Learner identity resolution` と auth/session 系責務の境界を定義し、`Learner` 解決、actor handoff、認証そのものを混同しないようにしなければならない
+- **FR-005**: 成果物は、登録・解説生成・画像生成について、request acceptance、workflow orchestration、provider invocation、result reading の責務差分を明示しなければならない
+- **FR-006**: 成果物は、read-side の責務として current result の取得、履歴取得、状態参照をどこで扱うかを明示しなければならない
+- **FR-007**: 成果物は、asset storage、asset retrieval/access、pronunciation media access の責務を区別し、保存と取得が同一責務かどうかを明示しなければならない
+- **FR-008**: 成果物は、各コンポーネントが product 内責務なのか、外部 adapter なのか、周辺 feature へ委ねる deferred scope なのかを示さなければならない
+- **FR-009**: 成果物は、コンポーネント定義を既存の domain language、auth/session 設計、backend command 設計と矛盾しない言葉で整理しなければならない
+- **FR-010**: 成果物は、ユーザーに完了済み結果だけを見せる rule を前提に、UI、read-side、async execution の責務分離を説明しなければならない
+- **FR-011**: 成果物は、各主要ユーザーフローについて、どのコンポーネント群が関与するかを第三者が追跡できる粒度で示さなければならない
+- **FR-012**: 成果物は、今回の見直し対象外である auth/session 実装詳細、query model 実装、workflow 実装、vendor 固有 adapter 実装を deferred scope として明示しなければならない
+- **FR-013**: 成果物は、オニオンアーキテクチャを主軸として、内側の `Domain Core` / `Application Coordination`、外側の `auth/session` boundary、非同期生成コンポーネント、external adapter の配置関係を示さなければならない
+- **FR-014**: 成果物は、top-level 責務として `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` を定義し、現行コンポーネントをいずれかへ割り当てなければならない
+- **FR-015**: 成果物は、`Async Generation` の配下に少なくとも `Explanation Generation Workflow` と `Image Generation Workflow` を別コンポーネントとして定義し、それぞれの完了条件と依存関係の違いを説明しなければならない
+- **FR-016**: 成果物は、`Domain Core` と `Application Coordination` を top-level 責務一覧へ混ぜずに、アーキテクチャの内側基盤として別枠で説明しなければならない
+
+### Key Entities *(include if feature involves data)*
+
+- **Component Definition**: 1 つのコンポーネントの名前、主責務、所属コンテキスト、扱う入出力、他コンポーネントとの境界を表す定義
+- **Context Boundary**: UI、domain-adjacent application logic、async workflow、external adapter、deferred scope のどこに属するかを示す境界情報
+- **Interaction Responsibility**: 登録、生成、閲覧、actor 解決、保存、取得の各フローで、どの責務をどのコンポーネントが担うかを示す整理単位
+- **Deferred Scope Item**: 現時点では別 feature が正本を持つ責務領域を示す項目
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: レビュー担当者が、現行一覧の各コンポーネントについて主責務と所属コンテキストを 5 分以内に説明できる
+- **SC-002**: 現行一覧に含まれる各項目について、責務混在または不足している境界の指摘漏れが 0 件になる
+- **SC-003**: 第三者が、登録、解説閲覧、画像生成の 3 つの主要フローをコンポーネント単位で 5 分以内に追跡できる
+- **SC-004**: auth/session、backend command、query model、vendor adapter への責務割り当てについて、文書横断の矛盾が 0 件になる
+
+## Assumptions
+
+- 現行のコンポーネント一覧は [adr.md](/Users/lihs/workspace/vocastock/docs/external/adr.md) の「コンポーネント」節を正本候補として見直す
+- 既存の domain model、auth/session 設計、backend command 設計はすでに存在し、今回の feature はそれらを置き換えずに接続境界を整理する
+- この feature は docs-first の議論整理であり、実装コードや vendor 選定は含まない
+- query model、workflow 実装、storage 実装、認証実装の詳細は別 feature が正本を持つ前提とする
+- 主軸アーキテクチャはオニオンアーキテクチャとし、`auth/session` は outer boundary、`Explanation generation` / `Image generation` は長時間処理を担う非同期別コンポーネントとして扱う
+- top-level の整理は `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Generation`、`External Adapters` を基準に行う
+- `Async Generation` は 1 つの抽象カテゴリとして置くが、実際の workflow component は `Explanation Generation Workflow` と `Image Generation Workflow` に分ける
+- `Domain Core` と `Application Coordination` はオニオンの内側基盤として明示するが、現行コンポーネントの割り当て表とは別レイヤ表現で扱う

--- a/specs/009-component-boundaries/tasks.md
+++ b/specs/009-component-boundaries/tasks.md
@@ -1,0 +1,197 @@
+# Tasks: 機能別コンポーネント定義
+
+**Input**: Design documents from `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/`  
+**Prerequisites**: [plan.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md) (required), [spec.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md) (required), [research.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/research.md), [data-model.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md), [contracts/](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts), [quickstart.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/quickstart.md)
+
+**Tests**: 専用の test-first task は追加しない。検証は component allocation review、architecture topology review、actor-boundary review、async-generation review、deferred-scope review、cross-document review を independent test として扱う。
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this belongs to (`US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 009 の設計成果物を置く受け皿と参照導線を揃える
+
+- [X] T001 Create the feature artifact skeleton in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md`, `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/research.md`, `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md`, `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/quickstart.md`, and `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/`
+- [X] T002 [P] Update `/Users/lihs/workspace/vocastock/.specify/feature.json` to keep `/Users/lihs/workspace/vocastock/specs/009-component-boundaries` as the active feature directory
+- [X] T003 [P] Sync `/Users/lihs/workspace/vocastock/AGENTS.md` with the planning context for component boundary design
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: すべての user story が依存する component taxonomy、用語、参照元を固定する
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Update component-boundary source-of-truth references in `/Users/lihs/workspace/vocastock/docs/external/requirements.md` using `/Users/lihs/workspace/vocastock/specs/003-architecture-design/spec.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md`, and `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/plan.md` as alignment inputs
+- [X] T005 [P] Cross-check domain terminology and external-port references in `/Users/lihs/workspace/vocastock/docs/internal/domain/common.md`, `/Users/lihs/workspace/vocastock/docs/internal/domain/learner.md`, `/Users/lihs/workspace/vocastock/docs/internal/domain/vocabulary-expression.md`, `/Users/lihs/workspace/vocastock/docs/internal/domain/learning-state.md`, `/Users/lihs/workspace/vocastock/docs/internal/domain/explanation.md`, `/Users/lihs/workspace/vocastock/docs/internal/domain/visual.md`, and `/Users/lihs/workspace/vocastock/docs/internal/domain/service.md` against `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md` without changing domain semantics
+- [X] T006 [P] Normalize onion-architecture vocabulary, top-level responsibility names, and completed-result visibility wording across `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md`, `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md`, and `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/`
+- [X] T007 [P] Capture feature-wide assumptions, dependency-direction review method, deferred-scope framing, and cross-feature source-of-truth notes in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md` and `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/research.md`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - 現行コンポーネント境界を棚卸しする (Priority: P1) 🎯 MVP
+
+**Goal**: 現行のフラットな component 一覧を canonical topology と current-to-canonical mapping へ整理し、不足項目と責務混在を第三者がレビュー可能な形で示す
+
+**Independent Test**: [architecture-topology-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/architecture-topology-contract.md)、[component-allocation-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/component-allocation-contract.md)、[data-model.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md) を読むだけで、現行 component の keep / split / add と top-level 責務の差分を第三者が説明できること
+
+### Implementation for User Story 1
+
+- [X] T008 [P] [US1] Define onion topology, inner foundation layers, top-level responsibilities, and dependency-direction rules in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/architecture-topology-contract.md`
+- [X] T009 [P] [US1] Define the current-to-canonical component allocation, keep / split / add decisions, and new component list in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/component-allocation-contract.md`
+- [X] T010 [US1] Map `InternalFoundationLayer`, `TopLevelResponsibility`, and `ComponentDefinition` semantics, including the canonical component catalog, into `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md`
+- [X] T011 [US1] Align User Story 1 wording, acceptance scenarios, edge cases, and FR-001 through FR-003 in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md`, and update the component section in `/Users/lihs/workspace/vocastock/docs/external/adr.md` with the finalized topology and allocation decisions
+
+**Checkpoint**: User Story 1 should make the topology and current-list audit independently reviewable
+
+---
+
+## Phase 4: User Story 2 - コンテキストごとの責務を分離する (Priority: P2)
+
+**Goal**: actor/auth boundary、command intake、query read、async workflow、external adapter の責務差分を整理し、登録・解説閲覧・画像生成フローの component 分離を一貫化する
+
+**Independent Test**: [actor-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/actor-boundary-contract.md)、[async-generation-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/async-generation-boundary-contract.md)、[data-model.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md) を読むだけで、actor handoff、write/read split、workflow split、adapter split を第三者が説明できること
+
+### Implementation for User Story 2
+
+- [X] T012 [P] [US2] Define `Learner Identity Resolution`, `Actor Session Handoff`, boundary rules, and auth/session deferred areas in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/actor-boundary-contract.md`
+- [X] T013 [P] [US2] Define explanation/image request acceptance, workflow execution, result reading, status reading, and adapter split in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/async-generation-boundary-contract.md`
+- [X] T014 [US2] Extend `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md` with `FlowAssignment`, canonical flow tables, and non-ownership rules for `Command Intake`, `Query Read`, `Async Generation`, and `External Adapters`
+- [X] T015 [US2] Align `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md` Domain & Async Impact, User Story 2 acceptance scenarios, and FR-004 through FR-010 with the finalized responsibility split
+- [X] T016 [US2] Capture the rationale for auth/session boundary separation, write/read split, workflow split, and adapter split in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/research.md`
+
+**Checkpoint**: User Story 2 should make responsibility separation and flow decomposition independently reviewable
+
+---
+
+## Phase 5: User Story 3 - 後続 feature との境界を固定する (Priority: P3)
+
+**Goal**: auth/session、backend command、query model、vendor adapter 実装、follow-on image scope を deferred ownership として整理し、どの変更要求が 009 の対象かを判断できるようにする
+
+**Independent Test**: [deferred-scope-contract.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/deferred-scope-contract.md)、[quickstart.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/quickstart.md)、[plan.md](/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md) を読むだけで、任意の変更要求を in-scope component または deferred source-of-truth へ第三者が割り当てられること
+
+### Implementation for User Story 3
+
+- [X] T017 [P] [US3] Define the ownership matrix, scope rules, and follow-on items in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/deferred-scope-contract.md`
+- [X] T018 [P] [US3] Update `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/quickstart.md` with the review sequence for topology, allocation, actor/auth boundary, async generation, and deferred-scope decisions
+- [X] T019 [P] [US3] Capture the rationale for deferring auth/session implementation, command semantics, query model implementation, vendor-specific adapters, and multiple current image scope in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/research.md`
+- [X] T020 [US3] Align `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md` User Story 3 wording, FR-011 through FR-016, assumptions, and deferred edge cases with the finalized ownership matrix and follow-on scope
+- [X] T021 [US3] Update `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md` Structure Decision and source-of-truth notes to match the finalized deferred-scope ownership and no-redefinition constraints
+
+**Checkpoint**: User Story 3 should make deferred ownership and follow-on scope independently reviewable
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 複数ストーリーに跨る整合と最終導線を整える
+
+- [X] T022 [P] Reconcile all 009 artifacts across `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/spec.md`, `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md`, `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/research.md`, `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/data-model.md`, `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/quickstart.md`, and `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/`
+- [X] T023 [P] Cross-check 009 component terminology against `/Users/lihs/workspace/vocastock/docs/external/adr.md`, `/Users/lihs/workspace/vocastock/docs/external/requirements.md`, `/Users/lihs/workspace/vocastock/specs/003-architecture-design/spec.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md`, and `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/plan.md`
+- [X] T024 Re-run the review flow in `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/quickstart.md` and reconcile reviewer guidance with the finalized component taxonomy and deferred-scope boundaries
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on other stories
+- **User Story 2 (P2)**: Can start after Foundational - shared onion vocabulary and top-level taxonomy are fixed in Phase 2, so no dependency on US1 remains
+- **User Story 3 (P3)**: Can start after Foundational - uses the same taxonomy and source-of-truth references, but remains independently reviewable
+
+### Within Each User Story
+
+- Topology and allocation contracts should be fixed before final spec wording adjustments
+- Actor/auth boundary and async-generation contracts should land before flow-assignment and rationale alignment
+- Deferred-scope ownership should be fixed before quickstart and structure-decision guidance are finalized
+
+### Parallel Opportunities
+
+- `T002` and `T003` can run in parallel after `T001`
+- `T005`, `T006`, and `T007` can run in parallel after `T004`
+- In US1, `T008` and `T009` can run in parallel
+- In US2, `T012` and `T013` can run in parallel
+- In US3, `T017`, `T018`, and `T019` can run in parallel
+- Final polish `T022` and `T023` can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch topology and allocation tasks together:
+Task: "Define onion topology, inner foundation layers, top-level responsibilities, and dependency-direction rules in /Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/architecture-topology-contract.md"
+Task: "Define the current-to-canonical component allocation, keep / split / add decisions, and new component list in /Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/component-allocation-contract.md"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch responsibility-split tasks together:
+Task: "Define Learner Identity Resolution, Actor Session Handoff, boundary rules, and auth/session deferred areas in /Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/actor-boundary-contract.md"
+Task: "Define explanation/image request acceptance, workflow execution, result reading, status reading, and adapter split in /Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/async-generation-boundary-contract.md"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch deferred-scope tasks together:
+Task: "Define the ownership matrix, scope rules, and follow-on items in /Users/lihs/workspace/vocastock/specs/009-component-boundaries/contracts/deferred-scope-contract.md"
+Task: "Update /Users/lihs/workspace/vocastock/specs/009-component-boundaries/quickstart.md with the review sequence for topology, allocation, actor/auth boundary, async generation, and deferred-scope decisions"
+Task: "Capture the rationale for deferred auth/session, command semantics, query model implementation, vendor-specific adapters, and multiple current image scope in /Users/lihs/workspace/vocastock/specs/009-component-boundaries/research.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate that the topology and current-list audit can be reviewed independently
+5. Stop and review before adding responsibility-split and deferred-scope refinements
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational to fix taxonomy, terminology, and source-of-truth references
+2. Add User Story 1 to define the onion topology and current-to-canonical mapping
+3. Add User Story 2 to fix actor/auth boundary, async workflow, and adapter separation
+4. Add User Story 3 to define deferred ownership and follow-on scope
+5. Finish with cross-cutting reconciliation
+
+### Parallel Team Strategy
+
+1. One contributor handles Setup and Foundational alignment
+2. After Foundation:
+   - Contributor A: User Story 1 topology and allocation
+   - Contributor B: User Story 2 responsibility separation
+   - Contributor C: User Story 3 deferred-scope ownership and review guidance
+3. Reconcile all artifacts together in Phase 6
+
+---
+
+## Notes
+
+- [P] tasks target different files and can proceed in parallel after dependencies
+- No standalone test-file tasks were generated because this feature is a design package and independent review is the intended validation mode
+- Keep 009 terminology aligned with `Domain Core`, `Application Coordination`, `Actor/Auth Boundary`, `Command Intake`, `Query Read`, `Async Generation`, and `External Adapters`
+- Do not pull auth/session implementation detail, backend command semantics, query model implementation, or vendor SDK design into this feature

--- a/specs/010-subscription-component-boundaries/checklists/requirements.md
+++ b/specs/010-subscription-component-boundaries/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Subscription Component Boundaries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-18  
+**Feature**: [spec.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- 現時点で未解決の clarification はありません

--- a/specs/010-subscription-component-boundaries/contracts/entitlement-gate-contract.md
+++ b/specs/010-subscription-component-boundaries/contracts/entitlement-gate-contract.md
@@ -1,0 +1,45 @@
+# Contract: Entitlement And Gate Separation
+
+## Purpose
+
+subscription state、entitlement、feature gate、usage quota を別責務として固定する。
+
+## Role Separation
+
+| Component | Primary Responsibility | Must Not Decide |
+|-----------|------------------------|-----------------|
+| `Entitlement Policy` | plan と authoritative subscription state から権限集合を導出する | usage 消費、purchase verification |
+| `Subscription Feature Gate` | entitlement と feature key から allow / limited / deny を決定する | store verification、quota 集計 |
+| `Usage Metering / Quota Gate` | 利用量、無料枠、期間上限を評価する | plan 由来の paid entitlement 付与 |
+| `Subscription Feature Gate Reader` | app core / UI 向けに gate result を返す | entitlement 自体の再計算 |
+
+## Decision Pipeline
+
+1. authoritative subscription state を更新する
+2. `Entitlement Policy` が entitlement set を導出する
+3. `Subscription Feature Gate` が feature ごとの unlock 方針を決定する
+4. `Usage Metering / Quota Gate` が利用量制限を適用する
+5. `Subscription Feature Gate Reader` が app-facing decision を返す
+
+## Gate Rules
+
+- feature unlock は confirmed entitlement に対してのみ行う
+- `pending-sync` は feature unlock の根拠に使ってはならない
+- `grace` は paid entitlement を維持するため、通常の premium gate を継続してよい
+- quota 枯渇時は entitlement が有効でも `limited` または `deny` を返しうる
+
+## Example Outcomes
+
+| Subscription State | Entitlement | Quota | Feature Gate Outcome |
+|--------------------|-------------|-------|----------------------|
+| `active` | premium | remaining | `allow` |
+| `grace` | premium | remaining | `allow` |
+| `active` | premium | exhausted | `limited` or `deny` |
+| `pending-sync` | none confirmed | any | `deny` |
+| `expired` | free only | remaining free quota | `limited` or `deny` |
+
+## Invariants
+
+- `Entitlement` と `Usage Metering / Quota Gate` の責務を 1 つの `isPremium` フラグへ潰してはならない
+- UI local state だけで premium unlock を決めてはならない
+- quota の消費履歴は paid / free の判定根拠ではなく、usage execution 可否の判定根拠として扱う

--- a/specs/010-subscription-component-boundaries/contracts/purchase-reconciliation-contract.md
+++ b/specs/010-subscription-component-boundaries/contracts/purchase-reconciliation-contract.md
@@ -1,0 +1,50 @@
+# Contract: Purchase Reconciliation
+
+## Purpose
+
+購入完了、復元、状態再同期、store notification による authoritative update の流れを固定する。
+
+## Flow 1: Complete Purchase
+
+1. `Subscription Paywall UI` が `Mobile Storefront Adapter` を通じて購入開始を要求し、purchase state を `initiated` にする
+2. storefront 完了後、`Purchase Result Intake` が purchase artifact を受け付け、purchase state を `submitted` にする
+3. `Purchase Verification Workflow` が `Purchase Verification Adapter` を使って artifact を検証し、purchase state を `verifying` にする
+4. 検証成功時に purchase state を `verified` にし、authoritative subscription state を更新し、`Entitlement Policy` を再計算する
+5. 検証失敗時は purchase state を `rejected` にし、paid entitlement を付与しない
+6. `Subscription Status Reader`、`Entitlement Reader`、`Subscription Feature Gate Reader` が app-facing 結果を返す
+
+## Flow 2: Restore Purchase
+
+1. `Restore Purchase Intake` が restore 要求を受け付け、purchase state を `initiated` にする
+2. `Mobile Storefront Adapter` が storefront 側の restore を実行し、artifact 取得後に purchase state を `submitted` にする
+3. `Purchase Verification Workflow` が復元対象の artifact を検証し、purchase state を `verifying` にする
+4. 成功時は purchase state を `verified` にし、authoritative subscription state と entitlement を再計算する
+5. app は synced mirror を通じて更新結果を受け取る
+
+## Flow 3: Refresh And Cross-Device Reconciliation
+
+1. `Subscription Status Refresh Intake` が明示 refresh または起動時同期を受け付ける
+2. `Store Notification Reconciliation Workflow` が `Store Notification Adapter` 経由の通知や未処理イベントを照合する
+3. authoritative subscription state と entitlement mirror を再計算する
+4. `Subscription Status Reader` と `Entitlement Reader` が最新状態を返す
+
+## Adapter Resilience Matrix
+
+| Adapter | Timeout | Retry | Fallback |
+|---------|---------|-------|----------|
+| `Mobile Storefront Adapter` | purchase state を `initiated` または `submitted` のままにする | user-driven retry または restore 再試行 | paywall に再試行導線を出し、unlock は止める |
+| `Purchase Verification Adapter` | purchase state を `verifying` に留める | workflow retry または refresh 再実行 | authoritative state を新規 paid にしないまま status 表示を継続する |
+| `Store Notification Adapter` | 未反映イベントを保留する | reconciliation workflow が再取得する | 既存 mirror を維持し manual refresh を許可する |
+
+## Partial Success Rules
+
+- storefront 側の完了だけでは premium unlock を確定してはならない
+- verification が未完了なら `pending-sync` を返し、premium unlock を行ってはならない
+- verification 失敗時は paid entitlement を付与してはならない
+- purchase state が `verified` になる前に premium unlock を行ってはならない
+
+## Read Visibility Rules
+
+- app は pending / failed / revoked などの状態を表示してよい
+- app は incomplete purchase payload、raw receipt、provider token を表示または保持してはならない
+- protected feature 実行前の最終 gate は authoritative state と synced mirror に基づかなければならない

--- a/specs/010-subscription-component-boundaries/contracts/subscription-authority-contract.md
+++ b/specs/010-subscription-component-boundaries/contracts/subscription-authority-contract.md
@@ -1,0 +1,62 @@
+# Contract: Subscription Authority
+
+## Purpose
+
+課金状態の最終正本、state model、app-facing mirror の関係を固定する。
+
+## Authoritative Source Matrix
+
+| Concern | Authoritative Owner | App-Facing Form | Not Authoritative |
+|---------|---------------------|-----------------|-------------------|
+| purchase 完了 artifact | `Purchase Result Intake` -> `Purchase Verification Workflow` | purchase pending / failed status | local storefront cache 単体 |
+| subscription state | backend authoritative subscription state | `Subscription Status Reader` | paywall UI、local cache |
+| entitlement | `Entitlement Policy` | `Entitlement Reader` の synced mirror | storefront callback 単体 |
+| feature unlock | `Subscription Feature Gate` | `Subscription Feature Gate Reader` | UI local flag |
+| usage allowance | `Usage Metering / Quota Gate` | `Usage Allowance Reader` | アプリの local counter |
+
+## State Model
+
+| State | Paid Entitlement | UI Status | Requires Additional Reconciliation |
+|-------|------------------|-----------|------------------------------------|
+| `active` | 維持する | 表示する | No |
+| `grace` | 維持する | 表示する | Yes |
+| `expired` | 維持しない | 表示する | No |
+| `pending-sync` | 維持しない | 表示する | Yes |
+| `revoked` | 維持しない | 表示する | No |
+
+## Purchase State Model
+
+| State | UI Status | Premium Unlock | Requires Adapter Retry |
+|-------|-----------|----------------|------------------------|
+| `initiated` | 表示する | No | No |
+| `submitted` | 表示する | No | Yes |
+| `verifying` | 表示する | No | Yes |
+| `verified` | 表示する | Yes | No |
+| `rejected` | 表示する | No | No |
+
+## State Rules
+
+1. `grace` は一時継続状態であり、通常の paid entitlement を維持しなければならない
+2. `pending-sync` は UI に状態表示してよいが、premium unlock の根拠に使ってはならない
+3. `revoked` は返金や強制失効を含み、paid entitlement を即時停止しなければならない
+4. `expired` と `revoked` はどちらも non-paid だが、失効理由の意味は混同してはならない
+5. `verified` だけが premium unlock の前提となりうる purchase state でなければならない
+6. `submitted` と `verifying` は purchase progress を示すが、authoritative subscription state と同一視してはならない
+
+## Mirror Rules
+
+- app core と UI は authoritative backend source から同期済みの entitlement mirror だけを参照する
+- mirror は read-only であり、ローカル UI 操作だけで entitlement を変更してはならない
+- purchase 完了直後でも backend authoritative state への反映が未完了なら `pending-sync` として扱い、premium unlock を確定してはならない
+
+## Failure / Drift Handling
+
+- purchase 成功表示と authoritative state がずれた場合、unlock 判定は authoritative state を優先する
+- cross-device で mirror がずれた場合、`Subscription Status Refresh Intake` または store notification reconciliation を経由して同期する
+- `grace` から `expired` へ遷移した後は、paid entitlement を維持してはならない
+
+## Adapter Resilience Rules
+
+- `Mobile Storefront Adapter` の timeout では purchase state を `initiated` または `submitted` のまま保持し、paywall 側に retry 導線を出す
+- `Purchase Verification Adapter` の timeout または一時障害では purchase state を `verifying` に留め、authoritative subscription state は `pending-sync` または既存状態を維持する
+- `Store Notification Adapter` の障害では既存 mirror を維持してよいが、新しい paid entitlement を付与してはならない

--- a/specs/010-subscription-component-boundaries/contracts/subscription-deferred-scope-contract.md
+++ b/specs/010-subscription-component-boundaries/contracts/subscription-deferred-scope-contract.md
@@ -1,0 +1,36 @@
+# Contract: Subscription Deferred Scope
+
+## Purpose
+
+今回の feature が ownership を持つ領域と、別 feature または外部境界へ委譲する領域を固定する。
+
+## In Scope
+
+- subscription-specific component taxonomy
+- authoritative subscription state と entitlement mirror の責務分離
+- `Entitlement Policy`、`Subscription Feature Gate`、`Usage Metering / Quota Gate` の役割分離
+- purchase / restore / refresh / notification reconciliation の boundary 定義
+- UI が参照する subscription status、entitlement、quota decision の app-facing read 責務
+
+## Deferred To Existing Source Of Truth
+
+| Concern | Source Of Truth | Reason |
+|---------|-----------------|--------|
+| auth / account / session lifecycle | `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/` | 010 では actor handoff 接点だけを使う |
+| protected feature の command semantics | `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/` | billing gate は前段判定のみを扱う |
+| product-wide component taxonomy | `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/` | 010 は subscription-specific package である |
+
+## Deferred To External Boundary Or Future Implementation
+
+| Concern | Source Of Truth | Reason |
+|---------|-----------------|--------|
+| pricing catalog | mobile storefront / product business policy | component boundary feature で固定しない |
+| tax / refund policy | mobile storefront / legal-operational policy | store policy と運用判断の領域 |
+| vendor SDK detail | future implementation | adapter の存在だけを定義し、SDK 選定は実装時に決める |
+| store-specific dashboard setup | App Store Connect / Play Console | product architecture 文書ではなく運用設定 |
+
+## Guardrails
+
+- in-scope component が pricing / tax / refund rule を再定義してはならない
+- 010 は 008、007、009 の正本を上書きしてはならない
+- deferred concern を理由なく `UI` や `Feature Gate` に取り込んではならない

--- a/specs/010-subscription-component-boundaries/contracts/subscription-topology-contract.md
+++ b/specs/010-subscription-component-boundaries/contracts/subscription-topology-contract.md
@@ -1,0 +1,61 @@
+# Contract: Subscription Topology
+
+## Purpose
+
+subscription component を 009 の product-wide taxonomy に沿って配置し、どの責務を
+billing package が持つかを固定する。
+
+## Top-Level Boundary Groups
+
+| Boundary Group | Owns | Must Not Own |
+|----------------|------|--------------|
+| `Presentation` | paywall、subscription status、upsell、pending / revoked / expired の状態表示 | authoritative subscription state、verification、quota 消費 |
+| `Actor/Auth Boundary` | actor reference の handoff | auth lifecycle、purchase verification |
+| `Command Intake` | purchase artifact 提出、restore 要求、status refresh 要求の受付 | paid unlock の最終確定、UI rendering |
+| `Query Read` | subscription status、entitlement mirror、usage allowance、feature gate result の返却 | purchase artifact 受付、verification 実行 |
+| `Async Subscription Reconciliation` | verification、notification ingest、authoritative state 更新 | paywall 表示、product policy UI |
+| `External Adapters` | storefront、verification API、notification source との接続 | entitlement policy、quota policy、feature gate 判定 |
+
+## Canonical Component Allocation
+
+| Component | Boundary Group | Notes |
+|-----------|----------------|-------|
+| `Subscription Paywall UI` | `Presentation` | purchase 開始導線と upsell 表示 |
+| `Subscription Status UI` | `Presentation` | state / entitlement / quota 表示 |
+| `Actor Session Handoff` | `Actor/Auth Boundary` | 008 の auth/session 正本を再利用する依存 component |
+| `Purchase Result Intake` | `Command Intake` | storefront 完了後の artifact 提出受付 |
+| `Restore Purchase Intake` | `Command Intake` | restore 開始要求受付 |
+| `Subscription Status Refresh Intake` | `Command Intake` | status refresh / cross-device 再同期の起点 |
+| `Subscription Status Reader` | `Query Read` | authoritative state の app-facing read |
+| `Entitlement Reader` | `Query Read` | synced entitlement mirror の read |
+| `Usage Allowance Reader` | `Query Read` | quota 状態の read |
+| `Subscription Feature Gate Reader` | `Query Read` | app core / UI 向け gate decision の read |
+| `Purchase Verification Workflow` | `Async Subscription Reconciliation` | purchase artifact の照合と state 更新 |
+| `Store Notification Reconciliation Workflow` | `Async Subscription Reconciliation` | server notification による state / entitlement 再計算 |
+| `Mobile Storefront Adapter` | `External Adapters` | App Store / Google Play 接続 |
+| `Purchase Verification Adapter` | `External Adapters` | receipt / token 検証接続 |
+| `Store Notification Adapter` | `External Adapters` | store notification の受信と正規化 |
+
+## Inner Policy Components
+
+次の 3 つは top-level boundary group とは別に、内側基盤の policy として扱う。
+
+| Policy | Role |
+|--------|------|
+| `Entitlement Policy` | authoritative subscription state と plan から解放権限を導出する |
+| `Subscription Feature Gate` | entitlement と feature key から allow / limited / deny を決定する |
+| `Usage Metering / Quota Gate` | 利用回数、期間上限、無料枠消費を評価する |
+
+## Dependency Direction
+
+1. `Presentation` は `Query Read` の結果を表示してよいが、`Async Subscription Reconciliation` を直接呼び出してはならない
+2. `Command Intake` は `External Adapters` を直接 ownership せず、workflow 起動要求だけを行う
+3. `Async Subscription Reconciliation` は adapter を使って authoritative state を更新してよいが、UI 向け read model を直接返してはならない
+4. `Query Read` は authoritative source から導出された state / mirror / gate result だけを返し、verification を開始してはならない
+5. `External Adapters` は timeout、retry、fallback を持ってよいが、未確認 entitlement の unlock を決めてはならない
+
+## Invariants
+
+- product-wide taxonomy の正本は引き続き 009 にあり、010 は subscription-specific package として追加される
+- subscription package は auth/session、command semantics、pricing policy の正本を置き換えてはならない
+- `Presentation` で利用する entitlement mirror は backend authority から同期済みでなければならない

--- a/specs/010-subscription-component-boundaries/data-model.md
+++ b/specs/010-subscription-component-boundaries/data-model.md
@@ -1,0 +1,421 @@
+# Data Model: Subscription Component Boundaries
+
+## Component Boundary Overview
+
+```mermaid
+classDiagram
+    class SubscriptionBoundaryGroup {
+        <<BoundaryGroup>>
+        +SubscriptionBoundaryGroupName name
+        +string purpose
+    }
+
+    class InnerPolicyComponent {
+        <<InnerPolicy>>
+        +string name
+        +string purpose
+        +string outputs
+    }
+
+    class SubscriptionComponentDefinition {
+        <<DesignEntity>>
+        +string name
+        +SubscriptionBoundaryGroupName group
+        +string primaryInputs
+        +string primaryOutputs
+        +string owns
+        +string mustNotOwn
+    }
+
+    class AuthoritativeSubscriptionStateModel {
+        <<StateModel>>
+        +SubscriptionStateName state
+        +bool keepsPaidEntitlement
+        +bool allowsStatusDisplay
+        +bool requiresReconciliation
+    }
+
+    class PurchaseStateModel {
+        <<StateModel>>
+        +PurchaseStateName state
+        +bool allowsStatusDisplay
+        +bool canUnlockPremium
+        +bool requiresAdapterRetry
+    }
+
+    class AdapterResiliencePolicy {
+        <<DesignEntity>>
+        +string adapterName
+        +string timeoutBehavior
+        +string retryBehavior
+        +string fallbackBehavior
+    }
+
+    class EntitlementMirror {
+        <<DesignEntity>>
+        +string actorReference
+        +string entitlementSnapshot
+        +string syncedAt
+        +string source
+    }
+
+    class UsageQuotaPolicy {
+        <<DesignEntity>>
+        +string featureKey
+        +string allowanceWindow
+        +string exhaustionBehavior
+    }
+
+    class SubscriptionFlowAssignment {
+        <<DesignEntity>>
+        +string flowName
+        +string intakeStep
+        +string authorityStep
+        +string gateStep
+        +string readStep
+    }
+
+    class DeferredScopeItem {
+        <<DesignEntity>>
+        +string concern
+        +string sourceOfTruth
+        +string reason
+    }
+
+    SubscriptionBoundaryGroup --> "1..*" SubscriptionComponentDefinition : groups
+    InnerPolicyComponent --> SubscriptionComponentDefinition : informs
+    SubscriptionFlowAssignment --> "1..*" SubscriptionComponentDefinition : references
+```
+
+## Entity: SubscriptionBoundaryGroup
+
+**Purpose**: 009 の component taxonomy を再利用しつつ、subscription 専用 component を
+どの outer boundary に置くかを示す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| name | SubscriptionBoundaryGroupName | 1 | boundary group 名 |
+| purpose | string | 1 | その group が担う責務 |
+
+**Validation rules**:
+
+- すべての subscription component はちょうど 1 つの boundary group に属さなければならない
+- `Domain Core` と `Application Coordination` は 009 と同様に内側基盤であり、この entity には含めない
+
+## Entity: InnerPolicyComponent
+
+**Purpose**: backend authority と app-facing 判定のあいだにある内側ポリシー部品を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| name | string | 1 | canonical policy 名 |
+| purpose | string | 1 | 何を決めるか |
+| outputs | string | 1 | 後続 component へ渡す判断結果 |
+
+**Validation rules**:
+
+- `Entitlement Policy` は usage 消費判定を持ってはならない
+- `Subscription Feature Gate` は purchase verification を持ってはならない
+- `Usage Metering / Quota Gate` は subscription state の最終正本を持ってはならない
+
+## Entity: SubscriptionComponentDefinition
+
+**Purpose**: 1 つの subscription component の ownership と非責務を定義する。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| name | string | 1 | canonical component 名 |
+| group | SubscriptionBoundaryGroupName | 1 | 所属 boundary group |
+| primaryInputs | string | 1 | 主要入力 |
+| primaryOutputs | string | 1 | 主要出力 |
+| owns | string | 1 | 主責務 |
+| mustNotOwn | string | 1 | 持ってはいけない責務 |
+
+**Validation rules**:
+
+- `Presentation` 配下の component は課金状態の正本を持ってはならない
+- `Command Intake` 配下の component は paid unlock 判定を確定してはならない
+- `Async Subscription Reconciliation` 配下の component は UI 表示責務を持ってはならない
+- `External Adapters` 配下の component は product policy を最終決定してはならない
+
+## Entity: AuthoritativeSubscriptionStateModel
+
+**Purpose**: authoritative subscription state と unlock 影響を定義する。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| state | SubscriptionStateName | 1 | authoritative subscription state |
+| keepsPaidEntitlement | bool | 1 | paid entitlement を維持するか |
+| allowsStatusDisplay | bool | 1 | UI に状態表示してよいか |
+| requiresReconciliation | bool | 1 | 追加の同期や照合が必要か |
+
+**Validation rules**:
+
+- `grace` は `keepsPaidEntitlement = true` でなければならない
+- `pending-sync` は `keepsPaidEntitlement = false` でなければならない
+- `revoked` は paid entitlement を維持してはならない
+
+## Entity: PurchaseStateModel
+
+**Purpose**: purchase / restore の受付と照合の進行状況を、authoritative subscription state と
+分離して定義する。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| state | PurchaseStateName | 1 | canonical purchase state |
+| allowsStatusDisplay | bool | 1 | UI に状態表示してよいか |
+| canUnlockPremium | bool | 1 | premium unlock の根拠になりうるか |
+| requiresAdapterRetry | bool | 1 | adapter retry または再同期が必要か |
+
+**Validation rules**:
+
+- `verified` 以外は `canUnlockPremium = false` でなければならない
+- `submitted` と `verifying` は purchase artifact の処理中であり、status 表示だけを許可する
+- `rejected` は purchase failure を示すが、authoritative subscription state の paid entitlement を直接決めてはならない
+
+## Entity: EntitlementMirror
+
+**Purpose**: app core と UI が参照する同期済み entitlement snapshot を表す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| actorReference | string | 1 | actor / learner の参照 |
+| entitlementSnapshot | string | 1 | backend authority から同期された権限集合 |
+| syncedAt | string | 1 | 最終同期時刻 |
+| source | string | 1 | authoritative backend source |
+
+**Validation rules**:
+
+- `EntitlementMirror` は backend authoritative state から導出される read-only view でなければならない
+- local purchase cache や storefront callback だけで `EntitlementMirror` を確定してはならない
+
+## Entity: AdapterResiliencePolicy
+
+**Purpose**: 外部 adapter ごとの timeout、retry、fallback の扱いを定義する。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| adapterName | string | 1 | adapter 名 |
+| timeoutBehavior | string | 1 | timeout 時に返す状態や扱い |
+| retryBehavior | string | 1 | retry 条件と再試行主体 |
+| fallbackBehavior | string | 1 | 障害時の代替動作 |
+
+**Validation rules**:
+
+- resilience policy は未確認 entitlement を unlock 根拠にしてはならない
+- adapter failure 時の fallback は state 表示継続と retry / refresh 導線を含められるが、paid entitlement の付与を含めてはならない
+
+## Entity: UsageQuotaPolicy
+
+**Purpose**: entitlement と別に、利用量制限と枯渇時の扱いを定義する。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| featureKey | string | 1 | 制限対象機能 |
+| allowanceWindow | string | 1 | 日次 / 月次 / trial などの集計窓 |
+| exhaustionBehavior | string | 1 | 枯渇時に deny / wait / upsell のどれを返すか |
+
+**Validation rules**:
+
+- usage quota は paid entitlement の有無と独立に評価できなければならない
+- free tier と paid tier の差分は quota policy または entitlement policy のどちらか一方にだけ持たせ、二重定義してはならない
+
+## Entity: SubscriptionFlowAssignment
+
+**Purpose**: 購入、復元、保護機能評価の各フローに component を割り当てる。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| flowName | string | 1 | flow 名 |
+| intakeStep | string | 0..1 | command / intake step |
+| authorityStep | string | 0..1 | verification / authoritative state 更新 step |
+| gateStep | string | 0..1 | entitlement / quota / feature gate 判定 step |
+| readStep | string | 0..1 | app-facing read / mirror step |
+
+**Validation rules**:
+
+- authoritative state 更新を伴う flow は `Async Subscription Reconciliation` を経由しなければならない
+- UI 制御に使う結果は `Query Read` または synced mirror 経由でなければならない
+
+## Entity: DeferredScopeItem
+
+**Purpose**: 今回 ownership を持たない billing concern と、その正本を示す。
+
+| Field | Type | Cardinality | Description |
+|-------|------|-------------|-------------|
+| concern | string | 1 | deferred concern 名 |
+| sourceOfTruth | string | 1 | 正本となる feature または外部境界 |
+| reason | string | 1 | 今回扱わない理由 |
+
+**Validation rules**:
+
+- deferred concern には必ず source-of-truth を付けなければならない
+- in-scope component と deferred concern で同じ責務を二重定義してはならない
+
+## Canonical Boundary Groups
+
+| Group | Purpose |
+|-------|---------|
+| `Presentation` | paywall、subscription status、upsell、pending-sync 表示の UI を担う |
+| `Actor/Auth Boundary` | auth/session 由来の actor reference を subscription 判断へ handoff する |
+| `Command Intake` | purchase artifact 提出、復元要求、status refresh 要求の受付を担う |
+| `Query Read` | subscription status、entitlement mirror、quota 状態、feature gate 結果を返す |
+| `Async Subscription Reconciliation` | verification、notification ingest、authoritative state 更新を担う |
+| `External Adapters` | storefront、verification API、notification source など外部接続を担う |
+
+## Inner Policy Components
+
+| Policy | Purpose | Outputs |
+|--------|---------|---------|
+| `Entitlement Policy` | authoritative subscription state と plan から解放権限を導出する | entitlement set |
+| `Subscription Feature Gate` | entitlement と feature key から allow / limited / deny を返す | feature gate decision |
+| `Usage Metering / Quota Gate` | 利用上限、無料枠、期間消費を評価する | quota decision |
+
+## Canonical Component Catalog
+
+### Presentation
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Subscription Paywall UI` | plan 提示、購入導線起動、pending / revoked / expired の状態表示 | 課金確定、entitlement 確定、quota 消費 |
+| `Subscription Status UI` | current subscription state、entitlement mirror、quota 残量の表示 | authoritative state 更新、verification |
+
+### Actor/Auth Boundary
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Actor Session Handoff` | auth/session から actor reference を subscription flow へ渡す | 認証そのもの、課金状態の正本、store credential 保持 |
+
+### Command Intake
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Purchase Result Intake` | storefront 完了後の purchase artifact 提出を受け付ける | purchase verification 本体、unlock 確定 |
+| `Restore Purchase Intake` | restore 要求の受付 | store API detail、entitlement 確定 |
+| `Subscription Status Refresh Intake` | 同期再実行や cross-device refresh の起点 | authoritative state の読み出し API 直結 |
+
+### Query Read
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Subscription Status Reader` | authoritative subscription state を app-facing status に整形して返す | verification 実行 |
+| `Entitlement Reader` | synced entitlement mirror を返す | purchase artifact 受付、quota 消費 |
+| `Usage Allowance Reader` | usage 残量と quota 状態を返す | entitlement 付与 |
+| `Subscription Feature Gate Reader` | app core / UI 向けの allow / limited / deny 判定を返す | purchase verification、storefront 操作 |
+
+### Async Subscription Reconciliation
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Purchase Verification Workflow` | purchase artifact を検証し authoritative subscription state を更新する | UI 表示、pricing catalog 提供 |
+| `Store Notification Reconciliation Workflow` | server notification を取り込み authoritative state / entitlement を再計算する | storefront 起動、paywall rendering |
+
+### External Adapters
+
+| Component | Owns | Must Not Own |
+|-----------|------|--------------|
+| `Mobile Storefront Adapter` | App Store / Google Play の購入開始と restore 接続 | entitlement 確定、quota 判定 |
+| `Purchase Verification Adapter` | receipt / token / purchase artifact の検証接続 | product policy 決定 |
+| `Store Notification Adapter` | store notification の受信と正規化 | authoritative entitlement の最終決定 |
+
+## Authoritative Subscription State Effects
+
+| State | Paid Entitlement | UI Status | Notes |
+|-------|------------------|-----------|-------|
+| `active` | 維持する | 表示する | 通常の有料状態 |
+| `grace` | 維持する | 表示する | 一時継続状態。paid entitlement は維持 |
+| `expired` | 維持しない | 表示する | paid entitlement 停止 |
+| `pending-sync` | 維持しない | 表示する | 反映待ち。unlock 判定に使わない |
+| `revoked` | 維持しない | 表示する | 返金、取り消し、強制失効など |
+
+## Purchase State Effects
+
+| State | UI Status | Premium Unlock | Notes |
+|-------|-----------|----------------|-------|
+| `initiated` | 表示してよい | 不可 | storefront 開始前後の初期状態 |
+| `submitted` | 表示してよい | 不可 | purchase artifact 提出済み |
+| `verifying` | 表示してよい | 不可 | verification 実行中 |
+| `verified` | 表示してよい | 可 | authoritative update 成功後にのみ unlock 根拠になりうる |
+| `rejected` | 表示してよい | 不可 | verification failure または拒否 |
+
+## Adapter Resilience Matrix
+
+| Adapter | Timeout Behavior | Retry Behavior | Fallback Behavior |
+|---------|------------------|----------------|-------------------|
+| `Mobile Storefront Adapter` | purchase state を `initiated` または `submitted` のまま保持し、status 表示を継続する | user-driven retry または restore の再実行を許可する | paywall と status UI に再試行導線を出し、premium unlock は行わない |
+| `Purchase Verification Adapter` | purchase state を `verifying` に留める | workflow が retry し、一定回数後は refresh を要求する | `pending-sync` と processing status を返し、entitlement mirror は更新しない |
+| `Store Notification Adapter` | authoritative subscription state の更新を保留する | reconciliation workflow が再取得を試みる | 既存 mirror のまま status を表示しつつ manual refresh を許可する |
+
+## Flow Assignments
+
+### Flow: Complete Purchase
+
+| Step | Component |
+|------|-----------|
+| actor handoff | `Actor Session Handoff` |
+| purchase state progression | `initiated` -> `submitted` -> `verifying` -> `verified` or `rejected` |
+| purchase submission | `Purchase Result Intake` |
+| verification | `Purchase Verification Workflow` + `Purchase Verification Adapter` |
+| authoritative update | `Purchase Verification Workflow` |
+| entitlement derivation | `Entitlement Policy` |
+| gate evaluation | `Subscription Feature Gate` + `Usage Metering / Quota Gate` |
+| app-facing read | `Subscription Status Reader` + `Entitlement Reader` + `Subscription Feature Gate Reader` |
+
+### Flow: Restore Purchase
+
+| Step | Component |
+|------|-----------|
+| actor handoff | `Actor Session Handoff` |
+| purchase state progression | `initiated` -> `submitted` -> `verifying` -> `verified` or `rejected` |
+| restore request | `Restore Purchase Intake` + `Mobile Storefront Adapter` |
+| verification | `Purchase Verification Workflow` + `Purchase Verification Adapter` |
+| authoritative update | `Purchase Verification Workflow` |
+| app-facing read | `Subscription Status Reader` + `Entitlement Reader` |
+
+### Flow: Evaluate Protected Feature
+
+| Step | Component |
+|------|-----------|
+| actor handoff | `Actor Session Handoff` |
+| status refresh | `Subscription Status Refresh Intake` |
+| entitlement read | `Entitlement Reader` |
+| quota read | `Usage Allowance Reader` |
+| gate decision | `Subscription Feature Gate Reader` |
+| upsell / status display | `Subscription Paywall UI` or `Subscription Status UI` |
+
+## Deferred Scope Items
+
+| Concern | Source of Truth | Reason |
+|---------|-----------------|--------|
+| auth/account/session lifecycle | `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/` | actor handoff 接点だけを使い、認証詳細は再定義しない |
+| protected feature command semantics | `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/` | billing gate は前段判定のみを扱い、command rule 自体は 007 を正本とする |
+| product-wide component taxonomy | `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/` | 010 は subscription-specific package であり 009 を置き換えない |
+| pricing catalog、tax、refund policy | mobile storefront / external business policy | billing policy detail は architecture boundary feature の対象外 |
+| vendor SDK selection / store-specific setup | future implementation | adapter の存在だけを定義し、SDK 詳細は実装フェーズへ委ねる |
+
+## Enumerations
+
+### SubscriptionBoundaryGroupName
+
+- `presentation`
+- `actor-auth-boundary`
+- `command-intake`
+- `query-read`
+- `async-subscription-reconciliation`
+- `external-adapters`
+
+### SubscriptionStateName
+
+- `active`
+- `grace`
+- `expired`
+- `pending-sync`
+- `revoked`
+
+### PurchaseStateName
+
+- `initiated`
+- `submitted`
+- `verifying`
+- `verified`
+- `rejected`

--- a/specs/010-subscription-component-boundaries/plan.md
+++ b/specs/010-subscription-component-boundaries/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: Subscription Component Boundaries
+
+**Branch**: `010-component-boundaries` | **Date**: 2026-04-19 | **Spec**: [/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md)
+**Input**: Feature specification from `/specs/010-subscription-component-boundaries/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+vocastock のサブスク責務を、既存の 009 component boundary discipline と整合する
+subscription boundary package として定義する。課金そのものは mobile storefront の外部境界に
+置き、課金状態の最終正本は backend authoritative subscription state が持つ。app core と UI は
+同期済み entitlement mirror を参照して制御し、機能解放は `Entitlement Policy` と
+`Subscription Feature Gate`、利用回数や無料枠の消費判定は `Usage Metering / Quota Gate`
+へ分離する。`Purchase State Model` は `initiated`、`submitted`、`verifying`、`verified`、
+`rejected` を持つ canonical 受付・照合モデルとして定義し、authoritative subscription
+state と分離する。`grace` は有料 entitlement を維持する一時継続状態として扱い、
+restore purchase、status refresh、cross-device reconciliation は purchase verification と
+store notification を介した別 workflow で定義する。外部 adapter には timeout、retry、
+fallback を明示し、一時障害中も未確認 entitlement を unlock 根拠にしない。
+
+## Technical Context
+
+**Language/Version**: Markdown 1.x, YAML/JSON reference documents  
+**Primary Dependencies**: 憲章、`docs/external/requirements.md`、`docs/external/adr.md`、`docs/internal/domain/common.md`、`docs/internal/domain/learner.md`、`docs/internal/domain/service.md`、`specs/007-backend-command-design/`、`specs/008-auth-session-design/`、`specs/009-component-boundaries/`  
+**Storage**: Git-managed repository files、設計上で参照する抽象的な subscription state store、purchase state store、entitlement store、usage metering store、store purchase artifact / notification ingest store  
+**Testing**: spec / constitution / architecture の手動クロスレビュー、subscription authority review、purchase-state review、entitlement gate review、adapter resilience review、purchase reconciliation review、deferred scope review  
+**Target Platform**: Flutter paywall / subscription status UI、mobile storefront boundary、backend subscription authority、app-facing entitlement mirror、store verification / notification boundary  
+**Project Type**: documentation / architecture component design  
+**Performance Goals**: レビュー担当者が 5 分以内に「課金状態の正本」「機能 unlock の正本」「UI 制御責務」を説明できること、10 分以内に purchase / restore / protected feature evaluation の 3 フローを component 単位で追跡できること、5 分以内に任意の billing 変更要求を in-scope component または deferred scope へ割り当てられること  
+**Constraints**: product code は追加しない、009 のオニオン分離方針と矛盾しない、課金状態の最終正本は backend 側に置く、アプリ側は同期済み entitlement mirror だけで UI 制御する、purchase state は `initiated` / `submitted` / `verifying` / `verified` / `rejected` を区別する、authoritative subscription state は `active` / `grace` / `expired` / `pending-sync` / `revoked` を区別する、`grace` 中は有料 entitlement を維持する、entitlement と usage limit の消費判定を統合しない、mobile storefront / purchase verification / store notification adapter ごとに timeout / retry / fallback を定義する、store SDK detail や pricing / tax / refund policy は再定義しない、auth/session と command semantics の既存正本を上書きしない、識別子命名は憲章に従う  
+**Scale/Scope**: 6 つの boundary group、3 つの inner policy component、15 の canonical subscription component、2 つの canonical state model、3 つの主要フロー、5 つの contract 文書を含む docs-first の billing boundary design package を対象とする
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Domain impact is identified. 本 feature は `docs/internal/domain/*.md` を terminology source として参照するが、aggregate、value object、repository contract 自体は変更しない。subscription / billing component の責務境界のみを整理する docs-first feature として扱う。
+- [x] Async generation flows keep lifecycle and visibility rules. 本 feature は解説生成や画像生成の workflow 自体を再定義せず、billing gate が既存の完了結果のみ公開ルールを壊さない前提で設計する。subscription reconciliation は別 workflow として扱うが、生成物の visibility rule は変更しない。
+- [x] External dependencies remain behind ports/adapters. mobile storefront、purchase verification、store notification は external adapter として整理し、domain や UI へ vendor detail を持ち込まない。憲章の要件に従い、timeout、retry、障害時 fallback を plan と contract に明示する。
+- [x] User stories are independently reviewable. 課金責務の正本整理、unlock / quota 分離、deferred scope 固定はそれぞれ別の成果物レビューで確認できる。
+- [x] 学習概念を混同しない。purchase state、subscription state、entitlement、feature gate decision、usage limit は `Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態と統合しない。
+- [x] Identifier naming follows the constitution. 本 feature は新しい domain identifier を追加しないが、参照する用語と contract 名では `XxxIdentifier` / `identifier` / 概念名参照の規約を崩さない。
+
+Post-design re-check: PASS. Verified against `research.md`, `data-model.md`,
+`contracts/subscription-topology-contract.md`,
+`contracts/subscription-authority-contract.md`,
+`contracts/entitlement-gate-contract.md`,
+`contracts/purchase-reconciliation-contract.md`, and
+`contracts/subscription-deferred-scope-contract.md`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-subscription-component-boundaries/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── entitlement-gate-contract.md
+│   ├── purchase-reconciliation-contract.md
+│   ├── subscription-authority-contract.md
+│   ├── subscription-deferred-scope-contract.md
+│   └── subscription-topology-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+docs/
+├── external/
+│   ├── adr.md
+│   └── requirements.md
+└── internal/
+    └── domain/
+        ├── common.md
+        ├── learner.md
+        └── service.md
+
+specs/
+├── 007-backend-command-design/
+├── 008-auth-session-design/
+├── 009-component-boundaries/
+└── 010-subscription-component-boundaries/
+```
+
+**Structure Decision**: 010 は 009 の product-wide component boundary 正本を置き換えず、
+その内側 / 外側分離を再利用した subscription-specific boundary package として扱う。
+component taxonomy の最終的な外部同期先は `docs/external/adr.md` と
+`docs/external/requirements.md` だが、本 feature の planning artifact では
+`specs/010-subscription-component-boundaries/` に設計判断と review 導線をまとめる。
+auth/session の behavioral contract は `specs/008-auth-session-design/`、
+command semantics と retry / regenerate rule は `specs/007-backend-command-design/`、
+既存の product-wide component taxonomy は `specs/009-component-boundaries/` を正本参照とし、
+010 では billing-specific component、purchase state model、authority rule、adapter resilience、
+gate rule、deferred scope だけを定義する。
+
+## Complexity Tracking
+
+> No constitution violations requiring justification were identified.

--- a/specs/010-subscription-component-boundaries/quickstart.md
+++ b/specs/010-subscription-component-boundaries/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart: Subscription Component Boundaries
+
+## 1. topology を確認する
+
+最初に [subscription-topology-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-topology-contract.md) を読み、010 が 009 のオニオン分離を再利用した subscription-specific boundary package であることを確認する。
+
+確認ポイント:
+
+- top-level boundary group が `Presentation`、`Actor/Auth Boundary`、`Command Intake`、`Query Read`、`Async Subscription Reconciliation`、`External Adapters` に整理されていること
+- `Domain Core` と `Application Coordination` は 009 側の内側基盤を再利用し、この feature で再定義していないこと
+
+## 2. authority と state model を確認する
+
+[subscription-authority-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-authority-contract.md) を読み、課金状態の最終正本が backend にあること、app は synced entitlement mirror だけを UI 制御に使うことを確認する。
+
+確認ポイント:
+
+- `active`、`grace`、`expired`、`pending-sync`、`revoked` の 5 状態が定義されていること
+- `initiated`、`submitted`、`verifying`、`verified`、`rejected` の purchase state model が subscription state と別に定義されていること
+- `grace` は paid entitlement を維持し、`pending-sync` は status 表示できても unlock 判定には使わないこと
+
+## 3. entitlement と quota gate の分離を確認する
+
+[entitlement-gate-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/entitlement-gate-contract.md) を読み、subscription state、entitlement、feature gate、usage limit が別責務になっていることを確認する。
+
+確認ポイント:
+
+- `Entitlement Policy` と `Subscription Feature Gate` が別 component として定義されていること
+- usage 消費判定が `Usage Metering / Quota Gate` に分離されていること
+
+## 4. purchase / restore / refresh のフローを確認する
+
+[purchase-reconciliation-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/purchase-reconciliation-contract.md) を読み、購入完了、復元、状態再同期がどの component を通るかを確認する。
+
+確認ポイント:
+
+- purchase artifact 提出、verification、authoritative state 更新、mirror 読み出しが別工程になっていること
+- purchase state progression が `verified` になるまで unlock 根拠に使われないこと
+- store notification による cross-device reconciliation が別 workflow として定義されていること
+
+## 5. adapter resilience を確認する
+
+[subscription-authority-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-authority-contract.md) と [purchase-reconciliation-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/purchase-reconciliation-contract.md) を読み、timeout、retry、fallback が unlock 誤判定を起こさない形で定義されていることを確認する。
+
+確認ポイント:
+
+- `Mobile Storefront Adapter`、`Purchase Verification Adapter`、`Store Notification Adapter` ごとに timeout / retry / fallback が示されていること
+- adapter 障害中は status 表示を継続しても未確認 entitlement を unlock 根拠にしないこと
+
+## 6. deferred scope を確認する
+
+最後に [subscription-deferred-scope-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-deferred-scope-contract.md) を読み、今回 ownership を持たない billing concern を確認する。
+
+確認ポイント:
+
+- auth/session は 008、command semantics は 007、product-wide taxonomy は 009 を参照すること
+- pricing / tax / refund policy / vendor SDK detail は今回の対象外であること
+
+## Review Sequence
+
+1. [spec.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md)
+2. [plan.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/plan.md)
+3. [research.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/research.md)
+4. [data-model.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md)
+5. [subscription-topology-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-topology-contract.md)
+6. [subscription-authority-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-authority-contract.md)
+7. [entitlement-gate-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/entitlement-gate-contract.md)
+8. [purchase-reconciliation-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/purchase-reconciliation-contract.md)
+9. [subscription-deferred-scope-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-deferred-scope-contract.md)

--- a/specs/010-subscription-component-boundaries/research.md
+++ b/specs/010-subscription-component-boundaries/research.md
@@ -1,0 +1,113 @@
+# Research: Subscription Component Boundaries
+
+## Decision: 010 は 009 のオニオン分離を再利用し、subscription 専用 component family を定義する
+
+**Rationale**: 既存の 009 は product-wide の component boundary discipline を固定している。
+subscription feature が別のアーキテクチャ様式を持ち込むと、責務の見せ方が feature ごとに
+ずれる。そこで 010 では 009 の内側基盤 / 外側責務の分離を再利用しつつ、billing 文脈に
+必要な component family だけを追加定義する。
+
+**Alternatives considered**:
+
+- subscription 用に別のレイヤードアーキテクチャを採用する
+- 009 の component taxonomy を直接上書きして billing を組み込む
+
+## Decision: 課金状態の最終正本は backend authoritative subscription state が持ち、アプリは同期済み entitlement mirror だけで UI 制御する
+
+**Rationale**: スマホアプリだけを正本にすると、複数端末、restore purchase、反映遅延、
+返金や revoke を安全に扱えない。backend が正本を持ち、アプリには同期済みの entitlement
+mirror だけを渡す形なら、セキュリティと UX を両立しやすい。
+
+**Alternatives considered**:
+
+- アプリ側を最終正本にする
+- backend のみを都度参照し、アプリ mirror を持たない
+
+## Decision: authoritative subscription state は `active` / `grace` / `expired` / `pending-sync` / `revoked` の 5 状態にする
+
+**Rationale**: `active` / `inactive` の 2 状態では、支払い猶予、反映遅延、失効、revocation を
+区別できない。5 状態に分けることで、unlock 判定、UI 表示、reconciliation の責務を明確に
+できる。
+
+**Alternatives considered**:
+
+- `active` / `inactive` の 2 状態だけを使う
+- `pending-sync` を持たず、すべて `inactive` に含める
+
+## Decision: `grace` は一時継続状態として扱い、通常の有料 entitlement を維持する
+
+**Rationale**: `grace` で即時ロックすると、課金更新遅延や store 由来の短期揺らぎで UX が
+悪化する。`revoked` と `expired` を別に持つ以上、`grace` は paid entitlement 維持とする
+方が state 分離の意味が明確になる。
+
+**Alternatives considered**:
+
+- `grace` で閲覧のみ許可し、生成を止める
+- `grace` でも即時に有料機能を停止する
+
+## Decision: `Entitlement Policy`、`Subscription Feature Gate`、`Usage Metering / Quota Gate` を分離する
+
+**Rationale**: 契約で何が許可されるかと、今期の無料枠や上限を消費済みかは別概念である。
+これを 1 つの `isPremium` や単一 gate に潰すと、plan 変更、無料枠、quota 超過、機能単位の
+制限差分を安全に扱えない。unlock 権限、最終 gate、quota 消費判定を分ける方が拡張しやすい。
+
+**Alternatives considered**:
+
+- entitlement と quota 判定を 1 component にまとめる
+- アプリ側 local counter で quota を管理する
+
+## Decision: purchase state は `initiated` / `submitted` / `verifying` / `verified` / `rejected` の canonical model として subscription state から分離する
+
+**Rationale**: 課金受付と契約状態反映は別タイミングで進むため、purchase 成功表示と
+authoritative subscription state を 1 つの state へ潰すと `pending-sync` の意味が曖昧になる。
+purchase state を別モデルにすることで、受付、検証中、検証成功、拒否を subscription state と
+独立に説明できる。
+
+**Alternatives considered**:
+
+- purchase state を定義せず `pending-sync` に吸収する
+- purchase state を storefront 側の local status のみで扱う
+
+## Decision: purchase / restore / refresh は command intake、verification / notification は async reconciliation、status / entitlement / allowance は read-side に分離する
+
+**Rationale**: purchase interaction、purchase verification、store notification 反映、UI 表示は
+タイミングも失敗要因も異なる。1 つの billing component にまとめると、受付、同期、状態参照、
+機能 gate が混線する。write-side、read-side、async reconciliation を分けた方が review しやすい。
+
+**Alternatives considered**:
+
+- purchase / restore / refresh を単一 billing service にまとめる
+- status read と entitlement decision を同じ reader に押し込む
+
+## Decision: mobile storefront、purchase verification、store notification は external adapters とし、pricing / tax / refund policy / SDK detail は deferred scope に残す
+
+**Rationale**: この feature の目的は component boundary 定義であり、ストア設定、税務、
+価格カタログ、SDK detail を確定することではない。外部境界だけを明示し、具体 policy や
+vendor detail は別 feature に委ねた方が責務が二重化しない。
+
+**Alternatives considered**:
+
+- store-specific pricing / tax / refund detail まで 010 で定義する
+- vendor SDK の選択と boundary 定義を同じ artifact で固定する
+
+## Decision: mobile storefront、purchase verification、store notification adapter には timeout / retry / fallback を明示する
+
+**Rationale**: 憲章は新しい外部依存に対して timeout、再試行、障害時の代替動作の記載を
+要求している。billing では adapter 障害時に unlock を誤判定しないことが重要なので、
+各 adapter の resilience を明示する。
+
+**Alternatives considered**:
+
+- resilience は実装時にのみ決め、計画書には書かない
+- すべての adapter に共通の曖昧な fallback だけを定義する
+
+## Decision: auth/session と backend command の既存正本は再定義せず、subscription component は接続境界だけを定義する
+
+**Rationale**: actor handoff は 008、command semantics は 007 がすでに正本を持つ。
+subscription feature がそれらの behavioral contract を再定義すると、auth / billing / command
+の責務が衝突する。010 では billing 文脈から見た利用点だけを定義する。
+
+**Alternatives considered**:
+
+- 010 で actor resolution と command semantics を再度定義する
+- auth/session を subscription package に取り込む

--- a/specs/010-subscription-component-boundaries/spec.md
+++ b/specs/010-subscription-component-boundaries/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Subscription Component Boundaries
+
+**Feature Branch**: `010-component-boundaries`  
+**Created**: 2026-04-18  
+**Status**: Draft  
+**Input**: User description: "PR6のままサブスク用のアーキテクチャコンポーネント定義をする"
+
+## Clarifications
+
+### Session 2026-04-18
+
+- Q: 機能解放の最終判定をどこで行うか → A: backend が最終正本を持ち、アプリは同期済み entitlement mirror で UI 制御する
+- Q: authoritative subscription state の最小粒度 → A: `active` / `grace` / `expired` / `pending-sync` / `revoked` の 5 状態にする
+- Q: 利用上限の消費判定をどこで持つか → A: `Entitlement Policy` は解放権限だけを持ち、利用上限の消費判定は別の `Usage Metering / Quota Gate` component として分ける
+- Q: `grace` 状態での機能解放方針 → A: `grace` 中は通常の有料 entitlement を維持する
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 課金責務の正本を整理する (Priority: P1)
+
+アーキテクチャレビュー担当者として、サブスクに関わる責務がどこで管理されるかを
+一目で把握したい。そうすることで、課金有無の判定、機能解放、購入 UI が同じ箱に
+混ざらない状態を先に固定したい。
+
+**Why this priority**: 課金まわりは purchase、subscription state、entitlement、
+feature gate を混同しやすく、最初に責務境界を固定しないと後続設計が崩れるため。
+
+**Independent Test**: 成果物だけを読めば、第三者が 5 分以内に
+「誰が課金状態の正本を持ち、誰が機能解放を判定し、誰が UI を担うか」を説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** サブスク導入前の component catalog がある, **When** レビュー担当者が subscription 関連責務を確認する, **Then** mobile purchase、subscription state、entitlement、feature gate、UI の責務差分が明示されている
+2. **Given** 課金有無の判定をどこで持つかを確認する, **When** component definition を読む, **Then** mobile storefront、backend authoritative state、app-facing gate の境界が区別されている
+
+---
+
+### User Story 2 - 課金状態と機能解放の流れを分離する (Priority: P2)
+
+実装担当者として、購入受付、購入状態照合、subscription 状態保持、entitlement 判定、
+feature unlock の流れを混同せずに扱いたい。そうすることで、有料機能の開放条件と
+制限条件を一貫して定義したい。
+
+**Why this priority**: `isPremium` のような単一フラグへ潰すと、購入済みだが未反映、
+期限切れ、猶予中、復元待ちなどの状態を適切に扱えないため。
+
+**Independent Test**: 第三者が成果物だけを読んで、購入確認から entitlement 反映、
+feature gate 判定までを component 単位で追跡できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** ユーザーが有料プランを購入する, **When** subscription flow を確認する, **Then** purchase interaction、authoritative subscription state、entitlement evaluation、feature gate が別責務として示されている
+2. **Given** 課金により画像生成や解説生成の利用制限が変わる, **When** component definition を確認する, **Then** 制限条件と解放条件が entitlement と feature gate で表現されている
+3. **Given** 課金処理が pending または照合中である, **When** UI の責務を見る, **Then** 状態は表示できるが backend で confirmed された entitlement ではない限り unlock しないことが明示されている
+4. **Given** 月次上限や無料枠の消費判定を確認する, **When** component definition を読む, **Then** entitlement と usage metering / quota gate が別責務として示されている
+
+---
+
+### User Story 3 - 課金境界と deferred scope を固定する (Priority: P3)
+
+将来の変更担当者として、価格設定、税務、ストア固有設定、返金通知、利用制限変更の
+どれが今回の対象で、どれが別 feature や外部境界の責務かを判断したい。
+
+**Why this priority**: billing は store policy、backend verification、product policy が
+絡むため、対象外領域を明示しないと文書間で責務が二重化しやすいため。
+
+**Independent Test**: 任意のサブスク関連変更要求を見たときに、第三者が
+in-scope component か deferred scope かを 5 分以内に割り当てられれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** ストア固有の購入設定や価格変更の相談がある, **When** component definition を確認する, **Then** 外部境界または deferred scope として扱うべき理由が示されている
+2. **Given** 課金による機能 unlock 条件を変更したい, **When** component definition を確認する, **Then** 変更先が entitlement policy か feature gate かを判断できる
+
+---
+
+### Edge Cases
+
+- ユーザー端末では購入成功に見えるが、authoritative subscription state への反映がまだ完了していない場合
+- purchase state が `submitted` または `verifying` のまま、purchase verification adapter のタイムアウトや一時障害で長引く場合
+- subscription が失効、猶予中、復元待ちのいずれかで、即時に unlock / lock を切り替えてよいか曖昧な場合
+- subscription state が `grace` または `revoked` のとき、UI 表示と機能 unlock の扱いがずれる場合
+- 同じ actor が複数端末を使い、端末ごとの local purchase cache と backend state がずれる場合
+- 購入済みでも entitlement が plan 変更で縮小され、機能ごとの制限値だけが変わる場合
+- サブスク状態は有効だが、特定機能だけ別 entitlement として制御したい場合
+- entitlement は有効でも usage quota が尽きており、unlock と実行可否の判定が分かれる場合
+- `grace` 中は有料機能を維持する一方、`expired` または `revoked` では停止する境界を明確にする必要がある場合
+- mobile storefront または store notification adapter が一時利用不能で、再試行中は状態表示だけを継続しつつ unlock は止める必要がある場合
+
+## Domain & Async Impact *(mandatory when applicable)*
+
+- **Domain Models Affected**: None
+- **Invariants / Terminology**: purchase state、subscription state、entitlement、feature gate decision、usage limit は別概念として維持し、`Frequency`、`Sophistication`、`Proficiency`、登録状態、生成状態とは統合しない
+- **Quota Rule**: entitlement の付与と usage limit の消費判定は別責務として扱い、quota 消費は独立した gate で評価する
+- **Async Lifecycle**: 課金確認と state reconciliation は pending / running / succeeded / failed を区別して説明し、未確定状態のまま unlock 判定へ進めない
+- **Purchase State Rule**: canonical purchase state は少なくとも `initiated`、`submitted`、`verifying`、`verified`、`rejected` を区別し、authoritative subscription state とは別概念として扱う
+- **Subscription State Rule**: authoritative subscription state は少なくとも `active`、`grace`、`expired`、`pending-sync`、`revoked` を区別して扱う
+- **Grace Rule**: `grace` は一時的な継続状態として扱い、通常の有料 entitlement を維持する
+- **User Visibility Rule**: ユーザーへは購入状態や反映待ち状態を表示してよいが、機能 unlock は confirmed entitlement に限る
+- **Identifier Naming Rule**: 既存の識別子命名規約を変更せず、新しい component 定義でも `XxxIdentifier`、`identifier`、概念名参照のルールを前提にする
+- **External Ports / Adapters**: mobile storefront、purchase verification、server notification、subscription synchronization は external boundary として区別する
+- **Adapter Resilience Rule**: mobile storefront、purchase verification、store notification adapter は timeout、retry、fallback を明示し、一時障害時も未確認 entitlement を unlock 根拠にしない
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 成果物は、サブスク関連の current component 候補を review し、purchase、subscription state、entitlement、feature gate、UI の主責務を定義しなければならない
+- **FR-002**: 成果物は、mobile purchase interaction と backend authoritative subscription state を別責務として定義しなければならない
+- **FR-002a**: 成果物は、authoritative subscription state として `active`、`grace`、`expired`、`pending-sync`、`revoked` を区別し、それぞれが unlock 判定へ与える影響を説明しなければならない
+- **FR-002b**: 成果物は、`grace` 状態では通常の有料 entitlement を維持し、`expired` と `revoked` とは異なる unlock 方針を明示しなければならない
+- **FR-002c**: 成果物は、purchase state の canonical model として `initiated`、`submitted`、`verifying`、`verified`、`rejected` を定義し、authoritative subscription state と別責務であることを明示しなければならない
+- **FR-003**: 成果物は、subscription 状態から機能解放条件を導く entitlement policy component を定義しなければならない
+- **FR-004**: 成果物は、entitlement に基づいて app core と UI の利用可否を判定する feature gate component を定義しなければならない
+- **FR-004a**: 成果物は、機能解放の最終正本を backend 側の entitlement 判定に置き、アプリ側は同期済み entitlement mirror を用いた UI 制御だけを行うよう定義しなければならない
+- **FR-004b**: 成果物は、entitlement の付与と usage limit の消費判定を別責務として定義し、`Usage Metering / Quota Gate` component を明示しなければならない
+- **FR-005**: 成果物は、purchase state、subscription state、entitlement、feature gate decision、usage limit を混同しないように定義しなければならない
+- **FR-006**: 成果物は、confirmed ではない purchase / subscription 状態では有料機能を unlock しない rule を示さなければならない
+- **FR-007**: 成果物は、restore purchase、status refresh、cross-device reconciliation がどの責務で扱われるかを示さなければならない
+- **FR-007a**: 成果物は、mobile storefront、purchase verification、store notification adapter ごとに timeout、retry、障害時 fallback の扱いを示さなければならない
+- **FR-008**: 成果物は、課金による機能制限と解放を subscription そのものではなく entitlement と feature gate の組み合わせで説明しなければならない
+- **FR-009**: 成果物は、課金状態の正本、機能 unlock の正本、UI 表示責務を別の component として定義しなければならない
+- **FR-010**: 成果物は、auth/session、component boundaries、backend command の既存設計と矛盾しない言葉で subscription component を整理しなければならない
+- **FR-011**: 成果物は、store-specific configuration、pricing catalog、tax、refund policy、vendor SDK detail を deferred scope または外部境界として明示しなければならない
+- **FR-012**: 成果物は、サブスク有無の判定と機能解放の判定を、第三者が end-to-end で追跡できる粒度で示さなければならない
+
+### Key Entities *(include if feature involves data)*
+
+- **Subscription Component Definition**: subscription 関連 component の名前、主責務、ownership、非責務を表す定義
+- **Purchase State**: 購入要求や復元要求の進行状況を表す状態
+- **Purchase State Model**: `initiated`、`submitted`、`verifying`、`verified`、`rejected` の canonical progression を持ち、authoritative subscription state より手前の受付・照合状態を表すモデル
+- **Subscription State**: actor に紐づく契約状態の正本として扱う状態であり、少なくとも `active`、`grace`、`expired`、`pending-sync`、`revoked` を区別する
+- **Entitlement**: 契約に基づいて解放される機能・上限・権限の集合
+- **Feature Gate Decision**: 特定機能を許可、制限、拒否する判定結果
+- **Usage Metering / Quota Gate**: entitlement とは別に、利用回数、期間上限、無料枠消費を評価して実行可否を返す component
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: レビュー担当者が、課金状態の正本、機能 unlock の正本、UI 表示責務を 5 分以内に説明できる
+- **SC-002**: 第三者が、購入確認から entitlement 反映、feature gate 判定までの流れを 10 分以内に追跡できる
+- **SC-003**: purchase state、subscription state、entitlement、feature gate decision の責務混同に関する指摘漏れが 0 件になる
+- **SC-004**: サブスク関連の変更要求を in-scope component または deferred scope へ割り当てる文書横断の矛盾が 0 件になる
+
+## Assumptions
+
+- mobile storefront が実際の課金処理を担い、product 内 component はその結果の利用点だけを定義する
+- backend が actor に紐づく authoritative subscription state と entitlement の正本を持つ
+- purchase と restore の受付は canonical purchase state model に従い、`verified` になるまで premium unlock の根拠にしない
+- authoritative subscription state の最小粒度は `active`、`grace`、`expired`、`pending-sync`、`revoked` とする
+- `grace` は短期的な継続状態として扱い、通常の有料 entitlement を維持する
+- app core は purchase detail や store credential ではなく、backend と同期済みの entitlement と feature gate decision だけを受け取る
+- 有料機能は explanation generation、image generation、利用上限など複数の feature gate へ展開されうる
+- 利用回数や期間上限の消費判定は backend 側の `Usage Metering / Quota Gate` が正本を持つ
+- mobile storefront、purchase verification、store notification adapter は timeout、retry、fallback を定義し、一時障害中は状態表示のみを継続して unlock は保留する
+- pricing catalog、税務、返金、store policy detail、vendor SDK 選定はこの feature では扱わない

--- a/specs/010-subscription-component-boundaries/tasks.md
+++ b/specs/010-subscription-component-boundaries/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Subscription Component Boundaries
+
+**Input**: Design documents from `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/`  
+**Prerequisites**: [plan.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/plan.md) (required), [spec.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md) (required), [research.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/research.md), [data-model.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md), [contracts/](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts), [quickstart.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/quickstart.md)
+
+**Tests**: 専用の test-first task は追加しない。検証は subscription authority review、purchase-state review、entitlement gate review、adapter resilience review、purchase reconciliation review、deferred-scope review、cross-document review を independent test として扱う。
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this belongs to (`US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 010 の設計成果物を置く受け皿と参照導線を揃える
+
+- [X] T001 Create the feature artifact skeleton in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/plan.md`, `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/research.md`, `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md`, `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/quickstart.md`, and `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/`
+- [X] T002 [P] Update `/Users/lihs/workspace/vocastock/.specify/feature.json` to keep `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries` as the active feature directory
+- [X] T003 [P] Sync `/Users/lihs/workspace/vocastock/AGENTS.md` with the planning context for subscription component boundary design
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: すべての user story が依存する source-of-truth、用語、authority framing を固定する
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Update billing-boundary source-of-truth references in `/Users/lihs/workspace/vocastock/docs/external/requirements.md` using `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/plan.md`, and `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md` as alignment inputs
+- [X] T005 [P] Cross-check subscription terminology and actor-reference wording in `/Users/lihs/workspace/vocastock/docs/internal/domain/common.md`, `/Users/lihs/workspace/vocastock/docs/internal/domain/learner.md`, and `/Users/lihs/workspace/vocastock/docs/internal/domain/service.md` against `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md` without changing domain semantics
+- [X] T006 [P] Normalize authoritative-state names, entitlement mirror wording, and quota terminology across `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md`, `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md`, and `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/`
+- [X] T007 [P] Capture feature-wide assumptions, external-boundary framing, and cross-feature source-of-truth notes in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/plan.md` and `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/research.md`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - 課金責務の正本を整理する (Priority: P1) 🎯 MVP
+
+**Goal**: subscription topology、authoritative state、app-facing mirror の責務を整理し、課金状態の正本、unlock の正本、UI 表示責務を独立レビュー可能にする
+
+**Independent Test**: [subscription-topology-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-topology-contract.md)、[subscription-authority-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-authority-contract.md)、[data-model.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md) を読むだけで、第三者が 5 分以内に authoritative owner、purchase state と subscription state の分離、entitlement mirror、UI responsibility を説明できること
+
+### Implementation for User Story 1
+
+- [X] T008 [P] [US1] Define boundary groups, canonical subscription components, inner policy components, and dependency-direction rules in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-topology-contract.md`
+- [X] T009 [P] [US1] Define the authoritative-source matrix, five-state subscription model, canonical purchase-state model, entitlement mirror rules, and adapter resilience rules in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-authority-contract.md`
+- [X] T010 [US1] Map `SubscriptionBoundaryGroup`, `SubscriptionComponentDefinition`, `AuthoritativeSubscriptionStateModel`, `PurchaseStateModel`, `AdapterResiliencePolicy`, and `EntitlementMirror` semantics into `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md`
+- [X] T011 [US1] Align User Story 1 wording, FR-001 through FR-004a, assumptions, and authority-related edge cases in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md`
+- [X] T012 [US1] Update the subscription / billing component section in `/Users/lihs/workspace/vocastock/docs/external/adr.md` and the billing source-of-truth guidance in `/Users/lihs/workspace/vocastock/docs/external/requirements.md` with the finalized topology and authority rules
+
+**Checkpoint**: User Story 1 should make subscription authority and UI responsibility independently reviewable
+
+---
+
+## Phase 4: User Story 2 - 課金状態と機能解放の流れを分離する (Priority: P2)
+
+**Goal**: entitlement、feature gate、usage quota、purchase / restore / refresh / reconciliation の流れを分離し、premium unlock と usage 制限を混同しない構成を固める
+
+**Independent Test**: [entitlement-gate-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/entitlement-gate-contract.md)、[purchase-reconciliation-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/purchase-reconciliation-contract.md)、[data-model.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md) を読むだけで、第三者が purchase state の進行、adapter timeout / retry / fallback、entitlement 反映、quota 判定、feature gate までを component 単位で追跡できること
+
+### Implementation for User Story 2
+
+- [X] T013 [P] [US2] Define entitlement, feature gate, and usage-quota responsibility separation in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/entitlement-gate-contract.md`
+- [X] T014 [P] [US2] Define complete-purchase, restore-purchase, and refresh / notification reconciliation flows, purchase-state progression, and adapter resilience matrix in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/purchase-reconciliation-contract.md`
+- [X] T015 [US2] Extend `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md` with `UsageQuotaPolicy`, `SubscriptionFlowAssignment`, purchase-state effect tables, adapter resilience matrix, and gate decision flow assignments
+- [X] T016 [US2] Align User Story 2 wording, Domain & Async Impact, and FR-004b through FR-009 in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md` with the finalized purchase-state / gate / reconciliation split
+- [X] T017 [US2] Capture the rationale for backend authority, purchase-state separation, adapter resilience, `grace` handling, `pending-sync` denial, and quota separation in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/research.md`
+
+**Checkpoint**: User Story 2 should make unlock / quota / reconciliation flow separation independently reviewable
+
+---
+
+## Phase 5: User Story 3 - 課金境界と deferred scope を固定する (Priority: P3)
+
+**Goal**: auth/session、backend command、product-wide taxonomy、pricing / tax / refund / SDK detail の ownership を切り分け、サブスク変更要求の行き先を一貫して判断できるようにする
+
+**Independent Test**: [subscription-deferred-scope-contract.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-deferred-scope-contract.md)、[quickstart.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/quickstart.md)、[plan.md](/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/plan.md) を読むだけで、第三者が任意の billing 変更要求を in-scope component または deferred source-of-truth へ 5 分以内に割り当てられること
+
+### Implementation for User Story 3
+
+- [X] T018 [P] [US3] Define the deferred ownership matrix, guardrails, and external-boundary split in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-deferred-scope-contract.md`
+- [X] T019 [P] [US3] Update `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/quickstart.md` with the review sequence for topology, authority, entitlement / quota separation, reconciliation, and deferred scope
+- [X] T020 [US3] Align User Story 3 wording, FR-010 through FR-012, assumptions, and deferred edge cases in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md` with the finalized ownership matrix
+- [X] T021 [US3] Update `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/plan.md` Structure Decision and source-of-truth notes to match the finalized deferred-scope ownership and external sync targets
+
+**Checkpoint**: User Story 3 should make deferred ownership and cross-feature boundaries independently reviewable
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 複数ストーリーに跨る整合と最終レビュー導線を整える
+
+- [X] T022 [P] Reconcile all 010 artifacts across `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/spec.md`, `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/plan.md`, `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/research.md`, `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/data-model.md`, `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/quickstart.md`, and `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/`
+- [X] T023 [P] Cross-check 010 subscription terminology against `/Users/lihs/workspace/vocastock/docs/external/adr.md`, `/Users/lihs/workspace/vocastock/docs/external/requirements.md`, `/Users/lihs/workspace/vocastock/specs/007-backend-command-design/plan.md`, `/Users/lihs/workspace/vocastock/specs/008-auth-session-design/plan.md`, and `/Users/lihs/workspace/vocastock/specs/009-component-boundaries/plan.md`
+- [X] T024 Re-run the review flow in `/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/quickstart.md` and reconcile reviewer guidance with the finalized subscription topology, purchase-state model, adapter resilience rules, entitlement / quota split, and deferred-scope boundaries
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on other stories
+- **User Story 2 (P2)**: Can start after Foundational - uses the topology and authority vocabulary from Phase 2, but remains independently reviewable
+- **User Story 3 (P3)**: Can start after Foundational - uses the same source-of-truth framing, but remains independently reviewable
+
+### Within Each User Story
+
+- Topology and authority contracts should be fixed before final spec wording adjustments
+- Entitlement / quota separation and reconciliation flows should land before final flow-alignment updates
+- Deferred ownership should be fixed before quickstart and structure-decision guidance are finalized
+
+### Parallel Opportunities
+
+- `T002` and `T003` can run in parallel after `T001`
+- `T005`, `T006`, and `T007` can run in parallel after `T004`
+- In US1, `T008` and `T009` can run in parallel
+- In US2, `T013` and `T014` can run in parallel
+- In US3, `T018` and `T019` can run in parallel
+- Final polish `T022` and `T023` can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch topology and authority tasks together:
+Task: "Define boundary groups, canonical subscription components, inner policy components, and dependency-direction rules in /Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-topology-contract.md"
+Task: "Define the authoritative-source matrix, five-state subscription model, entitlement mirror rules, and drift handling in /Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-authority-contract.md"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch gate-separation and reconciliation tasks together:
+Task: "Define entitlement, feature gate, and usage-quota responsibility separation in /Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/entitlement-gate-contract.md"
+Task: "Define complete-purchase, restore-purchase, and refresh / notification reconciliation flows in /Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/purchase-reconciliation-contract.md"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch deferred-scope tasks together:
+Task: "Define the deferred ownership matrix, guardrails, and external-boundary split in /Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/contracts/subscription-deferred-scope-contract.md"
+Task: "Update /Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/quickstart.md with the review sequence for topology, authority, entitlement / quota separation, reconciliation, and deferred scope"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate that subscription authority, entitlement mirror, and UI responsibility can be reviewed independently
+5. Stop and review before adding gate / quota and deferred-scope refinements
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational to fix vocabulary, source-of-truth references, and authority framing
+2. Add User Story 1 to define subscription topology and authoritative ownership
+3. Add User Story 2 to separate entitlement, quota, and reconciliation flows
+4. Add User Story 3 to define deferred ownership and review guidance
+5. Finish with cross-cutting reconciliation
+
+### Parallel Team Strategy
+
+1. One contributor handles Setup and Foundational alignment
+2. After Foundation:
+   - Contributor A: User Story 1 topology and authority
+   - Contributor B: User Story 2 gate / quota / reconciliation separation
+   - Contributor C: User Story 3 deferred ownership and review guidance
+3. Reconcile all artifacts together in Phase 6
+
+---
+
+## Notes
+
+- [P] tasks target different files and can proceed in parallel after dependencies
+- No standalone test-file tasks were generated because this feature is a design package and independent review is the intended validation mode
+- Keep 010 terminology aligned with `Presentation`, `Actor/Auth Boundary`, `Command Intake`, `Query Read`, `Async Subscription Reconciliation`, `External Adapters`, `Entitlement Policy`, `Subscription Feature Gate`, and `Usage Metering / Quota Gate`
+- Do not pull pricing / tax / refund policy, vendor SDK detail, auth/session lifecycle, or protected-feature command semantics into this feature


### PR DESCRIPTION
## Summary
- define the onion-based component taxonomy for vocastock
- sync the canonical component catalog into docs/external/adr.md
- add the 009 design package, review flow, and completed task tracking

## Validation
- requirements checklist: 16/16 pass
- cross-document review only (docs-first change)