### PR TITLE
feat(billing-worker): implement purchase verification and notification reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,158 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+vocastock は英単語の解説生成と視覚イメージ生成を扱うアプリケーションの polyglot monorepo。Rust (API services + shared) と Haskell (workers) を組み合わせたバックエンド、Flutter クライアント、Firebase を中心とした CQRS 構成。
+
+**開発モデル**: Spec Kit ベースの仕様駆動開発。憲章 `.specify/memory/constitution.md` が最上位、次に `docs/internal/domain/*.md` と `specs/NNN-*/` が続く。実装は必ず設計文書の更新と同じ変更セットで行う。
+
+## Repository Structure
+
+```
+applications/backend/
+├── graphql-gateway/      Rust — client-facing unified GraphQL endpoint
+├── command-api/          Rust — command acceptance / write / dispatch
+├── query-api/            Rust — completed result / status-only / subscription read
+├── explanation-worker/   Haskell — explanation workflow consumer
+├── image-worker/         Haskell — image workflow consumer
+└── billing-worker/       billing / restore / notification reconciliation
+
+packages/rust/
+├── shared-auth/          sidecar-only: auth / session handoff
+└── shared-runtime/       sidecar-only: logging / monitoring / readiness / correlation
+
+docker/applications/      Dockerfile は `docker/applications/<application>/` が正本
+docker/firebase/          repository-wide shared dependency stack (別管理)
+.specify/memory/          constitution.md — 最上位の設計憲章
+docs/internal/domain/     正本ドメイン文書 (common, learner, vocabulary-expression, learning-state, explanation, visual, service)
+docs/external/            requirements.md, adr.md
+specs/NNN-<slug>/         機能ごとの spec.md / plan.md / tasks.md など
+```
+
+## Core Architectural Principles (from constitution v2.1.0)
+
+1. **アプリケーション単位のドメイン所有**: domain model / workflow state / application coordination は **owning application 配下** に実装する。複数 application に同名概念が必要でも、shared executable domain package を新設してはならない。
+2. **shared package はサイドカー限定**: `packages/rust/shared-*` には logging / monitoring / auth-session handoff / request correlation / readiness probe / runtime helper のみ。aggregate / domain service / workflow state machine / persistence model / application use-case は禁止。
+3. **inner layer package の事前定義**: 各 application の inner layer package / module の名前、配置先、依存方向は、実装前に `specs/NNN/plan.md` に明記する。
+4. **非同期生成は完了結果のみ公開**: `pending` / `running` / `succeeded` / `failed` を区別し、ユーザーへは完了結果のみ表示。生成中や失敗中の本体は表示しない。
+5. **外部依存はポート越し**: AI サービス、画像ストレージ等はドメイン層から直接呼ばず、ポート/アダプタ経由で接続。ベンダー SDK をドメインへ持ち込まない。
+6. **学習概念を混同しない**: 頻出度、知的度、習熟度、登録状態、解説生成状態、画像生成状態を別概念として扱う。UI 文言、API、永続化、分析軸で混同しない。
+
+## Naming Constraints (厳守)
+
+- 識別子型は **`XxxIdentifier` 形式**。`id` / `ID` / `xxxId` は型名・フィールド名・契約名として使用禁止。
+- 集約自身の識別子フィールド名は常に **`identifier`**。
+- 集約が他集約/他概念の識別子を保持する場合、フィールド名は **概念名そのもの** (例: `User.bank: BankIdentifier`)。`bankIdentifier` や `bankId` は禁止。
+- `Detail` / `Info` のような含意の広い語はドメイン命名に使用禁止。
+
+## Rust Conventions
+
+- Cargo workspace root: `/Users/lihs/workspace/vocastock/Cargo.toml` (`resolver = "2"`, edition 2021)。
+- `workspace.lints.rust.unsafe_code = "forbid"`。
+- **`lib.rs` 禁止**: crate root は `[lib].path` で責務が分かる名前にする (例: `src/register_command_api/mod.rs`, `src/query_catalog_read/mod.rs`, `src/gateway_routing/mod.rs`)。既存の `lib.rs` に集まった定義は責務ごとに分割して移す。
+- レイヤー: `presentation → application → domain ← infrastructure`。
+- アプリケーションは必ず `shared-auth` / `shared-runtime` を依存として使う。
+
+## Haskell Conventions
+
+- GHC `9.2.8`、`default-language: GHC2021`。
+- package-local Cabal manifest (`<worker>.cabal`)。
+- モジュール階層は `<WorkerName>/...` (例: `ExplanationWorker.WorkflowStateMachine`, `ImageWorker.AssetStoragePort`)。
+- ポート/アダプタは separate module として切り出す (`GenerationPort`, `AssetStoragePort`, `ImagePersistence`, `CurrentExplanationHandoff` 等)。
+
+## Test Rules
+
+- **TDD 必須** (探索 → Red → Green → Refactoring)。
+- 配置: `tests/unit/*` (unit)、`tests/feature/*` (integration — Firebase エミュレータ + Docker)、`tests/support/*` (helper)。インラインテスト (`#[cfg(test)] mod tests`) は使わない。
+- 対応規則: `src/sample1.rs` → `tests/unit/sample1.rs` のようにファイル単位で対応させる。
+- **カバレッジ 90% 以上が絶対条件** (unit / feature 共通)。
+- Rust では `Cargo.toml` の `[[test]]` エントリ (`name = "unit"`, `name = "feature"`) で unit/feature を分ける。
+- Haskell では `test-suite unit` と `test-suite feature` を `.cabal` に分ける。feature は Docker/emulator を起動する形で `process`, `directory`, `filepath` を使う。
+
+## Common Commands
+
+**Rust quality gate** (workspace 全体):
+```bash
+bash scripts/ci/run_rust_quality_checks.sh --mode full
+# fmt → clippy → query-api unit → command-api unit → feature-all
+```
+
+**Rust 個別サービスのテスト** (例: command-api):
+```bash
+cargo test -p command-api --test unit
+cargo test -p command-api --test feature
+```
+
+**Haskell worker のビルド/テスト**:
+```bash
+cd applications/backend/explanation-worker
+cabal build all
+cabal test unit
+cabal test feature
+```
+
+**アプリケーションコンテナ検証**:
+```bash
+bash scripts/bootstrap/validate_application_containers.sh      # contract validate
+bash scripts/ci/run_application_container_smoke.sh             # application smoke (ポート競合時は空きポートへ自動退避)
+bash scripts/bootstrap/validate_local_stack.sh --with-application-containers  # Firebase emulator + application smoke
+```
+
+**Firebase emulator のみ**:
+```bash
+bash scripts/firebase/start_emulators.sh
+bash scripts/firebase/smoke_local_stack.sh
+bash scripts/firebase/stop_emulators.sh
+```
+
+**ホスト環境検証**:
+```bash
+bash scripts/bootstrap/verify_macos_toolchain.sh   # host baseline 検証
+bash scripts/bootstrap/validate_local_setup.sh     # local setup 検証
+```
+
+**Rust 変更検出** (CI と同じロジックをローカル再現):
+```bash
+bash scripts/ci/detect_rust_changes.sh --base origin/main --head HEAD
+```
+
+## Docker / Container Contract
+
+- Docker 関連ファイルは **`docker/applications/<application>/` が正本**。
+- API の既定 host port は **`18180-18182`** (Firebase emulator の `18080` と競合回避)。
+- local / CI は同じ Dockerfile / target / entry contract を使う (image artifact 共有は必須ではない)。
+- **canonical success signal**:
+  - API service → `HTTP readiness endpoint` (`VOCAS_READINESS_PATH`, 既定 `/readyz`)
+  - worker → `long-running consumer` の stable-run (`VOCAS_WORKER_STABLE_RUN_SECONDS`)
+- `rust-quality` ジョブは Rust path 非該当時は no-op success、該当時は `fmt → clippy → query-api unit → command-api unit → feature-all` を実行する。
+
+## Development Workflow
+
+1. **仕様確認**: 対象機能の `specs/NNN-*/spec.md` を確認。変更が必要なら同じ PR で更新。
+2. **plan の inner layer 定義**: 新規実装前に `plan.md` に inner layer package の名前/配置/依存方向を記述。
+3. **ドメイン文書の同期更新**: ドメイン境界を変える変更は `docs/internal/domain/*.md` を **同じ変更セットで更新**。先行実装は禁止。
+4. **TDD**: テスト (Red) → 実装 (Green) → リファクタ (Improve)。
+5. **pre-commit 検証** (該当する場合すべて):
+   - Rust: `cargo fmt --all` / `cargo clippy --all-targets -- -D warnings` / `cargo test --all`
+   - Haskell: `cabal build all` / `cabal test all`
+   - Container: `bash scripts/bootstrap/validate_application_containers.sh`
+6. **commit**: Conventional Commits + scope 必須 (例: `feat(command-api): ...`, `feat(explanation-worker): ...`, `chore(ci): ...`)。
+
+## Key References
+
+- 憲章: `.specify/memory/constitution.md` (変更は MAJOR/MINOR/PATCH でバージョン管理)
+- ドメイン正本: `docs/internal/domain/{common,learner,vocabulary-expression,learning-state,explanation,visual,service}.md`
+- ADR / 要件: `docs/external/{adr,requirements}.md`
+- Backend container contract: `docs/development/backend-container-environment.md`
+- CI policy: `docs/development/ci-policy.md`
+- 承認済みコンポーネントバージョン: `tooling/versions/approved-components.md`
+- auto-generated guidelines: `AGENTS.md` (最新の Spec Kit 出力)
+
+## Special Notes
+
+- 生成中または失敗中の中間生成結果はユーザーへ表示しない。完了済み結果のみ表示する。
+- shared package 配下へ domain を入れようとしたら、それは憲章違反 — owning application 配下に移す。
+- 新しい外部依存を追加する場合、タイムアウト/再試行/障害時代替動作を `plan.md` に必ず記載する。
+- `references/` ディレクトリは参考実装のコピー。vocastock 本体の実装対象ではない。

--- a/applications/backend/README.md
+++ b/applications/backend/README.md
@@ -19,3 +19,4 @@ API service は `HTTP readiness endpoint` を canonical success signal とし、
 - application smoke: `bash /Users/lihs/workspace/vocastock/scripts/ci/run_application_container_smoke.sh`
 - explanation-worker validation: `application-container-smoke.summary` に `success` / `retryable-failure` / `terminal-failure` が別 record で残る
 - image-worker validation: `application-container-smoke.summary` に `success` / `retryable-failure` / `terminal-failure` が別 record で残る
+- billing-worker validation: `application-container-smoke.summary` に `success` / `retryable-failure` / `terminal-failure` / `notification-reconciled` が別 record で残る

--- a/applications/backend/billing-worker/app/Main.hs
+++ b/applications/backend/billing-worker/app/Main.hs
@@ -1,0 +1,94 @@
+module Main (main) where
+
+import Control.Concurrent (threadDelay)
+import Control.Monad (forever)
+import BillingWorker.WorkerRuntime
+  ( WorkerScenario,
+    parseWorkerScenarioLabel,
+    renderScenarioReport,
+    runScenarioReport
+  )
+import System.Environment (lookupEnv)
+import System.IO
+  ( BufferMode (LineBuffering),
+    hSetBuffering,
+    stderr,
+    stdout
+  )
+
+data WorkerMode
+  = StableRunMode
+  | ValidateMode
+
+data WorkerConfig = WorkerConfig
+  { workerName :: String,
+    workerMode :: WorkerMode,
+    workerStableRunSeconds :: Int,
+    workerPollIntervalSeconds :: Int,
+    workerScenario :: Maybe WorkerScenario
+  }
+
+main :: IO ()
+main = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
+  loadWorkerConfigFromEnvironment >>= workerMain
+
+loadWorkerConfigFromEnvironment :: IO WorkerConfig
+loadWorkerConfigFromEnvironment = do
+  workerNameValue <- lookupOrDefault "VOCAS_WORKER_NAME" "billing-worker"
+  workerModeValue <- lookupOrDefault "VOCAS_WORKER_RUN_MODE" "stable"
+  stableRunEnv <- lookupEnv "VOCAS_WORKER_STABLE_RUN_SECONDS"
+  pollIntervalEnv <- lookupEnv "VOCAS_WORKER_POLL_INTERVAL_SECONDS"
+  scenarioValue <- lookupEnv "VOCAS_BILLING_WORKFLOW_SCENARIO"
+  pure
+    WorkerConfig
+      { workerName = workerNameValue,
+        workerMode = parseWorkerMode workerModeValue,
+        workerStableRunSeconds = readIntOrDefault stableRunEnv 10,
+        workerPollIntervalSeconds = readIntOrDefault pollIntervalEnv 30,
+        workerScenario = scenarioValue >>= parseWorkerScenarioLabel
+      }
+
+workerMain :: WorkerConfig -> IO ()
+workerMain workerConfig = do
+  maybePrintScenario workerConfig
+  case workerMode workerConfig of
+    ValidateMode -> pure ()
+    StableRunMode -> do
+      threadDelay (workerStableRunSeconds workerConfig * 1000000)
+      putStrLn $
+        "[vocastock] " ++ workerName workerConfig ++ " entered stable-run mode"
+      forever $ do
+        putStrLn $
+          "[vocastock] " ++ workerName workerConfig ++ " awaiting queue/subscription work"
+        threadDelay (workerPollIntervalSeconds workerConfig * 1000000)
+
+lookupOrDefault :: String -> String -> IO String
+lookupOrDefault key defaultValue = do
+  value <- lookupEnv key
+  pure (maybe defaultValue id value)
+
+readIntOrDefault :: Maybe String -> Int -> Int
+readIntOrDefault maybeValue defaultValue =
+  case maybeValue >>= readMaybeInt of
+    Just parsed -> parsed
+    Nothing -> defaultValue
+
+readMaybeInt :: String -> Maybe Int
+readMaybeInt value =
+  case reads value of
+    [(parsed, "")] -> Just parsed
+    _ -> Nothing
+
+parseWorkerMode :: String -> WorkerMode
+parseWorkerMode workerModeValue =
+  case workerModeValue of
+    "validate" -> ValidateMode
+    _ -> StableRunMode
+
+maybePrintScenario :: WorkerConfig -> IO ()
+maybePrintScenario workerConfig =
+  case workerScenario workerConfig of
+    Nothing -> pure ()
+    Just scenario -> putStrLn (renderScenarioReport (runScenarioReport scenario))

--- a/applications/backend/billing-worker/billing-worker.cabal
+++ b/applications/backend/billing-worker/billing-worker.cabal
@@ -1,0 +1,72 @@
+cabal-version: 3.4
+name: billing-worker
+version: 0.1.0.0
+build-type: Simple
+
+library
+  hs-source-dirs: src
+  exposed-modules:
+      BillingWorker.WorkItemContract
+      BillingWorker.WorkflowStateMachine
+      BillingWorker.PurchaseVerificationPort
+      BillingWorker.SubscriptionAuthorityPort
+      BillingWorker.EntitlementRecalcPort
+      BillingWorker.NotificationPort
+      BillingWorker.BillingPersistence
+      BillingWorker.CurrentSubscriptionHandoff
+      BillingWorker.FailureSummary
+      BillingWorker.WorkerRuntime
+  build-depends:
+      base >=4.15 && <5
+  default-language: GHC2021
+
+executable billing-worker
+  main-is: Main.hs
+  hs-source-dirs: app
+  build-depends:
+      base >=4.15 && <5
+    , billing-worker
+  default-language: GHC2021
+
+test-suite unit
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs:
+      tests/unit
+      tests/support
+  other-modules:
+      BillingWorker.WorkItemContractSpec
+      BillingWorker.WorkflowStateMachineSpec
+      BillingWorker.PurchaseVerificationPortSpec
+      BillingWorker.SubscriptionAuthorityPortSpec
+      BillingWorker.EntitlementRecalcPortSpec
+      BillingWorker.NotificationPortSpec
+      BillingWorker.BillingPersistenceSpec
+      BillingWorker.CurrentSubscriptionHandoffSpec
+      BillingWorker.FailureSummarySpec
+      BillingWorker.WorkerRuntimeSpec
+      TestSupport
+  build-depends:
+      base >=4.15 && <5
+    , billing-worker
+  default-language: GHC2021
+
+test-suite feature
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs:
+      tests/feature
+      tests/support
+  other-modules:
+      BillingWorker.FeatureSpec
+      FeatureSupport
+      TestSupport
+  build-depends:
+      base >=4.15 && <5
+    , containers
+    , directory
+    , filepath
+    , billing-worker
+    , process
+    , time
+  default-language: GHC2021

--- a/applications/backend/billing-worker/cabal.project
+++ b/applications/backend/billing-worker/cabal.project
@@ -1,0 +1,3 @@
+packages: .
+write-ghc-environment-files: never
+with-compiler: ghc-9.2.8

--- a/applications/backend/billing-worker/hie.yaml
+++ b/applications/backend/billing-worker/hie.yaml
@@ -1,0 +1,19 @@
+cradle:
+  cabal:
+    - path: "./app"
+      component: "exe:billing-worker"
+
+    - path: "./src"
+      component: "lib:billing-worker"
+
+    - path: "./tests/unit"
+      component: "test:unit"
+
+    - path: "./tests/feature"
+      component: "test:feature"
+
+    - path: "./tests/support/TestSupport.hs"
+      component: "test:unit"
+
+    - path: "./tests/support/FeatureSupport.hs"
+      component: "test:feature"

--- a/applications/backend/billing-worker/src/BillingWorker/BillingPersistence.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/BillingPersistence.hs
@@ -1,0 +1,167 @@
+module BillingWorker.BillingPersistence
+  ( BillingStore (..),
+    CompletedBillingRecord (..),
+    CompletedRecordVisibility (..),
+    CompletedBillingPayload (..),
+    RecordSource (..),
+    SaveAction (..),
+    SaveResult (..),
+    completedRecordFor,
+    emptyBillingStore,
+    existingRecordFor,
+    markRecordCurrentApplied,
+    renderCompletedRecordVisibility,
+    renderRecordSource,
+    renderSaveAction,
+    saveCompletedBilling
+  )
+where
+
+data RecordSource
+  = SourcePurchaseVerification
+  | SourceNotificationReconciliation
+  deriving (Eq, Show)
+
+data CompletedRecordVisibility
+  = HiddenUntilHandoff
+  | CurrentApplied
+  deriving (Eq, Show)
+
+data CompletedBillingPayload = CompletedBillingPayload
+  { completedPurchaseStateName :: String,
+    completedSubscriptionStateName :: String,
+    completedEntitlementBundleName :: String,
+    completedQuotaProfileName :: String,
+    completedTermStart :: String,
+    completedTermEnd :: String,
+    completedGraceWindow :: Maybe String
+  }
+  deriving (Eq, Show)
+
+data CompletedBillingRecord = CompletedBillingRecord
+  { recordIdentifier :: String,
+    recordSubscription :: String,
+    recordSource :: RecordSource,
+    recordVisibility :: CompletedRecordVisibility,
+    recordPayload :: CompletedBillingPayload
+  }
+  deriving (Eq, Show)
+
+data SaveAction
+  = SaveCreated
+  | SaveReused
+  deriving (Eq, Show)
+
+newtype BillingStore = BillingStore
+  { billingEntries :: [(String, CompletedBillingRecord)]
+  }
+  deriving (Eq, Show)
+
+data SaveResult = SaveResult
+  { saveAction :: SaveAction,
+    saveRecord :: CompletedBillingRecord,
+    saveStore :: BillingStore
+  }
+  deriving (Eq, Show)
+
+emptyBillingStore :: BillingStore
+emptyBillingStore = BillingStore {billingEntries = []}
+
+completedRecordFor ::
+  String -> String -> RecordSource -> CompletedBillingPayload -> CompletedBillingRecord
+completedRecordFor businessKey subscriptionIdentifier source completedPayload =
+  CompletedBillingRecord
+    { recordIdentifier = businessKey ++ "-completed",
+      recordSubscription = subscriptionIdentifier,
+      recordSource = source,
+      recordVisibility = HiddenUntilHandoff,
+      recordPayload = completedPayload
+    }
+
+existingRecordFor :: String -> BillingStore -> Maybe CompletedBillingRecord
+existingRecordFor businessKey store =
+  lookup (businessKey ++ "-completed") (billingEntries store)
+
+saveCompletedBilling ::
+  String ->
+  String ->
+  RecordSource ->
+  CompletedBillingPayload ->
+  BillingStore ->
+  SaveResult
+saveCompletedBilling businessKey subscriptionIdentifier source completedPayload store =
+  case existingRecordFor businessKey store of
+    Just existing ->
+      SaveResult
+        { saveAction = SaveReused,
+          saveRecord = existing,
+          saveStore = store
+        }
+    Nothing ->
+      let newRecord = completedRecordFor businessKey subscriptionIdentifier source completedPayload
+          updatedStore =
+            store
+              { billingEntries =
+                  (recordIdentifier newRecord, newRecord) : billingEntries store
+              }
+       in SaveResult
+            { saveAction = SaveCreated,
+              saveRecord = newRecord,
+              saveStore = updatedStore
+            }
+
+markRecordCurrentApplied ::
+  String -> BillingStore -> (CompletedBillingRecord, BillingStore)
+markRecordCurrentApplied businessKey store =
+  case existingRecordFor businessKey store of
+    Just existing ->
+      let appliedRecord = existing {recordVisibility = CurrentApplied}
+          updatedStore =
+            store
+              { billingEntries =
+                  ( recordIdentifier appliedRecord,
+                    appliedRecord
+                  )
+                    : filter
+                      (\(entryKey, _) -> entryKey /= recordIdentifier appliedRecord)
+                      (billingEntries store)
+              }
+       in (appliedRecord, updatedStore)
+    Nothing -> (placeholderRecord businessKey, store)
+
+placeholderRecord :: String -> CompletedBillingRecord
+placeholderRecord businessKey =
+  CompletedBillingRecord
+    { recordIdentifier = businessKey ++ "-missing",
+      recordSubscription = "",
+      recordSource = SourcePurchaseVerification,
+      recordVisibility = HiddenUntilHandoff,
+      recordPayload =
+        CompletedBillingPayload
+          { completedPurchaseStateName = "",
+            completedSubscriptionStateName = "",
+            completedEntitlementBundleName = "",
+            completedQuotaProfileName = "",
+            completedTermStart = "",
+            completedTermEnd = "",
+            completedGraceWindow = Nothing
+          }
+    }
+
+renderRecordSource :: RecordSource -> String
+renderRecordSource source =
+  case source of
+    SourcePurchaseVerification -> "purchase-verification"
+    SourceNotificationReconciliation -> "notification-reconciliation"
+
+renderCompletedRecordVisibility :: CompletedRecordVisibility -> String
+renderCompletedRecordVisibility completedVisibility =
+  case completedVisibility of
+    HiddenUntilHandoff -> "hidden-until-handoff"
+    CurrentApplied -> "current-applied"
+
+renderSaveAction :: SaveAction -> String
+renderSaveAction saveActionValue =
+  case saveActionValue of
+    SaveCreated -> "created"
+    SaveReused -> "reused"

--- a/applications/backend/billing-worker/src/BillingWorker/CurrentSubscriptionHandoff.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/CurrentSubscriptionHandoff.hs
@@ -1,0 +1,67 @@
+module BillingWorker.CurrentSubscriptionHandoff
+  ( CurrentAction (..),
+    ExistingCurrent (..),
+    HandoffStatus (..),
+    applyCurrentSubscriptionSuccess,
+    currentWasRetained,
+    renderCurrentAction,
+    renderHandoffStatus,
+    retainExistingCurrent
+  )
+where
+
+import BillingWorker.BillingPersistence
+  ( CompletedBillingRecord (..)
+  )
+
+data ExistingCurrent
+  = NoCurrent
+  | ExistingCurrent String
+  deriving (Eq, Show)
+
+data HandoffStatus
+  = HandoffApplied
+  | HandoffRetryableFailure
+  | HandoffSuperseded
+  deriving (Eq, Show)
+
+data CurrentAction
+  = CurrentSwitched String
+  | CurrentRetained (Maybe String)
+  | CurrentSuperseded String
+  deriving (Eq, Show)
+
+applyCurrentSubscriptionSuccess ::
+  CompletedBillingRecord -> ExistingCurrent -> HandoffStatus -> CurrentAction
+applyCurrentSubscriptionSuccess completedRecord existingCurrent handoffStatus =
+  case handoffStatus of
+    HandoffApplied -> CurrentSwitched (recordIdentifier completedRecord)
+    HandoffRetryableFailure -> retainExistingCurrent existingCurrent
+    HandoffSuperseded -> CurrentSuperseded (recordIdentifier completedRecord)
+
+retainExistingCurrent :: ExistingCurrent -> CurrentAction
+retainExistingCurrent existingCurrent =
+  case existingCurrent of
+    NoCurrent -> CurrentRetained Nothing
+    ExistingCurrent identifierValue -> CurrentRetained (Just identifierValue)
+
+currentWasRetained :: CurrentAction -> Bool
+currentWasRetained currentAction =
+  case currentAction of
+    CurrentRetained _ -> True
+    _ -> False
+
+renderCurrentAction :: CurrentAction -> String
+renderCurrentAction currentAction =
+  case currentAction of
+    CurrentSwitched identifierValue -> "switched:" ++ identifierValue
+    CurrentRetained Nothing -> "retained:none"
+    CurrentRetained (Just identifierValue) -> "retained:" ++ identifierValue
+    CurrentSuperseded identifierValue -> "superseded:" ++ identifierValue
+
+renderHandoffStatus :: HandoffStatus -> String
+renderHandoffStatus handoffStatus =
+  case handoffStatus of
+    HandoffApplied -> "applied"
+    HandoffRetryableFailure -> "retryable-failure"
+    HandoffSuperseded -> "superseded"

--- a/applications/backend/billing-worker/src/BillingWorker/EntitlementRecalcPort.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/EntitlementRecalcPort.hs
@@ -1,0 +1,88 @@
+module BillingWorker.EntitlementRecalcPort
+  ( EntitlementBundleName (..),
+    EntitlementDerivation (..),
+    QuotaProfileName (..),
+    deriveEntitlement,
+    parseEntitlementBundleName,
+    parseQuotaProfileName,
+    renderEntitlementBundleName,
+    renderQuotaProfileName
+  )
+where
+
+import BillingWorker.SubscriptionAuthorityPort
+  ( SubscriptionStateName (..)
+  )
+
+data EntitlementBundleName
+  = FreeBasicEntitlement
+  | PremiumGenerationEntitlement
+  deriving (Eq, Show)
+
+data QuotaProfileName
+  = FreeMonthlyQuota
+  | StandardMonthlyQuota
+  | ProMonthlyQuota
+  deriving (Eq, Show)
+
+data EntitlementDerivation = EntitlementDerivation
+  { derivationState :: SubscriptionStateName,
+    derivationBundle :: EntitlementBundleName,
+    derivationQuotaProfile :: QuotaProfileName
+  }
+  deriving (Eq, Show)
+
+deriveEntitlement ::
+  SubscriptionStateName -> QuotaProfileName -> EntitlementDerivation
+deriveEntitlement subscriptionStateValue paidQuotaProfile =
+  EntitlementDerivation
+    { derivationState = subscriptionStateValue,
+      derivationBundle = bundleFor subscriptionStateValue,
+      derivationQuotaProfile = quotaFor subscriptionStateValue paidQuotaProfile
+    }
+
+bundleFor :: SubscriptionStateName -> EntitlementBundleName
+bundleFor subscriptionStateValue =
+  case subscriptionStateValue of
+    SubscriptionActive -> PremiumGenerationEntitlement
+    SubscriptionGrace -> PremiumGenerationEntitlement
+    SubscriptionPendingSync -> FreeBasicEntitlement
+    SubscriptionExpired -> FreeBasicEntitlement
+    SubscriptionRevoked -> FreeBasicEntitlement
+
+quotaFor :: SubscriptionStateName -> QuotaProfileName -> QuotaProfileName
+quotaFor subscriptionStateValue paidQuotaProfile =
+  case subscriptionStateValue of
+    SubscriptionActive -> paidQuotaProfile
+    SubscriptionGrace -> paidQuotaProfile
+    SubscriptionPendingSync -> FreeMonthlyQuota
+    SubscriptionExpired -> FreeMonthlyQuota
+    SubscriptionRevoked -> FreeMonthlyQuota
+
+parseEntitlementBundleName :: String -> Maybe EntitlementBundleName
+parseEntitlementBundleName bundleName =
+  case bundleName of
+    "free-basic" -> Just FreeBasicEntitlement
+    "premium-generation" -> Just PremiumGenerationEntitlement
+    _ -> Nothing
+
+parseQuotaProfileName :: String -> Maybe QuotaProfileName
+parseQuotaProfileName profileName =
+  case profileName of
+    "free-monthly" -> Just FreeMonthlyQuota
+    "standard-monthly" -> Just StandardMonthlyQuota
+    "pro-monthly" -> Just ProMonthlyQuota
+    _ -> Nothing
+
+renderEntitlementBundleName :: EntitlementBundleName -> String
+renderEntitlementBundleName bundleName =
+  case bundleName of
+    FreeBasicEntitlement -> "free-basic"
+    PremiumGenerationEntitlement -> "premium-generation"
+
+renderQuotaProfileName :: QuotaProfileName -> String
+renderQuotaProfileName profileName =
+  case profileName of
+    FreeMonthlyQuota -> "free-monthly"
+    StandardMonthlyQuota -> "standard-monthly"
+    ProMonthlyQuota -> "pro-monthly"

--- a/applications/backend/billing-worker/src/BillingWorker/FailureSummary.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/FailureSummary.hs
@@ -1,0 +1,182 @@
+module BillingWorker.FailureSummary
+  ( BillingFailureSummary (..),
+    FailureClassification (..),
+    FailureCode (..),
+    PublicStatus (..),
+    Visibility (..),
+    failureSummaryFor,
+    renderFailureClassification,
+    renderFailureCode,
+    renderPublicStatus,
+    renderVisibility
+  )
+where
+
+data Visibility
+  = StatusOnly
+  | CompletedCurrent
+  deriving (Eq, Show)
+
+data FailureClassification
+  = ClassificationRetryable
+  | ClassificationTimeout
+  | ClassificationTerminal
+  | ClassificationDeadLetter
+  deriving (Eq, Show)
+
+data PublicStatus
+  = PublicRetryScheduled
+  | PublicTimedOut
+  | PublicFailedFinal
+  | PublicDeadLettered
+  deriving (Eq, Show)
+
+data FailureCode
+  = FailureRetryableVerification
+  | FailureRetryableNotificationIngest
+  | FailureTimedOut
+  | FailureTerminal
+  | FailureMalformedPayload
+  | FailureMalformedNotification
+  | FailureTriggerNotSupported
+  | FailurePreconditionInvalid
+  | FailureMissingPurchaseArtifact
+  | FailureMissingNotificationPayload
+  | FailureInvalidTarget
+  | FailureOwnershipMismatch
+  | FailureHandoffRetry
+  | FailureDuplicateInFlight
+  | FailureStaleNotification
+  | FailureOperatorReview
+  deriving (Eq, Show)
+
+data BillingFailureSummary = BillingFailureSummary
+  { summaryClassification :: FailureClassification,
+    summaryPublicStatus :: PublicStatus,
+    summaryCode :: FailureCode,
+    summaryMessage :: String,
+    summaryRetryable :: Bool,
+    summaryLastAttemptNumber :: Int
+  }
+  deriving (Eq, Show)
+
+failureSummaryFor :: FailureCode -> Int -> BillingFailureSummary
+failureSummaryFor failureCode attemptNumber =
+  BillingFailureSummary
+    { summaryClassification = classificationFor failureCode,
+      summaryPublicStatus = publicStatusFor failureCode,
+      summaryCode = failureCode,
+      summaryMessage = messageFor failureCode,
+      summaryRetryable = retryableFor failureCode,
+      summaryLastAttemptNumber = attemptNumber
+    }
+
+classificationFor :: FailureCode -> FailureClassification
+classificationFor failureCode =
+  case failureCode of
+    FailureRetryableVerification -> ClassificationRetryable
+    FailureRetryableNotificationIngest -> ClassificationRetryable
+    FailureHandoffRetry -> ClassificationRetryable
+    FailureTimedOut -> ClassificationTimeout
+    FailureDuplicateInFlight -> ClassificationRetryable
+    FailureOperatorReview -> ClassificationDeadLetter
+    _ -> ClassificationTerminal
+
+publicStatusFor :: FailureCode -> PublicStatus
+publicStatusFor failureCode =
+  case failureCode of
+    FailureRetryableVerification -> PublicRetryScheduled
+    FailureRetryableNotificationIngest -> PublicRetryScheduled
+    FailureHandoffRetry -> PublicRetryScheduled
+    FailureDuplicateInFlight -> PublicRetryScheduled
+    FailureTimedOut -> PublicTimedOut
+    FailureOperatorReview -> PublicDeadLettered
+    _ -> PublicFailedFinal
+
+retryableFor :: FailureCode -> Bool
+retryableFor failureCode =
+  case failureCode of
+    FailureRetryableVerification -> True
+    FailureRetryableNotificationIngest -> True
+    FailureHandoffRetry -> True
+    FailureDuplicateInFlight -> True
+    FailureTimedOut -> True
+    _ -> False
+
+messageFor :: FailureCode -> String
+messageFor failureCode =
+  case failureCode of
+    FailureRetryableVerification ->
+      "purchase verification temporarily unavailable"
+    FailureRetryableNotificationIngest ->
+      "store notification ingest temporarily unavailable"
+    FailureTimedOut ->
+      "billing workflow attempt timed out"
+    FailureTerminal ->
+      "billing workflow terminated without retry"
+    FailureMalformedPayload ->
+      "verification payload did not meet billing record requirements"
+    FailureMalformedNotification ->
+      "store notification payload could not be normalized"
+    FailureTriggerNotSupported ->
+      "work item trigger is not supported in this slice"
+    FailurePreconditionInvalid ->
+      "work item precondition invalid"
+    FailureMissingPurchaseArtifact ->
+      "purchase artifact reference is missing"
+    FailureMissingNotificationPayload ->
+      "notification payload is missing"
+    FailureInvalidTarget ->
+      "target subscription is unavailable"
+    FailureOwnershipMismatch ->
+      "actor does not own target subscription"
+    FailureHandoffRetry ->
+      "entitlement handoff pending retry"
+    FailureDuplicateInFlight ->
+      "duplicate work item is in flight"
+    FailureStaleNotification ->
+      "store notification is stale and was not applied"
+    FailureOperatorReview ->
+      "operator review is required"
+
+renderVisibility :: Visibility -> String
+renderVisibility visibility =
+  case visibility of
+    StatusOnly -> "status-only"
+    CompletedCurrent -> "completed-current"
+
+renderFailureClassification :: FailureClassification -> String
+renderFailureClassification classification =
+  case classification of
+    ClassificationRetryable -> "retryable"
+    ClassificationTimeout -> "timeout"
+    ClassificationTerminal -> "terminal"
+    ClassificationDeadLetter -> "dead-letter"
+
+renderPublicStatus :: PublicStatus -> String
+renderPublicStatus publicStatus =
+  case publicStatus of
+    PublicRetryScheduled -> "retry-scheduled"
+    PublicTimedOut -> "timed-out"
+    PublicFailedFinal -> "failed-final"
+    PublicDeadLettered -> "dead-lettered"
+
+renderFailureCode :: FailureCode -> String
+renderFailureCode failureCode =
+  case failureCode of
+    FailureRetryableVerification -> "retryable-verification"
+    FailureRetryableNotificationIngest -> "retryable-notification-ingest"
+    FailureTimedOut -> "timed-out"
+    FailureTerminal -> "terminal"
+    FailureMalformedPayload -> "malformed-payload"
+    FailureMalformedNotification -> "malformed-notification"
+    FailureTriggerNotSupported -> "trigger-not-supported"
+    FailurePreconditionInvalid -> "precondition-invalid"
+    FailureMissingPurchaseArtifact -> "missing-purchase-artifact"
+    FailureMissingNotificationPayload -> "missing-notification-payload"
+    FailureInvalidTarget -> "invalid-target"
+    FailureOwnershipMismatch -> "ownership-mismatch"
+    FailureHandoffRetry -> "handoff-retry"
+    FailureDuplicateInFlight -> "duplicate-in-flight"
+    FailureStaleNotification -> "stale-notification"
+    FailureOperatorReview -> "operator-review"

--- a/applications/backend/billing-worker/src/BillingWorker/NotificationPort.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/NotificationPort.hs
@@ -1,0 +1,174 @@
+module BillingWorker.NotificationPort
+  ( NotificationIngestOutcome (..),
+    NotificationIngestStatus (..),
+    NotificationPayload (..),
+    NotificationPayloadIssue (..),
+    NotificationSource (..),
+    malformedNotificationOutcome,
+    nonRetryableNotificationOutcome,
+    parseNotificationSource,
+    reconciledNotificationOutcome,
+    renderNotificationIngestStatus,
+    renderNotificationSource,
+    retryableNotificationOutcome,
+    staleNotificationOutcome,
+    timedOutNotificationOutcome,
+    validateNotificationPayload
+  )
+where
+
+data NotificationSource
+  = AppStoreNotification
+  | GooglePlayNotification
+  | UnsupportedNotificationSource String
+  deriving (Eq, Show)
+
+data NotificationIngestStatus
+  = NotificationReconciled
+  | NotificationRetryableFailure
+  | NotificationNonRetryableFailure
+  | NotificationTimedOut
+  | NotificationStale
+  deriving (Eq, Show)
+
+data NotificationPayload = NotificationPayload
+  { notificationProviderIdentifier :: String,
+    notificationSubscriptionStateName :: String,
+    notificationTermStart :: String,
+    notificationTermEnd :: String,
+    notificationGraceWindow :: Maybe String,
+    notificationOriginalTimestamp :: String
+  }
+  deriving (Eq, Show)
+
+data NotificationIngestOutcome = NotificationIngestOutcome
+  { ingestStatus :: NotificationIngestStatus,
+    ingestRequestIdentifier :: String,
+    ingestSource :: NotificationSource,
+    ingestPayload :: Maybe NotificationPayload,
+    ingestFailureReason :: Maybe String
+  }
+  deriving (Eq, Show)
+
+data NotificationPayloadIssue
+  = MissingProviderIdentifier
+  | MissingStateName
+  | MissingNotificationPeriod
+  | UnknownStateName
+  deriving (Eq, Show)
+
+reconciledNotificationOutcome ::
+  String ->
+  NotificationSource ->
+  NotificationPayload ->
+  NotificationIngestOutcome
+reconciledNotificationOutcome requestIdentifier source reconciledPayload =
+  NotificationIngestOutcome
+    { ingestStatus = NotificationReconciled,
+      ingestRequestIdentifier = requestIdentifier,
+      ingestSource = source,
+      ingestPayload = Just reconciledPayload,
+      ingestFailureReason = Nothing
+    }
+
+malformedNotificationOutcome ::
+  String ->
+  NotificationSource ->
+  NotificationPayload ->
+  NotificationIngestOutcome
+malformedNotificationOutcome requestIdentifier source malformedPayload =
+  NotificationIngestOutcome
+    { ingestStatus = NotificationReconciled,
+      ingestRequestIdentifier = requestIdentifier,
+      ingestSource = source,
+      ingestPayload = Just malformedPayload,
+      ingestFailureReason = Nothing
+    }
+
+retryableNotificationOutcome ::
+  String -> NotificationSource -> String -> NotificationIngestOutcome
+retryableNotificationOutcome requestIdentifier source redactedReason =
+  NotificationIngestOutcome
+    { ingestStatus = NotificationRetryableFailure,
+      ingestRequestIdentifier = requestIdentifier,
+      ingestSource = source,
+      ingestPayload = Nothing,
+      ingestFailureReason = Just redactedReason
+    }
+
+nonRetryableNotificationOutcome ::
+  String -> NotificationSource -> String -> NotificationIngestOutcome
+nonRetryableNotificationOutcome requestIdentifier source redactedReason =
+  NotificationIngestOutcome
+    { ingestStatus = NotificationNonRetryableFailure,
+      ingestRequestIdentifier = requestIdentifier,
+      ingestSource = source,
+      ingestPayload = Nothing,
+      ingestFailureReason = Just redactedReason
+    }
+
+timedOutNotificationOutcome ::
+  String -> NotificationSource -> NotificationIngestOutcome
+timedOutNotificationOutcome requestIdentifier source =
+  NotificationIngestOutcome
+    { ingestStatus = NotificationTimedOut,
+      ingestRequestIdentifier = requestIdentifier,
+      ingestSource = source,
+      ingestPayload = Nothing,
+      ingestFailureReason = Nothing
+    }
+
+staleNotificationOutcome ::
+  String ->
+  NotificationSource ->
+  NotificationPayload ->
+  NotificationIngestOutcome
+staleNotificationOutcome requestIdentifier source stalePayload =
+  NotificationIngestOutcome
+    { ingestStatus = NotificationStale,
+      ingestRequestIdentifier = requestIdentifier,
+      ingestSource = source,
+      ingestPayload = Just stalePayload,
+      ingestFailureReason = Just "stale-notification"
+    }
+
+parseNotificationSource :: String -> NotificationSource
+parseNotificationSource sourceLabel =
+  case sourceLabel of
+    "app-store" -> AppStoreNotification
+    "google-play" -> GooglePlayNotification
+    other -> UnsupportedNotificationSource other
+
+renderNotificationSource :: NotificationSource -> String
+renderNotificationSource source =
+  case source of
+    AppStoreNotification -> "app-store"
+    GooglePlayNotification -> "google-play"
+    UnsupportedNotificationSource label -> "unsupported:" ++ label
+
+renderNotificationIngestStatus :: NotificationIngestStatus -> String
+renderNotificationIngestStatus notificationIngestStatus =
+  case notificationIngestStatus of
+    NotificationReconciled -> "reconciled"
+    NotificationRetryableFailure -> "retryable-failure"
+    NotificationNonRetryableFailure -> "non-retryable-failure"
+    NotificationTimedOut -> "timed-out"
+    NotificationStale -> "stale"
+
+validateNotificationPayload ::
+  NotificationPayload -> Either NotificationPayloadIssue NotificationPayload
+validateNotificationPayload notificationPayload
+  | null (notificationProviderIdentifier notificationPayload) =
+      Left MissingProviderIdentifier
+  | null (notificationSubscriptionStateName notificationPayload) =
+      Left MissingStateName
+  | null (notificationTermStart notificationPayload)
+      || null (notificationTermEnd notificationPayload) =
+      Left MissingNotificationPeriod
+  | not (isKnownSubscriptionState (notificationSubscriptionStateName notificationPayload)) =
+      Left UnknownStateName
+  | otherwise = Right notificationPayload
+
+isKnownSubscriptionState :: String -> Bool
+isKnownSubscriptionState stateName =
+  stateName `elem` ["active", "grace", "expired", "pending-sync", "revoked"]

--- a/applications/backend/billing-worker/src/BillingWorker/PurchaseVerificationPort.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/PurchaseVerificationPort.hs
@@ -1,0 +1,131 @@
+module BillingWorker.PurchaseVerificationPort
+  ( VerificationOutcome (..),
+    VerificationPayload (..),
+    VerificationStatus (..),
+    VerificationPayloadIssue (..),
+    malformedVerifiedOutcome,
+    nonRetryableVerificationOutcome,
+    renderVerificationStatus,
+    retryableVerificationOutcome,
+    successfulVerificationOutcome,
+    timedOutVerificationOutcome,
+    validateVerificationPayload
+  )
+where
+
+data VerificationStatus
+  = VerificationVerified
+  | VerificationRetryableFailure
+  | VerificationNonRetryableFailure
+  | VerificationTimedOut
+  deriving (Eq, Show)
+
+data VerificationPayload = VerificationPayload
+  { payloadSubscriptionStateName :: String,
+    payloadEntitlementBundleName :: String,
+    payloadQuotaProfileName :: String,
+    payloadTermStart :: String,
+    payloadTermEnd :: String,
+    payloadGraceWindow :: Maybe String
+  }
+  deriving (Eq, Show)
+
+data VerificationOutcome = VerificationOutcome
+  { outcomeStatus :: VerificationStatus,
+    outcomeRequestIdentifier :: String,
+    outcomePayload :: Maybe VerificationPayload,
+    outcomeFailureReason :: Maybe String
+  }
+  deriving (Eq, Show)
+
+data VerificationPayloadIssue
+  = MissingSubscriptionState
+  | MissingEntitlementBundle
+  | MissingQuotaProfile
+  | MissingEffectivePeriod
+  | UnknownSubscriptionState
+  | UnknownEntitlementBundle
+  | UnknownQuotaProfile
+  deriving (Eq, Show)
+
+successfulVerificationOutcome :: String -> VerificationPayload -> VerificationOutcome
+successfulVerificationOutcome requestIdentifier verifiedPayload =
+  VerificationOutcome
+    { outcomeStatus = VerificationVerified,
+      outcomeRequestIdentifier = requestIdentifier,
+      outcomePayload = Just verifiedPayload,
+      outcomeFailureReason = Nothing
+    }
+
+malformedVerifiedOutcome :: String -> VerificationPayload -> VerificationOutcome
+malformedVerifiedOutcome requestIdentifier malformedPayload =
+  VerificationOutcome
+    { outcomeStatus = VerificationVerified,
+      outcomeRequestIdentifier = requestIdentifier,
+      outcomePayload = Just malformedPayload,
+      outcomeFailureReason = Nothing
+    }
+
+retryableVerificationOutcome :: String -> String -> VerificationOutcome
+retryableVerificationOutcome requestIdentifier redactedReason =
+  VerificationOutcome
+    { outcomeStatus = VerificationRetryableFailure,
+      outcomeRequestIdentifier = requestIdentifier,
+      outcomePayload = Nothing,
+      outcomeFailureReason = Just redactedReason
+    }
+
+nonRetryableVerificationOutcome :: String -> String -> VerificationOutcome
+nonRetryableVerificationOutcome requestIdentifier redactedReason =
+  VerificationOutcome
+    { outcomeStatus = VerificationNonRetryableFailure,
+      outcomeRequestIdentifier = requestIdentifier,
+      outcomePayload = Nothing,
+      outcomeFailureReason = Just redactedReason
+    }
+
+timedOutVerificationOutcome :: String -> VerificationOutcome
+timedOutVerificationOutcome requestIdentifier =
+  VerificationOutcome
+    { outcomeStatus = VerificationTimedOut,
+      outcomeRequestIdentifier = requestIdentifier,
+      outcomePayload = Nothing,
+      outcomeFailureReason = Nothing
+    }
+
+renderVerificationStatus :: VerificationStatus -> String
+renderVerificationStatus verificationStatus =
+  case verificationStatus of
+    VerificationVerified -> "verified"
+    VerificationRetryableFailure -> "retryable-failure"
+    VerificationNonRetryableFailure -> "non-retryable-failure"
+    VerificationTimedOut -> "timed-out"
+
+validateVerificationPayload ::
+  VerificationPayload -> Either VerificationPayloadIssue VerificationPayload
+validateVerificationPayload verificationPayload
+  | null (payloadSubscriptionStateName verificationPayload) = Left MissingSubscriptionState
+  | null (payloadEntitlementBundleName verificationPayload) = Left MissingEntitlementBundle
+  | null (payloadQuotaProfileName verificationPayload) = Left MissingQuotaProfile
+  | null (payloadTermStart verificationPayload)
+      || null (payloadTermEnd verificationPayload) =
+      Left MissingEffectivePeriod
+  | not (isKnownSubscriptionState (payloadSubscriptionStateName verificationPayload)) =
+      Left UnknownSubscriptionState
+  | not (isKnownEntitlementBundle (payloadEntitlementBundleName verificationPayload)) =
+      Left UnknownEntitlementBundle
+  | not (isKnownQuotaProfile (payloadQuotaProfileName verificationPayload)) =
+      Left UnknownQuotaProfile
+  | otherwise = Right verificationPayload
+
+isKnownSubscriptionState :: String -> Bool
+isKnownSubscriptionState stateName =
+  stateName `elem` ["active", "grace", "expired", "pending-sync", "revoked"]
+
+isKnownEntitlementBundle :: String -> Bool
+isKnownEntitlementBundle bundleName =
+  bundleName `elem` ["free-basic", "premium-generation"]
+
+isKnownQuotaProfile :: String -> Bool
+isKnownQuotaProfile profileName =
+  profileName `elem` ["free-monthly", "standard-monthly", "pro-monthly"]

--- a/applications/backend/billing-worker/src/BillingWorker/SubscriptionAuthorityPort.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/SubscriptionAuthorityPort.hs
@@ -1,0 +1,74 @@
+module BillingWorker.SubscriptionAuthorityPort
+  ( AuthorityUpdateOutcome (..),
+    AuthorityUpdateStatus (..),
+    SubscriptionStateName (..),
+    authorityUpdateFor,
+    parseSubscriptionStateName,
+    renderAuthorityUpdateStatus,
+    renderSubscriptionStateName
+  )
+where
+
+data SubscriptionStateName
+  = SubscriptionActive
+  | SubscriptionGrace
+  | SubscriptionExpired
+  | SubscriptionPendingSync
+  | SubscriptionRevoked
+  deriving (Eq, Show)
+
+data AuthorityUpdateStatus
+  = AuthorityApplied
+  | AuthorityReuseCommitted
+  | AuthorityRetryableFailure
+  | AuthorityNonRetryableFailure
+  deriving (Eq, Show)
+
+data AuthorityUpdateOutcome = AuthorityUpdateOutcome
+  { authoritySubscription :: String,
+    authorityTargetState :: SubscriptionStateName,
+    authorityStatus :: AuthorityUpdateStatus,
+    authorityIdempotencyKey :: String
+  }
+  deriving (Eq, Show)
+
+authorityUpdateFor ::
+  String ->
+  SubscriptionStateName ->
+  AuthorityUpdateStatus ->
+  String ->
+  AuthorityUpdateOutcome
+authorityUpdateFor subscriptionIdentifier targetState authorityStatusValue idempotencyKey =
+  AuthorityUpdateOutcome
+    { authoritySubscription = subscriptionIdentifier,
+      authorityTargetState = targetState,
+      authorityStatus = authorityStatusValue,
+      authorityIdempotencyKey = idempotencyKey
+    }
+
+parseSubscriptionStateName :: String -> Maybe SubscriptionStateName
+parseSubscriptionStateName stateName =
+  case stateName of
+    "active" -> Just SubscriptionActive
+    "grace" -> Just SubscriptionGrace
+    "expired" -> Just SubscriptionExpired
+    "pending-sync" -> Just SubscriptionPendingSync
+    "revoked" -> Just SubscriptionRevoked
+    _ -> Nothing
+
+renderSubscriptionStateName :: SubscriptionStateName -> String
+renderSubscriptionStateName subscriptionStateName =
+  case subscriptionStateName of
+    SubscriptionActive -> "active"
+    SubscriptionGrace -> "grace"
+    SubscriptionExpired -> "expired"
+    SubscriptionPendingSync -> "pending-sync"
+    SubscriptionRevoked -> "revoked"
+
+renderAuthorityUpdateStatus :: AuthorityUpdateStatus -> String
+renderAuthorityUpdateStatus authorityUpdateStatus =
+  case authorityUpdateStatus of
+    AuthorityApplied -> "applied"
+    AuthorityReuseCommitted -> "reuse-committed"
+    AuthorityRetryableFailure -> "retryable-failure"
+    AuthorityNonRetryableFailure -> "non-retryable-failure"

--- a/applications/backend/billing-worker/src/BillingWorker/WorkItemContract.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/WorkItemContract.hs
@@ -1,0 +1,171 @@
+module BillingWorker.WorkItemContract
+  ( DuplicateDisposition (..),
+    DuplicateStatus (..),
+    IntakeFailure (..),
+    ValidatedWorkItem (..),
+    WorkItem (..),
+    WorkTrigger (..),
+    defaultPurchaseWorkItem,
+    defaultNotificationWorkItem,
+    duplicateDisposition,
+    renderDuplicateDisposition,
+    renderIntakeFailure,
+    renderWorkTrigger,
+    validateWorkItem
+  )
+where
+
+data WorkTrigger
+  = PurchaseArtifactSubmitted
+  | NotificationReceived
+  | UnsupportedTrigger String
+  deriving (Eq, Show)
+
+data WorkItem = WorkItem
+  { workIdentifier :: String,
+    workTrigger :: WorkTrigger,
+    workBusinessKey :: String,
+    workSubscription :: String,
+    workActor :: String,
+    workPurchaseArtifact :: Maybe String,
+    workNotificationPayload :: Maybe String,
+    workRequestCorrelation :: String,
+    workAcceptedOrder :: Int
+  }
+  deriving (Eq, Show)
+
+data ValidatedWorkItem = ValidatedWorkItem
+  { validatedIdentifier :: String,
+    validatedTrigger :: WorkTrigger,
+    validatedBusinessKey :: String,
+    validatedSubscription :: String,
+    validatedActor :: String,
+    validatedPurchaseArtifact :: Maybe String,
+    validatedNotificationPayload :: Maybe String,
+    validatedRequestCorrelation :: String,
+    validatedAcceptedOrder :: Int
+  }
+  deriving (Eq, Show)
+
+data IntakeFailure
+  = TriggerNotSupported
+  | PreconditionInvalid
+  | MissingPurchaseArtifact
+  | MissingNotificationPayload
+  deriving (Eq, Show)
+
+data DuplicateStatus
+  = DuplicateAbsent
+  | DuplicateQueued
+  | DuplicateRunning
+  | DuplicateRetryScheduled
+  | DuplicateSucceeded
+  deriving (Eq, Show)
+
+data DuplicateDisposition
+  = ProcessFresh
+  | IgnoreDuplicateInFlight
+  | ReuseCompletedDuplicate
+  deriving (Eq, Show)
+
+defaultPurchaseWorkItem :: WorkItem
+defaultPurchaseWorkItem =
+  WorkItem
+    { workIdentifier = "billing-work-item-001",
+      workTrigger = PurchaseArtifactSubmitted,
+      workBusinessKey = "billing-business-key-001",
+      workSubscription = "subscription-001",
+      workActor = "actor-001",
+      workPurchaseArtifact = Just "purchase-artifact-001",
+      workNotificationPayload = Nothing,
+      workRequestCorrelation = "correlation-001",
+      workAcceptedOrder = 1
+    }
+
+defaultNotificationWorkItem :: WorkItem
+defaultNotificationWorkItem =
+  WorkItem
+    { workIdentifier = "billing-work-item-002",
+      workTrigger = NotificationReceived,
+      workBusinessKey = "billing-business-key-002",
+      workSubscription = "subscription-001",
+      workActor = "actor-001",
+      workPurchaseArtifact = Nothing,
+      workNotificationPayload = Just "notification-payload-001",
+      workRequestCorrelation = "correlation-002",
+      workAcceptedOrder = 1
+    }
+
+duplicateDisposition :: DuplicateStatus -> DuplicateDisposition
+duplicateDisposition status =
+  case status of
+    DuplicateAbsent -> ProcessFresh
+    DuplicateQueued -> IgnoreDuplicateInFlight
+    DuplicateRunning -> IgnoreDuplicateInFlight
+    DuplicateRetryScheduled -> IgnoreDuplicateInFlight
+    DuplicateSucceeded -> ReuseCompletedDuplicate
+
+renderDuplicateDisposition :: DuplicateDisposition -> String
+renderDuplicateDisposition disposition =
+  case disposition of
+    ProcessFresh -> "fresh"
+    IgnoreDuplicateInFlight -> "inflight-noop"
+    ReuseCompletedDuplicate -> "reuse-completed"
+
+renderIntakeFailure :: IntakeFailure -> String
+renderIntakeFailure intakeFailure =
+  case intakeFailure of
+    TriggerNotSupported -> "trigger-not-supported"
+    PreconditionInvalid -> "precondition-invalid"
+    MissingPurchaseArtifact -> "missing-purchase-artifact"
+    MissingNotificationPayload -> "missing-notification-payload"
+
+renderWorkTrigger :: WorkTrigger -> String
+renderWorkTrigger workTriggerValue =
+  case workTriggerValue of
+    PurchaseArtifactSubmitted -> "purchase-artifact-submitted"
+    NotificationReceived -> "notification-received"
+    UnsupportedTrigger label -> "unsupported:" ++ label
+
+validateWorkItem :: WorkItem -> Either IntakeFailure ValidatedWorkItem
+validateWorkItem workItem
+  | not (isSupportedTrigger (workTrigger workItem)) = Left TriggerNotSupported
+  | null (workIdentifier workItem)
+      || null (workBusinessKey workItem)
+      || null (workSubscription workItem)
+      || null (workActor workItem)
+      || null (workRequestCorrelation workItem)
+      || workAcceptedOrder workItem < 1 =
+      Left PreconditionInvalid
+  | workTrigger workItem == PurchaseArtifactSubmitted
+      && not (hasNonEmpty (workPurchaseArtifact workItem)) =
+      Left MissingPurchaseArtifact
+  | workTrigger workItem == NotificationReceived
+      && not (hasNonEmpty (workNotificationPayload workItem)) =
+      Left MissingNotificationPayload
+  | otherwise =
+      Right
+        ValidatedWorkItem
+          { validatedIdentifier = workIdentifier workItem,
+            validatedTrigger = workTrigger workItem,
+            validatedBusinessKey = workBusinessKey workItem,
+            validatedSubscription = workSubscription workItem,
+            validatedActor = workActor workItem,
+            validatedPurchaseArtifact = workPurchaseArtifact workItem,
+            validatedNotificationPayload = workNotificationPayload workItem,
+            validatedRequestCorrelation = workRequestCorrelation workItem,
+            validatedAcceptedOrder = workAcceptedOrder workItem
+          }
+
+isSupportedTrigger :: WorkTrigger -> Bool
+isSupportedTrigger workTriggerValue =
+  case workTriggerValue of
+    PurchaseArtifactSubmitted -> True
+    NotificationReceived -> True
+    UnsupportedTrigger _ -> False
+
+hasNonEmpty :: Maybe String -> Bool
+hasNonEmpty maybeValue =
+  case maybeValue of
+    Just value -> not (null value)
+    Nothing -> False

--- a/applications/backend/billing-worker/src/BillingWorker/WorkerRuntime.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/WorkerRuntime.hs
@@ -1,0 +1,407 @@
+module BillingWorker.WorkerRuntime
+  ( ScenarioReport (..),
+    WorkerScenario (..),
+    parseWorkerScenarioLabel,
+    renderScenarioReport,
+    runScenarioReport,
+    workerScenarioLabel
+  )
+where
+
+import Data.List (intercalate)
+
+import BillingWorker.BillingPersistence
+  ( CompletedBillingPayload (..),
+    CompletedBillingRecord,
+    RecordSource (..),
+    completedRecordFor,
+    emptyBillingStore
+  )
+import BillingWorker.CurrentSubscriptionHandoff
+  ( CurrentAction (..),
+    ExistingCurrent (..),
+    HandoffStatus (..),
+    renderCurrentAction
+  )
+import BillingWorker.FailureSummary
+  ( BillingFailureSummary (..),
+    Visibility,
+    renderFailureCode,
+    renderPublicStatus,
+    renderVisibility
+  )
+import BillingWorker.NotificationPort
+  ( NotificationIngestOutcome,
+    NotificationPayload (..),
+    NotificationSource (..),
+    malformedNotificationOutcome,
+    nonRetryableNotificationOutcome,
+    reconciledNotificationOutcome,
+    retryableNotificationOutcome,
+    staleNotificationOutcome,
+    timedOutNotificationOutcome
+  )
+import BillingWorker.PurchaseVerificationPort
+  ( VerificationOutcome,
+    VerificationPayload (..),
+    malformedVerifiedOutcome,
+    nonRetryableVerificationOutcome,
+    retryableVerificationOutcome,
+    successfulVerificationOutcome,
+    timedOutVerificationOutcome
+  )
+import BillingWorker.WorkflowStateMachine
+  ( RetryBudget (..),
+    WorkflowOutcome (..),
+    WorkflowState,
+    deadLetterOutcome,
+    duplicateOutcome,
+    intakeFailureOutcome,
+    ownershipMismatchOutcome,
+    renderWorkflowState,
+    runNotificationOutcome,
+    runVerificationOutcome
+  )
+import BillingWorker.WorkItemContract
+  ( DuplicateDisposition (..),
+    DuplicateStatus (..),
+    IntakeFailure,
+    ValidatedWorkItem,
+    WorkItem (..),
+    WorkTrigger (..),
+    defaultNotificationWorkItem,
+    defaultPurchaseWorkItem,
+    duplicateDisposition,
+    renderDuplicateDisposition,
+    renderIntakeFailure,
+    validateWorkItem
+  )
+
+data WorkerScenario
+  = ScenarioSuccess
+  | ScenarioRetryableFailure
+  | ScenarioTerminalFailure
+  | ScenarioTimeout
+  | ScenarioDuplicateRunning
+  | ScenarioDuplicateSucceeded
+  | ScenarioRetryExhausted
+  | ScenarioInvalidTarget
+  | ScenarioOwnershipMismatch
+  | ScenarioNotificationReconciled
+  | ScenarioNotificationRetryable
+  | ScenarioNotificationTerminal
+  | ScenarioNotificationStale
+  | ScenarioNotificationDeadLetter
+  deriving (Eq, Show)
+
+data ScenarioReport = ScenarioReport
+  { reportScenario :: String,
+    reportFinalState :: String,
+    reportTrail :: [String],
+    reportVisibility :: String,
+    reportFailureCode :: String,
+    reportPublicStatus :: String,
+    reportRetryable :: Bool,
+    reportCompletedSaved :: Bool,
+    reportHandoffCompleted :: Bool,
+    reportCurrentAction :: String,
+    reportCurrentRetained :: Bool,
+    reportDuplicateDisposition :: String,
+    reportSource :: String
+  }
+  deriving (Eq, Show)
+
+runScenarioReport :: WorkerScenario -> ScenarioReport
+runScenarioReport scenario =
+  let workflowOutcome = runScenario scenario
+      failureCodeValue =
+        case workflowFailureSummary workflowOutcome of
+          Nothing -> "none"
+          Just summaryValue -> renderFailureCode (summaryCode summaryValue)
+      publicStatusValue =
+        case workflowFailureSummary workflowOutcome of
+          Nothing -> "none"
+          Just summaryValue -> renderPublicStatus (summaryPublicStatus summaryValue)
+      retryableValue =
+        case workflowFailureSummary workflowOutcome of
+          Nothing -> False
+          Just summaryValue -> summaryRetryable summaryValue
+   in ScenarioReport
+        { reportScenario = workerScenarioLabel scenario,
+          reportFinalState = renderWorkflowState (workflowFinalState workflowOutcome),
+          reportTrail = map renderWorkflowState (workflowTrail workflowOutcome),
+          reportVisibility = renderVisibility (workflowVisibility workflowOutcome),
+          reportFailureCode = failureCodeValue,
+          reportPublicStatus = publicStatusValue,
+          reportRetryable = retryableValue,
+          reportCompletedSaved = maybe False (const True) (workflowCompletedRecord workflowOutcome),
+          reportHandoffCompleted = workflowHandoffCompleted workflowOutcome,
+          reportCurrentAction = renderCurrentAction (workflowCurrentAction workflowOutcome),
+          reportCurrentRetained = currentWasRetained (workflowCurrentAction workflowOutcome),
+          reportDuplicateDisposition =
+            renderDuplicateDisposition (workflowDuplicateDisposition workflowOutcome),
+          reportSource = sourceForScenario scenario
+        }
+
+workerScenarioLabel :: WorkerScenario -> String
+workerScenarioLabel scenario =
+  case scenario of
+    ScenarioSuccess -> "success"
+    ScenarioRetryableFailure -> "retryable-failure"
+    ScenarioTerminalFailure -> "terminal-failure"
+    ScenarioTimeout -> "timed-out"
+    ScenarioDuplicateRunning -> "duplicate-running"
+    ScenarioDuplicateSucceeded -> "duplicate-succeeded"
+    ScenarioRetryExhausted -> "retry-exhausted"
+    ScenarioInvalidTarget -> "invalid-target"
+    ScenarioOwnershipMismatch -> "ownership-mismatch"
+    ScenarioNotificationReconciled -> "notification-reconciled"
+    ScenarioNotificationRetryable -> "notification-retryable"
+    ScenarioNotificationTerminal -> "notification-terminal"
+    ScenarioNotificationStale -> "notification-stale"
+    ScenarioNotificationDeadLetter -> "notification-dead-letter"
+
+parseWorkerScenarioLabel :: String -> Maybe WorkerScenario
+parseWorkerScenarioLabel scenarioLabel =
+  case scenarioLabel of
+    "success" -> Just ScenarioSuccess
+    "retryable-failure" -> Just ScenarioRetryableFailure
+    "terminal-failure" -> Just ScenarioTerminalFailure
+    "timed-out" -> Just ScenarioTimeout
+    "duplicate-running" -> Just ScenarioDuplicateRunning
+    "duplicate-succeeded" -> Just ScenarioDuplicateSucceeded
+    "retry-exhausted" -> Just ScenarioRetryExhausted
+    "invalid-target" -> Just ScenarioInvalidTarget
+    "ownership-mismatch" -> Just ScenarioOwnershipMismatch
+    "notification-reconciled" -> Just ScenarioNotificationReconciled
+    "notification-retryable" -> Just ScenarioNotificationRetryable
+    "notification-terminal" -> Just ScenarioNotificationTerminal
+    "notification-stale" -> Just ScenarioNotificationStale
+    "notification-dead-letter" -> Just ScenarioNotificationDeadLetter
+    _ -> Nothing
+
+renderScenarioReport :: ScenarioReport -> String
+renderScenarioReport report =
+  intercalate
+    " "
+    [ "VOCAS_BILLING_RESULT",
+      "scenario=" ++ reportScenario report,
+      "final_state=" ++ reportFinalState report,
+      "trail=" ++ intercalate "," (reportTrail report),
+      "visibility=" ++ reportVisibility report,
+      "failure_code=" ++ reportFailureCode report,
+      "public_status=" ++ reportPublicStatus report,
+      "retryable=" ++ renderBool (reportRetryable report),
+      "completed_saved=" ++ renderBool (reportCompletedSaved report),
+      "handoff_completed=" ++ renderBool (reportHandoffCompleted report),
+      "current_action=" ++ reportCurrentAction report,
+      "current_retained=" ++ renderBool (reportCurrentRetained report),
+      "duplicate=" ++ reportDuplicateDisposition report,
+      "source=" ++ reportSource report
+    ]
+
+currentWasRetained :: CurrentAction -> Bool
+currentWasRetained currentAction =
+  case currentAction of
+    CurrentRetained _ -> True
+    _ -> False
+
+renderBool :: Bool -> String
+renderBool value =
+  if value then "true" else "false"
+
+sourceForScenario :: WorkerScenario -> String
+sourceForScenario scenario =
+  case scenario of
+    ScenarioSuccess -> "purchase-verification"
+    ScenarioRetryableFailure -> "purchase-verification"
+    ScenarioTerminalFailure -> "purchase-verification"
+    ScenarioTimeout -> "purchase-verification"
+    ScenarioDuplicateRunning -> "purchase-verification"
+    ScenarioDuplicateSucceeded -> "purchase-verification"
+    ScenarioRetryExhausted -> "purchase-verification"
+    ScenarioInvalidTarget -> "purchase-verification"
+    ScenarioOwnershipMismatch -> "purchase-verification"
+    ScenarioNotificationReconciled -> "notification-reconciliation"
+    ScenarioNotificationRetryable -> "notification-reconciliation"
+    ScenarioNotificationTerminal -> "notification-reconciliation"
+    ScenarioNotificationStale -> "notification-reconciliation"
+    ScenarioNotificationDeadLetter -> "notification-reconciliation"
+
+runScenario :: WorkerScenario -> WorkflowOutcome
+runScenario scenario =
+  case scenario of
+    ScenarioSuccess ->
+      runPurchaseVerificationScenario
+        (successfulVerificationOutcome "verification-request-001" defaultVerifiedPayload)
+        HandoffApplied
+        (freshBudget 3)
+    ScenarioRetryableFailure ->
+      runPurchaseVerificationScenario
+        (retryableVerificationOutcome "verification-request-002" "verification-temporarily-unavailable")
+        HandoffApplied
+        (freshBudget 3)
+    ScenarioTerminalFailure ->
+      runPurchaseVerificationScenario
+        (nonRetryableVerificationOutcome "verification-request-003" "signature-invalid")
+        HandoffApplied
+        (freshBudget 3)
+    ScenarioTimeout ->
+      runPurchaseVerificationScenario
+        (timedOutVerificationOutcome "verification-request-004")
+        HandoffApplied
+        (RetryBudget {retryAttempt = 1, retryLimit = 3})
+    ScenarioDuplicateRunning ->
+      runDuplicateScenario DuplicateRunning Nothing
+    ScenarioDuplicateSucceeded ->
+      runDuplicateScenario DuplicateSucceeded (Just reuseCompletedRecord)
+    ScenarioRetryExhausted ->
+      runPurchaseVerificationScenario
+        (timedOutVerificationOutcome "verification-request-005")
+        HandoffApplied
+        (RetryBudget {retryAttempt = 3, retryLimit = 3})
+    ScenarioInvalidTarget ->
+      intakeFailureOutcome NoCurrent emptyBillingStore preconditionInvalidFailure
+    ScenarioOwnershipMismatch ->
+      ownershipMismatchOutcome NoCurrent emptyBillingStore
+    ScenarioNotificationReconciled ->
+      runNotificationScenario
+        ( reconciledNotificationOutcome
+            "notification-request-001"
+            AppStoreNotification
+            defaultNotificationPayload
+        )
+        HandoffApplied
+        (freshBudget 3)
+    ScenarioNotificationRetryable ->
+      runNotificationScenario
+        ( retryableNotificationOutcome
+            "notification-request-002"
+            AppStoreNotification
+            "notification-temporarily-unavailable"
+        )
+        HandoffApplied
+        (freshBudget 3)
+    ScenarioNotificationTerminal ->
+      runNotificationScenario
+        ( nonRetryableNotificationOutcome
+            "notification-request-003"
+            GooglePlayNotification
+            "notification-malformed"
+        )
+        HandoffApplied
+        (freshBudget 3)
+    ScenarioNotificationStale ->
+      runNotificationScenario
+        ( staleNotificationOutcome
+            "notification-request-004"
+            AppStoreNotification
+            stalePayload
+        )
+        HandoffApplied
+        (freshBudget 3)
+    ScenarioNotificationDeadLetter ->
+      deadLetterOutcome NoCurrent emptyBillingStore
+
+runPurchaseVerificationScenario ::
+  VerificationOutcome -> HandoffStatus -> RetryBudget -> WorkflowOutcome
+runPurchaseVerificationScenario verificationOutcome handoffStatus retryBudget =
+  case validateWorkItem defaultPurchaseWorkItem of
+    Left intakeFailure ->
+      intakeFailureOutcome NoCurrent emptyBillingStore intakeFailure
+    Right validated ->
+      runVerificationOutcome
+        retryBudget
+        NoCurrent
+        emptyBillingStore
+        validated
+        verificationOutcome
+        handoffStatus
+
+runNotificationScenario ::
+  NotificationIngestOutcome -> HandoffStatus -> RetryBudget -> WorkflowOutcome
+runNotificationScenario notificationIngestOutcome handoffStatus retryBudget =
+  case validateWorkItem defaultNotificationWorkItem of
+    Left intakeFailure ->
+      intakeFailureOutcome NoCurrent emptyBillingStore intakeFailure
+    Right validated ->
+      runNotificationOutcome
+        retryBudget
+        NoCurrent
+        emptyBillingStore
+        validated
+        notificationIngestOutcome
+        handoffStatus
+
+runDuplicateScenario ::
+  DuplicateStatus -> Maybe CompletedBillingRecord -> WorkflowOutcome
+runDuplicateScenario duplicateStatus maybeRecord =
+  let disposition = duplicateDisposition duplicateStatus
+      existingCurrent =
+        case duplicateStatus of
+          DuplicateSucceeded -> ExistingCurrent "existing-entitlement-snapshot-001"
+          _ -> NoCurrent
+   in duplicateOutcome disposition existingCurrent emptyBillingStore maybeRecord
+
+freshBudget :: Int -> RetryBudget
+freshBudget retryLimitValue =
+  RetryBudget {retryAttempt = 1, retryLimit = retryLimitValue}
+
+preconditionInvalidFailure :: IntakeFailure
+preconditionInvalidFailure =
+  case validateWorkItem invalidPreconditionItem of
+    Left intakeFailure -> intakeFailure
+    Right _ -> error "expected precondition failure"
+
+invalidPreconditionItem :: WorkItem
+invalidPreconditionItem =
+  defaultPurchaseWorkItem {workSubscription = ""}
+
+reuseCompletedRecord :: CompletedBillingRecord
+reuseCompletedRecord =
+  completedRecordFor
+    "billing-business-key-existing"
+    "subscription-001"
+    SourcePurchaseVerification
+    CompletedBillingPayload
+      { completedPurchaseStateName = "verified",
+        completedSubscriptionStateName = "active",
+        completedEntitlementBundleName = "premium-generation",
+        completedQuotaProfileName = "standard-monthly",
+        completedTermStart = "2026-03-01T00:00:00Z",
+        completedTermEnd = "2026-04-01T00:00:00Z",
+        completedGraceWindow = Just "2026-04-08T00:00:00Z"
+      }
+
+defaultVerifiedPayload :: VerificationPayload
+defaultVerifiedPayload =
+  VerificationPayload
+    { payloadSubscriptionStateName = "active",
+      payloadEntitlementBundleName = "premium-generation",
+      payloadQuotaProfileName = "standard-monthly",
+      payloadTermStart = "2026-04-01T00:00:00Z",
+      payloadTermEnd = "2026-05-01T00:00:00Z",
+      payloadGraceWindow = Just "2026-05-08T00:00:00Z"
+    }
+
+defaultNotificationPayload :: NotificationPayload
+defaultNotificationPayload =
+  NotificationPayload
+    { notificationProviderIdentifier = "apple-notification-001",
+      notificationSubscriptionStateName = "grace",
+      notificationTermStart = "2026-04-01T00:00:00Z",
+      notificationTermEnd = "2026-05-01T00:00:00Z",
+      notificationGraceWindow = Just "2026-05-08T00:00:00Z",
+      notificationOriginalTimestamp = "2026-04-15T12:00:00Z"
+    }
+
+stalePayload :: NotificationPayload
+stalePayload =
+  NotificationPayload
+    { notificationProviderIdentifier = "apple-notification-002",
+      notificationSubscriptionStateName = "active",
+      notificationTermStart = "2025-03-01T00:00:00Z",
+      notificationTermEnd = "2025-04-01T00:00:00Z",
+      notificationGraceWindow = Nothing,
+      notificationOriginalTimestamp = "2025-03-15T12:00:00Z"
+    }

--- a/applications/backend/billing-worker/src/BillingWorker/WorkflowStateMachine.hs
+++ b/applications/backend/billing-worker/src/BillingWorker/WorkflowStateMachine.hs
@@ -1,0 +1,525 @@
+module BillingWorker.WorkflowStateMachine
+  ( RetryBudget (..),
+    WorkflowOutcome (..),
+    WorkflowState (..),
+    deadLetterOutcome,
+    duplicateOutcome,
+    intakeFailureOutcome,
+    ownershipMismatchOutcome,
+    renderWorkflowState,
+    runNotificationOutcome,
+    runVerificationOutcome
+  )
+where
+
+import BillingWorker.BillingPersistence
+  ( BillingStore,
+    CompletedBillingPayload (..),
+    CompletedBillingRecord,
+    CompletedRecordVisibility (..),
+    RecordSource (..),
+    SaveAction,
+    SaveResult (..),
+    markRecordCurrentApplied,
+    recordVisibility,
+    saveCompletedBilling
+  )
+import BillingWorker.CurrentSubscriptionHandoff
+  ( CurrentAction,
+    ExistingCurrent,
+    HandoffStatus (..),
+    applyCurrentSubscriptionSuccess,
+    retainExistingCurrent
+  )
+import BillingWorker.EntitlementRecalcPort
+  ( EntitlementDerivation (..),
+    QuotaProfileName (..),
+    deriveEntitlement,
+    renderEntitlementBundleName,
+    renderQuotaProfileName
+  )
+import BillingWorker.FailureSummary
+  ( BillingFailureSummary,
+    FailureCode (..),
+    Visibility (..),
+    failureSummaryFor
+  )
+import BillingWorker.NotificationPort
+  ( NotificationIngestOutcome (..),
+    NotificationIngestStatus (..),
+    NotificationPayload (..),
+    validateNotificationPayload
+  )
+import BillingWorker.PurchaseVerificationPort
+  ( VerificationOutcome (..),
+    VerificationPayload (..),
+    VerificationStatus (..),
+    validateVerificationPayload
+  )
+import BillingWorker.SubscriptionAuthorityPort
+  ( SubscriptionStateName (..),
+    parseSubscriptionStateName,
+    renderSubscriptionStateName
+  )
+import BillingWorker.WorkItemContract
+  ( DuplicateDisposition (..),
+    IntakeFailure (..),
+    ValidatedWorkItem (..),
+    WorkTrigger (..)
+  )
+
+data WorkflowState
+  = Queued
+  | Running
+  | RetryScheduled Int
+  | TimedOut Int
+  | Succeeded
+  | FailedFinal
+  | DeadLettered
+  deriving (Eq, Show)
+
+data RetryBudget = RetryBudget
+  { retryAttempt :: Int,
+    retryLimit :: Int
+  }
+  deriving (Eq, Show)
+
+data WorkflowOutcome = WorkflowOutcome
+  { workflowTrail :: [WorkflowState],
+    workflowFinalState :: WorkflowState,
+    workflowVisibility :: Visibility,
+    workflowFailureSummary :: Maybe BillingFailureSummary,
+    workflowCurrentAction :: CurrentAction,
+    workflowDuplicateDisposition :: DuplicateDisposition,
+    workflowCompletedRecord :: Maybe CompletedBillingRecord,
+    workflowSaveAction :: Maybe SaveAction,
+    workflowStore :: BillingStore,
+    workflowHandoffCompleted :: Bool
+  }
+  deriving (Eq, Show)
+
+renderWorkflowState :: WorkflowState -> String
+renderWorkflowState workflowState =
+  case workflowState of
+    Queued -> "queued"
+    Running -> "running"
+    RetryScheduled attempt -> "retry-scheduled-" ++ show attempt
+    TimedOut attempt -> "timed-out-" ++ show attempt
+    Succeeded -> "succeeded"
+    FailedFinal -> "failed-final"
+    DeadLettered -> "dead-lettered"
+
+duplicateOutcome ::
+  DuplicateDisposition ->
+  ExistingCurrent ->
+  BillingStore ->
+  Maybe CompletedBillingRecord ->
+  WorkflowOutcome
+duplicateOutcome disposition existingCurrent store maybeRecord =
+  case disposition of
+    ProcessFresh ->
+      buildOutcome
+        [Queued]
+        Queued
+        StatusOnly
+        Nothing
+        (retainExistingCurrent existingCurrent)
+        ProcessFresh
+        Nothing
+        Nothing
+        store
+        False
+    IgnoreDuplicateInFlight ->
+      buildOutcome
+        [Queued, Running]
+        Running
+        StatusOnly
+        (Just (failureSummaryFor FailureDuplicateInFlight 0))
+        (retainExistingCurrent existingCurrent)
+        disposition
+        Nothing
+        Nothing
+        store
+        False
+    ReuseCompletedDuplicate ->
+      buildOutcome
+        [Queued, Succeeded]
+        Succeeded
+        (maybe StatusOnly visibilityForRecord maybeRecord)
+        Nothing
+        (retainExistingCurrent existingCurrent)
+        disposition
+        maybeRecord
+        Nothing
+        store
+        False
+
+intakeFailureOutcome ::
+  ExistingCurrent -> BillingStore -> IntakeFailure -> WorkflowOutcome
+intakeFailureOutcome existingCurrent store intakeFailure =
+  let failureCode =
+        case intakeFailure of
+          TriggerNotSupported -> FailureTriggerNotSupported
+          PreconditionInvalid -> FailurePreconditionInvalid
+          MissingPurchaseArtifact -> FailureMissingPurchaseArtifact
+          MissingNotificationPayload -> FailureMissingNotificationPayload
+   in buildOutcome
+        [Queued, FailedFinal]
+        FailedFinal
+        StatusOnly
+        (Just (failureSummaryFor failureCode 0))
+        (retainExistingCurrent existingCurrent)
+        ProcessFresh
+        Nothing
+        Nothing
+        store
+        False
+
+ownershipMismatchOutcome ::
+  ExistingCurrent -> BillingStore -> WorkflowOutcome
+ownershipMismatchOutcome existingCurrent store =
+  buildOutcome
+    [Queued, Running, DeadLettered]
+    DeadLettered
+    StatusOnly
+    (Just (failureSummaryFor FailureOwnershipMismatch 1))
+    (retainExistingCurrent existingCurrent)
+    ProcessFresh
+    Nothing
+    Nothing
+    store
+    False
+
+deadLetterOutcome ::
+  ExistingCurrent -> BillingStore -> WorkflowOutcome
+deadLetterOutcome existingCurrent store =
+  buildOutcome
+    [Queued, Running, DeadLettered]
+    DeadLettered
+    StatusOnly
+    (Just (failureSummaryFor FailureOperatorReview 1))
+    (retainExistingCurrent existingCurrent)
+    ProcessFresh
+    Nothing
+    Nothing
+    store
+    False
+
+runVerificationOutcome ::
+  RetryBudget ->
+  ExistingCurrent ->
+  BillingStore ->
+  ValidatedWorkItem ->
+  VerificationOutcome ->
+  HandoffStatus ->
+  WorkflowOutcome
+runVerificationOutcome retryBudget existingCurrent store validatedWorkItem verificationOutcome handoffStatus =
+  case outcomeStatus verificationOutcome of
+    VerificationVerified ->
+      case outcomePayload verificationOutcome >>= either (const Nothing) Just . validateVerificationPayload of
+        Nothing ->
+          terminalFailureOutcome existingCurrent store FailureMalformedPayload
+        Just verifiedPayload ->
+          case parseSubscriptionStateName (payloadSubscriptionStateName verifiedPayload) of
+            Nothing ->
+              terminalFailureOutcome existingCurrent store FailureMalformedPayload
+            Just _ ->
+              runCommittedVerification
+                existingCurrent
+                store
+                validatedWorkItem
+                verifiedPayload
+                handoffStatus
+    VerificationRetryableFailure ->
+      retryableFailureOutcome retryBudget existingCurrent store FailureRetryableVerification
+    VerificationTimedOut ->
+      timedOutFailureOutcome retryBudget existingCurrent store
+    VerificationNonRetryableFailure ->
+      terminalFailureOutcome existingCurrent store FailureTerminal
+
+runCommittedVerification ::
+  ExistingCurrent ->
+  BillingStore ->
+  ValidatedWorkItem ->
+  VerificationPayload ->
+  HandoffStatus ->
+  WorkflowOutcome
+runCommittedVerification existingCurrent store validatedWorkItem verifiedPayload handoffStatus =
+  let completedPayload =
+        buildCompletedPayload
+          "verified"
+          (payloadSubscriptionStateName verifiedPayload)
+          (payloadEntitlementBundleName verifiedPayload)
+          (payloadQuotaProfileName verifiedPayload)
+          (payloadTermStart verifiedPayload)
+          (payloadTermEnd verifiedPayload)
+          (payloadGraceWindow verifiedPayload)
+      initialSave =
+        saveCompletedBilling
+          (validatedBusinessKey validatedWorkItem)
+          (validatedSubscription validatedWorkItem)
+          SourcePurchaseVerification
+          completedPayload
+          store
+   in finalizeHandoff existingCurrent validatedWorkItem initialSave handoffStatus
+
+runNotificationOutcome ::
+  RetryBudget ->
+  ExistingCurrent ->
+  BillingStore ->
+  ValidatedWorkItem ->
+  NotificationIngestOutcome ->
+  HandoffStatus ->
+  WorkflowOutcome
+runNotificationOutcome retryBudget existingCurrent store validatedWorkItem notificationIngestOutcome handoffStatus =
+  case ingestStatus notificationIngestOutcome of
+    NotificationReconciled ->
+      case ingestPayload notificationIngestOutcome >>= either (const Nothing) Just . validateNotificationPayload of
+        Nothing ->
+          terminalFailureOutcome existingCurrent store FailureMalformedNotification
+        Just reconciledPayload ->
+          case parseSubscriptionStateName (notificationSubscriptionStateName reconciledPayload) of
+            Nothing ->
+              terminalFailureOutcome existingCurrent store FailureMalformedNotification
+            Just subscriptionStateValue ->
+              runCommittedNotification
+                existingCurrent
+                store
+                validatedWorkItem
+                subscriptionStateValue
+                reconciledPayload
+                handoffStatus
+    NotificationRetryableFailure ->
+      retryableFailureOutcome retryBudget existingCurrent store FailureRetryableNotificationIngest
+    NotificationTimedOut ->
+      timedOutFailureOutcome retryBudget existingCurrent store
+    NotificationNonRetryableFailure ->
+      terminalFailureOutcome existingCurrent store FailureMalformedNotification
+    NotificationStale ->
+      terminalFailureOutcome existingCurrent store FailureStaleNotification
+
+runCommittedNotification ::
+  ExistingCurrent ->
+  BillingStore ->
+  ValidatedWorkItem ->
+  SubscriptionStateName ->
+  NotificationPayload ->
+  HandoffStatus ->
+  WorkflowOutcome
+runCommittedNotification existingCurrent store validatedWorkItem subscriptionStateValue reconciledPayload handoffStatus =
+  let entitlementDerivation =
+        deriveEntitlement
+          subscriptionStateValue
+          (carriedPaidQuota (validatedTrigger validatedWorkItem))
+      completedPayload =
+        buildCompletedPayload
+          (carriedPurchaseState (validatedTrigger validatedWorkItem))
+          (renderSubscriptionStateName subscriptionStateValue)
+          (renderEntitlementBundleName (derivationBundle entitlementDerivation))
+          (renderQuotaProfileName (derivationQuotaProfile entitlementDerivation))
+          (notificationTermStart reconciledPayload)
+          (notificationTermEnd reconciledPayload)
+          (notificationGraceWindow reconciledPayload)
+      initialSave =
+        saveCompletedBilling
+          (validatedBusinessKey validatedWorkItem)
+          (validatedSubscription validatedWorkItem)
+          SourceNotificationReconciliation
+          completedPayload
+          store
+   in finalizeHandoff existingCurrent validatedWorkItem initialSave handoffStatus
+
+finalizeHandoff ::
+  ExistingCurrent ->
+  ValidatedWorkItem ->
+  SaveResult ->
+  HandoffStatus ->
+  WorkflowOutcome
+finalizeHandoff existingCurrent validatedWorkItem initialSave handoffStatus =
+  case handoffStatus of
+    HandoffApplied ->
+      let (currentRecord, currentStore) =
+            markRecordCurrentApplied
+              (validatedBusinessKey validatedWorkItem)
+              (saveStore initialSave)
+       in buildOutcome
+            [Queued, Running, Succeeded]
+            Succeeded
+            CompletedCurrent
+            Nothing
+            ( applyCurrentSubscriptionSuccess
+                currentRecord
+                existingCurrent
+                HandoffApplied
+            )
+            ProcessFresh
+            (Just currentRecord)
+            (Just (saveAction initialSave))
+            currentStore
+            True
+    HandoffRetryableFailure ->
+      buildOutcome
+        [Queued, Running, RetryScheduled 1]
+        (RetryScheduled 1)
+        StatusOnly
+        (Just (failureSummaryFor FailureHandoffRetry 1))
+        (retainExistingCurrent existingCurrent)
+        ProcessFresh
+        (Just (saveRecord initialSave))
+        (Just (saveAction initialSave))
+        (saveStore initialSave)
+        False
+    HandoffSuperseded ->
+      buildOutcome
+        [Queued, Running, Succeeded]
+        Succeeded
+        StatusOnly
+        Nothing
+        ( applyCurrentSubscriptionSuccess
+            (saveRecord initialSave)
+            existingCurrent
+            HandoffSuperseded
+        )
+        ProcessFresh
+        (Just (saveRecord initialSave))
+        (Just (saveAction initialSave))
+        (saveStore initialSave)
+        False
+
+retryableFailureOutcome ::
+  RetryBudget ->
+  ExistingCurrent ->
+  BillingStore ->
+  FailureCode ->
+  WorkflowOutcome
+retryableFailureOutcome retryBudget existingCurrent store failureCode =
+  buildOutcome
+    [Queued, Running, RetryScheduled (retryAttempt retryBudget)]
+    (RetryScheduled (retryAttempt retryBudget))
+    StatusOnly
+    (Just (failureSummaryFor failureCode (retryAttempt retryBudget)))
+    (retainExistingCurrent existingCurrent)
+    ProcessFresh
+    Nothing
+    Nothing
+    store
+    False
+
+timedOutFailureOutcome ::
+  RetryBudget -> ExistingCurrent -> BillingStore -> WorkflowOutcome
+timedOutFailureOutcome retryBudget existingCurrent store
+  | retryAttempt retryBudget < retryLimit retryBudget =
+      buildOutcome
+        [Queued, Running, TimedOut (retryAttempt retryBudget), RetryScheduled (retryAttempt retryBudget)]
+        (RetryScheduled (retryAttempt retryBudget))
+        StatusOnly
+        (Just (failureSummaryFor FailureTimedOut (retryAttempt retryBudget)))
+        (retainExistingCurrent existingCurrent)
+        ProcessFresh
+        Nothing
+        Nothing
+        store
+        False
+  | otherwise =
+      buildOutcome
+        [Queued, Running, TimedOut (retryAttempt retryBudget), FailedFinal]
+        FailedFinal
+        StatusOnly
+        (Just (failureSummaryFor FailureTimedOut (retryAttempt retryBudget)))
+        (retainExistingCurrent existingCurrent)
+        ProcessFresh
+        Nothing
+        Nothing
+        store
+        False
+
+terminalFailureOutcome ::
+  ExistingCurrent -> BillingStore -> FailureCode -> WorkflowOutcome
+terminalFailureOutcome existingCurrent store failureCode =
+  buildOutcome
+    [Queued, Running, FailedFinal]
+    FailedFinal
+    StatusOnly
+    (Just (failureSummaryFor failureCode 1))
+    (retainExistingCurrent existingCurrent)
+    ProcessFresh
+    Nothing
+    Nothing
+    store
+    False
+
+visibilityForRecord :: CompletedBillingRecord -> Visibility
+visibilityForRecord completedBillingRecord =
+  case recordVisibility completedBillingRecord of
+    HiddenUntilHandoff -> StatusOnly
+    CurrentApplied -> CompletedCurrent
+
+buildCompletedPayload ::
+  String ->
+  String ->
+  String ->
+  String ->
+  String ->
+  String ->
+  Maybe String ->
+  CompletedBillingPayload
+buildCompletedPayload purchaseStateValue subscriptionStateValue bundleName quotaProfileName termStart termEnd graceWindow =
+  CompletedBillingPayload
+    { completedPurchaseStateName = purchaseStateValue,
+      completedSubscriptionStateName = subscriptionStateValue,
+      completedEntitlementBundleName = bundleName,
+      completedQuotaProfileName = quotaProfileName,
+      completedTermStart = termStart,
+      completedTermEnd = termEnd,
+      completedGraceWindow = graceWindow
+    }
+
+carriedPaidQuota :: WorkTrigger -> QuotaProfileName
+carriedPaidQuota workTriggerValue =
+  case workTriggerValue of
+    PurchaseArtifactSubmitted -> StandardMonthlyQuota
+    NotificationReceived -> StandardMonthlyQuota
+    UnsupportedTrigger _ -> FreeMonthlyQuota
+
+carriedPurchaseState :: WorkTrigger -> String
+carriedPurchaseState workTriggerValue =
+  case workTriggerValue of
+    PurchaseArtifactSubmitted -> "verified"
+    NotificationReceived -> "verified"
+    UnsupportedTrigger _ -> "verifying"
+
+buildOutcome ::
+  [WorkflowState] ->
+  WorkflowState ->
+  Visibility ->
+  Maybe BillingFailureSummary ->
+  CurrentAction ->
+  DuplicateDisposition ->
+  Maybe CompletedBillingRecord ->
+  Maybe SaveAction ->
+  BillingStore ->
+  Bool ->
+  WorkflowOutcome
+buildOutcome
+  workflowTrailValue
+  workflowFinalStateValue
+  workflowVisibilityValue
+  workflowFailureSummaryValue
+  workflowCurrentActionValue
+  workflowDuplicateDispositionValue
+  workflowCompletedRecordValue
+  workflowSaveActionValue
+  workflowStoreValue
+  workflowHandoffCompletedValue =
+    WorkflowOutcome
+      { workflowTrail = workflowTrailValue,
+        workflowFinalState = workflowFinalStateValue,
+        workflowVisibility = workflowVisibilityValue,
+        workflowFailureSummary = workflowFailureSummaryValue,
+        workflowCurrentAction = workflowCurrentActionValue,
+        workflowDuplicateDisposition = workflowDuplicateDispositionValue,
+        workflowCompletedRecord = workflowCompletedRecordValue,
+        workflowSaveAction = workflowSaveActionValue,
+        workflowStore = workflowStoreValue,
+        workflowHandoffCompleted = workflowHandoffCompletedValue
+      }

--- a/applications/backend/billing-worker/tests/feature/BillingWorker/FeatureSpec.hs
+++ b/applications/backend/billing-worker/tests/feature/BillingWorker/FeatureSpec.hs
@@ -1,0 +1,102 @@
+module BillingWorker.FeatureSpec (run) where
+
+import Data.List (isInfixOf)
+import FeatureSupport
+import TestSupport
+
+run :: IO ()
+run =
+  withFeatureRuntime $ \runtime -> do
+    runNamed "validates success, retryable, and terminal scenarios" $
+      testValidationScenarios runtime
+    runNamed "maps duplicate, invalid target, ownership mismatch, and dead letter" $
+      testFailureAndDuplicateScenarios runtime
+    runNamed "validates notification reconciliation success and failure paths" $
+      testNotificationScenarios runtime
+    runNamed "starts as a long-running consumer" $
+      testStableWorker runtime
+
+testValidationScenarios :: FeatureRuntime -> IO ()
+testValidationScenarios runtime = do
+  success <- runValidation runtime "success"
+  assertField success "final_state" "succeeded"
+  assertField success "visibility" "completed-current"
+  assertField success "completed_saved" "true"
+  assertField success "handoff_completed" "true"
+  assertField success "source" "purchase-verification"
+
+  retryable <- runValidation runtime "retryable-failure"
+  assertField retryable "final_state" "retry-scheduled-1"
+  assertField retryable "visibility" "status-only"
+  assertField retryable "failure_code" "retryable-verification"
+  assertField retryable "public_status" "retry-scheduled"
+  assertField retryable "current_retained" "true"
+
+  terminal <- runValidation runtime "terminal-failure"
+  assertField terminal "final_state" "failed-final"
+  assertField terminal "visibility" "status-only"
+  assertField terminal "failure_code" "terminal"
+  assertField terminal "public_status" "failed-final"
+  assertField terminal "current_retained" "true"
+
+testFailureAndDuplicateScenarios :: FeatureRuntime -> IO ()
+testFailureAndDuplicateScenarios runtime = do
+  timedOut <- runValidation runtime "timed-out"
+  assertField timedOut "final_state" "retry-scheduled-1"
+  assertField timedOut "failure_code" "timed-out"
+  assertField timedOut "public_status" "timed-out"
+
+  retryExhausted <- runValidation runtime "retry-exhausted"
+  assertField retryExhausted "final_state" "failed-final"
+  assertField retryExhausted "failure_code" "timed-out"
+
+  invalidTarget <- runValidation runtime "invalid-target"
+  assertField invalidTarget "final_state" "failed-final"
+  assertField invalidTarget "failure_code" "precondition-invalid"
+
+  ownershipMismatch <- runValidation runtime "ownership-mismatch"
+  assertField ownershipMismatch "final_state" "dead-lettered"
+  assertField ownershipMismatch "failure_code" "ownership-mismatch"
+
+  duplicateRunning <- runValidation runtime "duplicate-running"
+  assertField duplicateRunning "final_state" "running"
+  assertField duplicateRunning "duplicate" "inflight-noop"
+
+  duplicateSucceeded <- runValidation runtime "duplicate-succeeded"
+  assertField duplicateSucceeded "final_state" "succeeded"
+  assertField duplicateSucceeded "duplicate" "reuse-completed"
+  assertField duplicateSucceeded "current_retained" "true"
+
+testNotificationScenarios :: FeatureRuntime -> IO ()
+testNotificationScenarios runtime = do
+  reconciled <- runValidation runtime "notification-reconciled"
+  assertField reconciled "final_state" "succeeded"
+  assertField reconciled "visibility" "completed-current"
+  assertField reconciled "completed_saved" "true"
+  assertField reconciled "handoff_completed" "true"
+  assertField reconciled "source" "notification-reconciliation"
+
+  retryable <- runValidation runtime "notification-retryable"
+  assertField retryable "final_state" "retry-scheduled-1"
+  assertField retryable "failure_code" "retryable-notification-ingest"
+  assertField retryable "source" "notification-reconciliation"
+
+  terminal <- runValidation runtime "notification-terminal"
+  assertField terminal "final_state" "failed-final"
+  assertField terminal "failure_code" "malformed-notification"
+
+  stale <- runValidation runtime "notification-stale"
+  assertField stale "final_state" "failed-final"
+  assertField stale "failure_code" "stale-notification"
+
+  deadLetter <- runValidation runtime "notification-dead-letter"
+  assertField deadLetter "final_state" "dead-lettered"
+  assertField deadLetter "failure_code" "operator-review"
+
+testStableWorker :: FeatureRuntime -> IO ()
+testStableWorker runtime = do
+  startStableWorker runtime
+  waitForStableWorker runtime
+  logs <- workerLogs runtime
+  assertTrue "stable-run log" ("entered stable-run mode" `isInfixOf` logs)
+  assertTrue "polling log" ("awaiting queue/subscription work" `isInfixOf` logs)

--- a/applications/backend/billing-worker/tests/feature/Main.hs
+++ b/applications/backend/billing-worker/tests/feature/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import qualified BillingWorker.FeatureSpec
+
+main :: IO ()
+main = BillingWorker.FeatureSpec.run

--- a/applications/backend/billing-worker/tests/support/FeatureSupport.hs
+++ b/applications/backend/billing-worker/tests/support/FeatureSupport.hs
@@ -1,0 +1,365 @@
+module FeatureSupport
+  ( FeatureRuntime,
+    ValidationResult,
+    assertField,
+    runValidation,
+    startStableWorker,
+    waitForStableWorker,
+    withFeatureRuntime,
+    workerLogs
+  )
+where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (bracket)
+import Data.Char (toLower)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.List (isInfixOf, isPrefixOf)
+import qualified Data.Map.Strict as Map
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import System.Directory
+  ( copyFile,
+    createDirectoryIfMissing,
+    doesFileExist,
+    getCurrentDirectory,
+    removeFile
+  )
+import System.Environment (getEnv)
+import System.Exit (ExitCode (..))
+import System.FilePath ((</>), takeDirectory)
+import System.IO.Error (catchIOError)
+import System.Process (CreateProcess (cwd), proc, readCreateProcessWithExitCode)
+import TestSupport (assertEqual)
+
+constBillingWorkerService :: String
+constBillingWorkerService = "billing-worker"
+
+constEmulatorContainerName :: String
+constEmulatorContainerName = "vocastock-firebase-emulators"
+
+defaultFirestorePort :: Int
+defaultFirestorePort = 18080
+
+defaultStoragePort :: Int
+defaultStoragePort = 19199
+
+defaultAuthPort :: Int
+defaultAuthPort = 19099
+
+defaultReadyBudgetSeconds :: Int
+defaultReadyBudgetSeconds = 30
+
+defaultEmulatorReadyBudgetSeconds :: String
+defaultEmulatorReadyBudgetSeconds = "300"
+
+featureReuseEnv :: String
+featureReuseEnv = "VOCAS_FEATURE_REUSE_RUNNING"
+
+featureSkipBuildEnv :: String
+featureSkipBuildEnv = "VOCAS_FEATURE_SKIP_BUILD"
+
+data FeatureRuntime = FeatureRuntime
+  { runtimeRepoRoot :: FilePath,
+    runtimeComposeFile :: FilePath,
+    runtimeEnvFile :: FilePath,
+    runtimeStartedEmulators :: Bool,
+    runtimeStartedWorker :: IORef Bool
+  }
+
+newtype ValidationResult = ValidationResult
+  { validationFields :: Map.Map String String
+  }
+
+withFeatureRuntime :: (FeatureRuntime -> IO a) -> IO a
+withFeatureRuntime = bracket startRuntime cleanupRuntime
+
+startStableWorker :: FeatureRuntime -> IO ()
+startStableWorker runtime = do
+  args <- composeArgs runtime ["up", "-d"] >>= withBuildFlag
+  runCommandStrict (runtimeRepoRoot runtime) "docker" (args ++ [constBillingWorkerService])
+  writeIORef (runtimeStartedWorker runtime) True
+  pure ()
+  where
+    withBuildFlag args = do
+      skipBuild <- envFlag featureSkipBuildEnv
+      pure $
+        if skipBuild
+          then args
+          else args ++ ["--build"]
+
+waitForStableWorker :: FeatureRuntime -> IO ()
+waitForStableWorker runtime = poll defaultReadyBudgetSeconds
+  where
+    poll remaining = do
+      logs <- workerLogs runtime
+      if "entered stable-run mode" `isInfixOf` logs
+        then pure ()
+        else
+          if remaining <= 0
+            then error "billing-worker did not enter stable-run mode in time"
+            else threadDelay 1000000 >> poll (remaining - 1)
+
+workerLogs :: FeatureRuntime -> IO String
+workerLogs runtime = do
+  args <- composeArgs runtime ["logs", "--no-color", constBillingWorkerService]
+  runCommandStrict (runtimeRepoRoot runtime) "docker" args
+
+runValidation :: FeatureRuntime -> String -> IO ValidationResult
+runValidation runtime scenario = do
+  args <-
+    composeArgs
+      runtime
+      [ "run",
+        "--rm",
+        "--no-deps",
+        "-e",
+        "VOCAS_WORKER_RUN_MODE=validate",
+        "-e",
+        "VOCAS_BILLING_WORKFLOW_SCENARIO=" ++ scenario,
+        constBillingWorkerService
+      ]
+  stdout <- runCommandStrict (runtimeRepoRoot runtime) "docker" args
+  pure (parseValidationResult stdout)
+
+assertField :: ValidationResult -> String -> String -> IO ()
+assertField (ValidationResult fields) key expected =
+  assertEqual ("unexpected value for " ++ key) (Just expected) (Map.lookup key fields)
+
+startRuntime :: IO FeatureRuntime
+startRuntime = do
+  repoRoot <- findRepoRoot =<< getCurrentDirectory
+  let composeFile = repoRoot </> "docker/applications/compose.yaml"
+      firebaseEnvPrimary = repoRoot </> "docker/firebase/env/.env"
+      firebaseEnvFallback = repoRoot </> "docker/firebase/env/.env.example"
+  firebaseEnv <- loadEnvFile =<< resolveEnvFile firebaseEnvPrimary firebaseEnvFallback
+  let firestorePort = portFromEnv firebaseEnv "FIREBASE_FIRESTORE_PORT" defaultFirestorePort
+      storagePort = portFromEnv firebaseEnv "FIREBASE_STORAGE_PORT" defaultStoragePort
+      authPort = portFromEnv firebaseEnv "FIREBASE_AUTH_PORT" defaultAuthPort
+  applicationEnvFile <- ensureApplicationEnvFile repoRoot
+  envFile <- writeFeatureEnvFile repoRoot applicationEnvFile firestorePort storagePort authPort
+  reuseRunning <- shouldReuseRunningEmulators repoRoot
+  if reuseRunning
+    then pure ()
+    else startEmulators repoRoot
+  buildWorkerImage repoRoot composeFile envFile
+  removeStaleWorkerContainer repoRoot composeFile envFile
+  startedWorkerRef <- newIORef False
+  pure
+    FeatureRuntime
+      { runtimeRepoRoot = repoRoot,
+        runtimeComposeFile = composeFile,
+        runtimeEnvFile = envFile,
+        runtimeStartedEmulators = not reuseRunning,
+        runtimeStartedWorker = startedWorkerRef
+      }
+
+cleanupRuntime :: FeatureRuntime -> IO ()
+cleanupRuntime runtime = do
+  let repoRoot = runtimeRepoRoot runtime
+  startedWorker <- readIORef (runtimeStartedWorker runtime)
+  if startedWorker
+    then do
+      _ <- tryRunCommand repoRoot "docker" =<< composeArgs runtime ["down"]
+      pure ()
+    else pure ()
+  if runtimeStartedEmulators runtime
+    then do
+      _ <- tryRunCommand repoRoot "bash" [repoRoot </> "scripts/firebase/stop_emulators.sh"]
+      pure ()
+    else pure ()
+  catchIOError (removeFile (runtimeEnvFile runtime)) (\_ -> pure ())
+
+findRepoRoot :: FilePath -> IO FilePath
+findRepoRoot current = do
+  let marker = current </> "docker/applications/compose.yaml"
+      parent = takeDirectory current
+  exists <- doesFileExist marker
+  if exists
+    then pure current
+    else
+      if parent == current
+        then error "repository root with docker/applications/compose.yaml not found"
+        else findRepoRoot parent
+
+resolveEnvFile :: FilePath -> FilePath -> IO FilePath
+resolveEnvFile primary fallback = do
+  primaryExists <- doesFileExist primary
+  pure (if primaryExists then primary else fallback)
+
+ensureApplicationEnvFile :: FilePath -> IO FilePath
+ensureApplicationEnvFile repoRoot = do
+  let envFile = repoRoot </> "docker/applications/env/.env"
+      template = repoRoot </> "docker/applications/env/.env.example"
+  envExists <- doesFileExist envFile
+  if envExists
+    then pure envFile
+    else copyFile template envFile >> pure envFile
+
+writeFeatureEnvFile :: FilePath -> FilePath -> Int -> Int -> Int -> IO FilePath
+writeFeatureEnvFile repoRoot baseEnvFile firestorePort storagePort authPort = do
+  let logsDir = repoRoot </> ".artifacts/ci/logs"
+  createDirectoryIfMissing True logsDir
+  suffix <- uniqueSuffix
+  baseContents <- readFile baseEnvFile
+  let envFile = logsDir </> ("billing-worker-feature-" ++ suffix ++ ".env")
+      contents =
+        ensureTrailingNewline baseContents
+          ++ "VOCAS_WORKER_STABLE_RUN_SECONDS=1\n"
+          ++ "VOCAS_WORKER_POLL_INTERVAL_SECONDS=1\n"
+          ++ "FIRESTORE_EMULATOR_HOST=host.docker.internal:"
+          ++ show firestorePort
+          ++ "\n"
+          ++ "STORAGE_EMULATOR_HOST=host.docker.internal:"
+          ++ show storagePort
+          ++ "\n"
+          ++ "FIREBASE_AUTH_EMULATOR_HOST=host.docker.internal:"
+          ++ show authPort
+          ++ "\n"
+  writeFile envFile contents
+  pure envFile
+
+uniqueSuffix :: IO String
+uniqueSuffix = do
+  posix <- getPOSIXTime
+  pure (show (round (posix * 1000000) :: Integer))
+
+ensureTrailingNewline :: String -> String
+ensureTrailingNewline contents =
+  if null contents || last contents == '\n'
+    then contents
+    else contents ++ "\n"
+
+loadEnvFile :: FilePath -> IO (Map.Map String String)
+loadEnvFile path = do
+  contents <- readFile path
+  pure $
+    Map.fromList $
+      foldr parseLine [] (lines contents)
+  where
+    parseLine line acc =
+      case trim line of
+        [] -> acc
+        ('#' : _) -> acc
+        trimmed ->
+          case break (== '=') trimmed of
+            (key, '=' : value) -> (trim key, trim value) : acc
+            _ -> acc
+
+portFromEnv :: Map.Map String String -> String -> Int -> Int
+portFromEnv envMap key fallback =
+  case Map.lookup key envMap >>= readMaybeInt of
+    Just value -> value
+    Nothing -> fallback
+
+readMaybeInt :: String -> Maybe Int
+readMaybeInt value =
+  case reads value of
+    [(parsed, "")] -> Just parsed
+    _ -> Nothing
+
+shouldReuseRunningEmulators :: FilePath -> IO Bool
+shouldReuseRunningEmulators repoRoot = do
+  reuse <- envFlag featureReuseEnv
+  running <- emulatorContainerRunning repoRoot
+  pure (reuse || running)
+
+emulatorContainerRunning :: FilePath -> IO Bool
+emulatorContainerRunning repoRoot = do
+  output <- tryRunCommand repoRoot "docker" ["ps", "--format", "{{.Names}}"]
+  pure $
+    maybe
+      False
+      (any (== constEmulatorContainerName) . lines)
+      output
+
+startEmulators :: FilePath -> IO ()
+startEmulators repoRoot = do
+  readyBudget <- maybe defaultEmulatorReadyBudgetSeconds id <$> lookupEnvMaybe "VOCAS_EMULATOR_READY_BUDGET_SECONDS"
+  _ <- runCommandStrict repoRoot "bash" [repoRoot </> "scripts/firebase/start_emulators.sh"]
+  _ <- runCommandStrict repoRoot "bash" [repoRoot </> "scripts/firebase/smoke_local_stack.sh", readyBudget]
+  pure ()
+
+buildWorkerImage :: FilePath -> FilePath -> FilePath -> IO ()
+buildWorkerImage repoRoot composeFile envFile = do
+  skipBuild <- envFlag featureSkipBuildEnv
+  if skipBuild
+    then pure ()
+    else do
+      args <- composeArgs' composeFile envFile ["build", constBillingWorkerService]
+      _ <- runCommandStrict repoRoot "docker" args
+      pure ()
+
+removeStaleWorkerContainer :: FilePath -> FilePath -> FilePath -> IO ()
+removeStaleWorkerContainer repoRoot composeFile envFile = do
+  args <- composeArgs' composeFile envFile ["rm", "-sf", constBillingWorkerService]
+  _ <- tryRunCommand repoRoot "docker" args
+  pure ()
+
+composeArgs :: FeatureRuntime -> [String] -> IO [String]
+composeArgs runtime extra =
+  composeArgs' (runtimeComposeFile runtime) (runtimeEnvFile runtime) extra
+
+composeArgs' :: FilePath -> FilePath -> [String] -> IO [String]
+composeArgs' composeFile envFile extra =
+  pure $
+    [ "compose",
+      "--env-file",
+      envFile,
+      "-f",
+      composeFile
+    ]
+      ++ extra
+
+runCommandStrict :: FilePath -> String -> [String] -> IO String
+runCommandStrict repoRoot program args = do
+  (exitCode, stdout, stderr) <- readCreateProcessWithExitCode ((proc program args) {cwd = Just repoRoot}) ""
+  case exitCode of
+    ExitSuccess -> pure stdout
+    ExitFailure _ ->
+      error $
+        "command failed: "
+          ++ unwords (program : args)
+          ++ "\nstdout:\n"
+          ++ stdout
+          ++ "\nstderr:\n"
+          ++ stderr
+
+tryRunCommand :: FilePath -> String -> [String] -> IO (Maybe String)
+tryRunCommand repoRoot program args = do
+  (exitCode, stdout, _) <- readCreateProcessWithExitCode ((proc program args) {cwd = Just repoRoot}) ""
+  pure $
+    case exitCode of
+      ExitSuccess -> Just stdout
+      ExitFailure _ -> Nothing
+
+lookupEnvMaybe :: String -> IO (Maybe String)
+lookupEnvMaybe key = catchIOError (Just <$> getEnvCompat key) (\_ -> pure Nothing)
+
+getEnvCompat :: String -> IO String
+getEnvCompat = getEnv
+
+envFlag :: String -> IO Bool
+envFlag key = do
+  value <- lookupEnvMaybe key
+  pure $
+    maybe
+      False
+      (\raw -> map toLower (trim raw) `elem` ["1", "true", "yes", "on"])
+      value
+
+parseValidationResult :: String -> ValidationResult
+parseValidationResult stdout =
+  case filter ("VOCAS_BILLING_RESULT " `isPrefixOf`) (lines stdout) of
+    (line : _) -> ValidationResult (Map.fromList (map parseToken (tail (words line))))
+    [] -> error ("missing validation result in output:\n" ++ stdout)
+  where
+    parseToken token =
+      case break (== '=') token of
+        (key, '=' : value) -> (key, value)
+        _ -> error ("unexpected validation token: " ++ token)
+
+trim :: String -> String
+trim = trimRight . trimLeft
+  where
+    trimLeft = dropWhile (`elem` [' ', '\t'])
+    trimRight = reverse . trimLeft . reverse

--- a/applications/backend/billing-worker/tests/support/TestSupport.hs
+++ b/applications/backend/billing-worker/tests/support/TestSupport.hs
@@ -1,0 +1,27 @@
+module TestSupport
+  ( assertEqual,
+    assertTrue,
+    runNamed
+  )
+where
+
+assertEqual :: (Eq a, Show a) => String -> a -> a -> IO ()
+assertEqual label expected actual =
+  if expected == actual
+    then pure ()
+    else
+      error $
+        label
+          ++ " expected "
+          ++ show expected
+          ++ " but got "
+          ++ show actual
+
+assertTrue :: String -> Bool -> IO ()
+assertTrue label condition =
+  if condition
+    then pure ()
+    else error (label ++ " expected True but got False")
+
+runNamed :: String -> IO () -> IO ()
+runNamed _ action = action

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/BillingPersistenceSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/BillingPersistenceSpec.hs
@@ -1,0 +1,134 @@
+module BillingWorker.BillingPersistenceSpec (run) where
+
+import BillingWorker.BillingPersistence
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "builds completed record" testBuildsCompletedRecord
+  runNamed "creates a completed record" testCreatesCompletedRecord
+  runNamed "reuses existing completed record" testReusesCompletedRecord
+  runNamed "marks record current applied" testMarksRecordCurrentApplied
+  runNamed "renders labels" testRendersLabels
+  runExtraCoverageSamples
+
+samplePayload :: CompletedBillingPayload
+samplePayload =
+  CompletedBillingPayload
+    { completedPurchaseStateName = "verified",
+      completedSubscriptionStateName = "active",
+      completedEntitlementBundleName = "premium-generation",
+      completedQuotaProfileName = "standard-monthly",
+      completedTermStart = "2026-04-01T00:00:00Z",
+      completedTermEnd = "2026-05-01T00:00:00Z",
+      completedGraceWindow = Just "2026-05-08T00:00:00Z"
+    }
+
+testBuildsCompletedRecord :: IO ()
+testBuildsCompletedRecord = do
+  let record = completedRecordFor "bk-001" "subscription-001" SourcePurchaseVerification samplePayload
+  assertEqual "record identifier" "bk-001-completed" (recordIdentifier record)
+  assertEqual "subscription" "subscription-001" (recordSubscription record)
+  assertEqual "source" SourcePurchaseVerification (recordSource record)
+  assertEqual "visibility" HiddenUntilHandoff (recordVisibility record)
+  assertEqual "payload" samplePayload (recordPayload record)
+
+testCreatesCompletedRecord :: IO ()
+testCreatesCompletedRecord = do
+  let saveResult =
+        saveCompletedBilling
+          "bk-001"
+          "subscription-001"
+          SourcePurchaseVerification
+          samplePayload
+          emptyBillingStore
+  assertEqual "save action" SaveCreated (saveAction saveResult)
+  assertEqual "record identifier" "bk-001-completed" (recordIdentifier (saveRecord saveResult))
+  assertEqual
+    "lookup"
+    (Just (saveRecord saveResult))
+    (existingRecordFor "bk-001" (saveStore saveResult))
+
+testReusesCompletedRecord :: IO ()
+testReusesCompletedRecord = do
+  let initial =
+        saveCompletedBilling
+          "bk-001"
+          "subscription-001"
+          SourcePurchaseVerification
+          samplePayload
+          emptyBillingStore
+      reused =
+        saveCompletedBilling
+          "bk-001"
+          "subscription-001"
+          SourcePurchaseVerification
+          samplePayload
+          (saveStore initial)
+  assertEqual "reused action" SaveReused (saveAction reused)
+  assertEqual "same record" (saveRecord initial) (saveRecord reused)
+  assertEqual "store unchanged" (saveStore initial) (saveStore reused)
+
+testMarksRecordCurrentApplied :: IO ()
+testMarksRecordCurrentApplied = do
+  let initial =
+        saveCompletedBilling
+          "bk-001"
+          "subscription-001"
+          SourcePurchaseVerification
+          samplePayload
+          emptyBillingStore
+      (appliedRecord, appliedStore) =
+        markRecordCurrentApplied "bk-001" (saveStore initial)
+  assertEqual "visibility flipped" CurrentApplied (recordVisibility appliedRecord)
+  assertEqual
+    "store reflects applied visibility"
+    (Just CurrentApplied)
+    (fmap recordVisibility (existingRecordFor "bk-001" appliedStore))
+
+testRendersLabels :: IO ()
+testRendersLabels = do
+  assertEqual "purchase-verification source" "purchase-verification" (renderRecordSource SourcePurchaseVerification)
+  assertEqual "notification-reconciliation source" "notification-reconciliation" (renderRecordSource SourceNotificationReconciliation)
+  assertEqual "hidden-until-handoff" "hidden-until-handoff" (renderCompletedRecordVisibility HiddenUntilHandoff)
+  assertEqual "current-applied" "current-applied" (renderCompletedRecordVisibility CurrentApplied)
+  assertEqual "save action created" "created" (renderSaveAction SaveCreated)
+  assertEqual "save action reused" "reused" (renderSaveAction SaveReused)
+
+runExtraCoverageSamples :: IO ()
+runExtraCoverageSamples = do
+  runNamed "markRecordCurrentApplied falls back on missing record" testMarkMissingRecord
+  runNamed "records from notification source are tagged" testNotificationSourceRecord
+
+testMarkMissingRecord :: IO ()
+testMarkMissingRecord = do
+  let (record, store) = markRecordCurrentApplied "missing-key" emptyBillingStore
+  assertEqual "placeholder identifier" "missing-key-missing" (recordIdentifier record)
+  assertEqual "empty store preserved" emptyBillingStore store
+
+testNotificationSourceRecord :: IO ()
+testNotificationSourceRecord = do
+  let record =
+        completedRecordFor "bk-n-001" "subscription-002" SourceNotificationReconciliation samplePayload
+  assertEqual "record source" SourceNotificationReconciliation (recordSource record)
+  assertTrue "show record source" (not (null (show SourcePurchaseVerification)))
+  assertTrue "show completed visibility" (not (null (show HiddenUntilHandoff)))
+  assertTrue "show current-applied" (not (null (show CurrentApplied)))
+  assertTrue "show completed payload" (not (null (show samplePayload)))
+  assertTrue "show completed record" (not (null (show record)))
+  assertTrue "show save action" (not (null (show SaveCreated)))
+  assertTrue "show save action reused" (not (null (show SaveReused)))
+  assertTrue "show empty store" (not (null (show emptyBillingStore)))
+  let saveResult =
+        saveCompletedBilling "bk-p-001" "subscription-003" SourcePurchaseVerification samplePayload emptyBillingStore
+  assertTrue "show save result" (not (null (show saveResult)))
+  assertEqual "payload purchase state" "verified" (completedPurchaseStateName (recordPayload (saveRecord saveResult)))
+  assertEqual "payload subscription state" "active" (completedSubscriptionStateName (recordPayload (saveRecord saveResult)))
+  assertEqual "payload bundle" "premium-generation" (completedEntitlementBundleName (recordPayload (saveRecord saveResult)))
+  assertEqual "payload quota" "standard-monthly" (completedQuotaProfileName (recordPayload (saveRecord saveResult)))
+  assertEqual "payload term start" "2026-04-01T00:00:00Z" (completedTermStart (recordPayload (saveRecord saveResult)))
+  assertEqual "payload term end" "2026-05-01T00:00:00Z" (completedTermEnd (recordPayload (saveRecord saveResult)))
+  assertEqual "payload grace" (Just "2026-05-08T00:00:00Z") (completedGraceWindow (recordPayload (saveRecord saveResult)))
+  let expectedIdentifier = recordIdentifier (saveRecord saveResult)
+  assertTrue "record identifier non-empty" (not (null expectedIdentifier))
+  assertEqual "billing entries count" 1 (length (billingEntries (saveStore saveResult)))

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/CurrentSubscriptionHandoffSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/CurrentSubscriptionHandoffSpec.hs
@@ -1,0 +1,91 @@
+module BillingWorker.CurrentSubscriptionHandoffSpec (run) where
+
+import BillingWorker.BillingPersistence
+  ( CompletedBillingPayload (..),
+    RecordSource (..),
+    completedRecordFor
+  )
+import BillingWorker.CurrentSubscriptionHandoff
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "applied handoff switches current" testAppliedSwitches
+  runNamed "retryable handoff retains existing" testRetryableRetains
+  runNamed "superseded handoff marks superseded" testSupersededMarks
+  runNamed "retain no current keeps Nothing" testRetainNoCurrent
+  runNamed "currentWasRetained helper" testCurrentRetainedHelper
+  runNamed "renders handoff status" testRendersHandoffStatus
+  runNamed "renders current action" testRendersCurrentAction
+
+samplePayload :: CompletedBillingPayload
+samplePayload =
+  CompletedBillingPayload
+    { completedPurchaseStateName = "verified",
+      completedSubscriptionStateName = "active",
+      completedEntitlementBundleName = "premium-generation",
+      completedQuotaProfileName = "standard-monthly",
+      completedTermStart = "2026-04-01T00:00:00Z",
+      completedTermEnd = "2026-05-01T00:00:00Z",
+      completedGraceWindow = Just "2026-05-08T00:00:00Z"
+    }
+
+sampleRecord =
+  completedRecordFor "bk-001" "subscription-001" SourcePurchaseVerification samplePayload
+
+testAppliedSwitches :: IO ()
+testAppliedSwitches = do
+  let action = applyCurrentSubscriptionSuccess sampleRecord (ExistingCurrent "previous-001") HandoffApplied
+  assertEqual "switched" (CurrentSwitched "bk-001-completed") action
+
+testRetryableRetains :: IO ()
+testRetryableRetains = do
+  let action = applyCurrentSubscriptionSuccess sampleRecord (ExistingCurrent "previous-001") HandoffRetryableFailure
+  assertEqual "retains existing" (CurrentRetained (Just "previous-001")) action
+
+testSupersededMarks :: IO ()
+testSupersededMarks = do
+  let action = applyCurrentSubscriptionSuccess sampleRecord (ExistingCurrent "previous-001") HandoffSuperseded
+  assertEqual "superseded" (CurrentSuperseded "bk-001-completed") action
+
+testRetainNoCurrent :: IO ()
+testRetainNoCurrent = do
+  let action = retainExistingCurrent NoCurrent
+  assertEqual "retains Nothing" (CurrentRetained Nothing) action
+  let noCurrentApplied = applyCurrentSubscriptionSuccess sampleRecord NoCurrent HandoffApplied
+  assertEqual "no current applied" (CurrentSwitched "bk-001-completed") noCurrentApplied
+  let noCurrentRetryable = applyCurrentSubscriptionSuccess sampleRecord NoCurrent HandoffRetryableFailure
+  assertEqual "no current retryable" (CurrentRetained Nothing) noCurrentRetryable
+  let noCurrentSuperseded = applyCurrentSubscriptionSuccess sampleRecord NoCurrent HandoffSuperseded
+  assertEqual "no current superseded" (CurrentSuperseded "bk-001-completed") noCurrentSuperseded
+
+testCurrentRetainedHelper :: IO ()
+testCurrentRetainedHelper = do
+  assertTrue "retained is true" (currentWasRetained (CurrentRetained Nothing))
+  assertEqual "switched is false" False (currentWasRetained (CurrentSwitched "x"))
+  assertEqual "superseded is false" False (currentWasRetained (CurrentSuperseded "x"))
+  assertEqual "existing no current eq" NoCurrent NoCurrent
+  assertEqual "existing some eq" (ExistingCurrent "a") (ExistingCurrent "a")
+  assertEqual "handoff applied eq" HandoffApplied HandoffApplied
+  assertEqual "current switched eq" (CurrentSwitched "a") (CurrentSwitched "a")
+
+testRendersHandoffStatus :: IO ()
+testRendersHandoffStatus = do
+  assertEqual "applied" "applied" (renderHandoffStatus HandoffApplied)
+  assertEqual "retryable" "retryable-failure" (renderHandoffStatus HandoffRetryableFailure)
+  assertEqual "superseded" "superseded" (renderHandoffStatus HandoffSuperseded)
+
+testRendersCurrentAction :: IO ()
+testRendersCurrentAction = do
+  assertEqual "switched" "switched:bk-001" (renderCurrentAction (CurrentSwitched "bk-001"))
+  assertEqual "retained none" "retained:none" (renderCurrentAction (CurrentRetained Nothing))
+  assertEqual "retained some" "retained:prev" (renderCurrentAction (CurrentRetained (Just "prev")))
+  assertEqual "superseded" "superseded:bk-001" (renderCurrentAction (CurrentSuperseded "bk-001"))
+  assertTrue "show existing current none" (not (null (show NoCurrent)))
+  assertTrue "show existing current some" (not (null (show (ExistingCurrent "abc"))))
+  assertTrue "show handoff applied" (not (null (show HandoffApplied)))
+  assertTrue "show handoff retryable" (not (null (show HandoffRetryableFailure)))
+  assertTrue "show handoff superseded" (not (null (show HandoffSuperseded)))
+  assertTrue "show current switched" (not (null (show (CurrentSwitched "x"))))
+  assertTrue "show current retained" (not (null (show (CurrentRetained Nothing))))
+  assertTrue "show current superseded" (not (null (show (CurrentSuperseded "y"))))

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/EntitlementRecalcPortSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/EntitlementRecalcPortSpec.hs
@@ -1,0 +1,71 @@
+module BillingWorker.EntitlementRecalcPortSpec (run) where
+
+import BillingWorker.EntitlementRecalcPort
+import BillingWorker.SubscriptionAuthorityPort (SubscriptionStateName (..))
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "active preserves paid bundle and paid quota" testActivePreservesPaid
+  runNamed "grace preserves paid bundle and paid quota" testGracePreservesPaid
+  runNamed "pending-sync falls back to free" testPendingSyncFreeFallback
+  runNamed "expired falls back to free" testExpiredFreeFallback
+  runNamed "revoked falls back to free" testRevokedFreeFallback
+  runNamed "parses and renders bundle names" testBundleNameRoundTrip
+  runNamed "parses and renders quota profile names" testQuotaProfileRoundTrip
+
+testActivePreservesPaid :: IO ()
+testActivePreservesPaid = do
+  let derivation = deriveEntitlement SubscriptionActive ProMonthlyQuota
+  assertEqual "state" SubscriptionActive (derivationState derivation)
+  assertEqual "bundle" PremiumGenerationEntitlement (derivationBundle derivation)
+  assertEqual "quota" ProMonthlyQuota (derivationQuotaProfile derivation)
+
+testGracePreservesPaid :: IO ()
+testGracePreservesPaid = do
+  let derivation = deriveEntitlement SubscriptionGrace StandardMonthlyQuota
+  assertEqual "bundle" PremiumGenerationEntitlement (derivationBundle derivation)
+  assertEqual "quota" StandardMonthlyQuota (derivationQuotaProfile derivation)
+
+testPendingSyncFreeFallback :: IO ()
+testPendingSyncFreeFallback = do
+  let derivation = deriveEntitlement SubscriptionPendingSync StandardMonthlyQuota
+  assertEqual "bundle" FreeBasicEntitlement (derivationBundle derivation)
+  assertEqual "quota" FreeMonthlyQuota (derivationQuotaProfile derivation)
+
+testExpiredFreeFallback :: IO ()
+testExpiredFreeFallback = do
+  let derivation = deriveEntitlement SubscriptionExpired StandardMonthlyQuota
+  assertEqual "bundle" FreeBasicEntitlement (derivationBundle derivation)
+  assertEqual "quota" FreeMonthlyQuota (derivationQuotaProfile derivation)
+
+testRevokedFreeFallback :: IO ()
+testRevokedFreeFallback = do
+  let derivation = deriveEntitlement SubscriptionRevoked ProMonthlyQuota
+  assertEqual "bundle" FreeBasicEntitlement (derivationBundle derivation)
+  assertEqual "quota" FreeMonthlyQuota (derivationQuotaProfile derivation)
+
+testBundleNameRoundTrip :: IO ()
+testBundleNameRoundTrip = do
+  assertEqual "free-basic parse" (Just FreeBasicEntitlement) (parseEntitlementBundleName "free-basic")
+  assertEqual "premium parse" (Just PremiumGenerationEntitlement) (parseEntitlementBundleName "premium-generation")
+  assertEqual "unknown parse" Nothing (parseEntitlementBundleName "platinum")
+  assertEqual "free-basic render" "free-basic" (renderEntitlementBundleName FreeBasicEntitlement)
+  assertEqual "premium render" "premium-generation" (renderEntitlementBundleName PremiumGenerationEntitlement)
+
+testQuotaProfileRoundTrip :: IO ()
+testQuotaProfileRoundTrip = do
+  assertEqual "free-monthly parse" (Just FreeMonthlyQuota) (parseQuotaProfileName "free-monthly")
+  assertEqual "standard-monthly parse" (Just StandardMonthlyQuota) (parseQuotaProfileName "standard-monthly")
+  assertEqual "pro-monthly parse" (Just ProMonthlyQuota) (parseQuotaProfileName "pro-monthly")
+  assertEqual "unknown parse" Nothing (parseQuotaProfileName "enterprise")
+  assertEqual "free-monthly render" "free-monthly" (renderQuotaProfileName FreeMonthlyQuota)
+  assertEqual "standard-monthly render" "standard-monthly" (renderQuotaProfileName StandardMonthlyQuota)
+  assertEqual "pro-monthly render" "pro-monthly" (renderQuotaProfileName ProMonthlyQuota)
+  assertTrue "show bundles" (not (null (show FreeBasicEntitlement)))
+  assertTrue "show premium" (not (null (show PremiumGenerationEntitlement)))
+  assertTrue "show free-monthly" (not (null (show FreeMonthlyQuota)))
+  assertTrue "show standard-monthly" (not (null (show StandardMonthlyQuota)))
+  assertTrue "show pro-monthly" (not (null (show ProMonthlyQuota)))
+  let derivation = deriveEntitlement SubscriptionActive ProMonthlyQuota
+  assertTrue "show derivation" (not (null (show derivation)))

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/FailureSummarySpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/FailureSummarySpec.hs
@@ -1,0 +1,124 @@
+module BillingWorker.FailureSummarySpec (run) where
+
+import Data.List (isInfixOf)
+
+import BillingWorker.FailureSummary
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "classifies retryable verification failure" testClassifiesRetryable
+  runNamed "classifies timeout" testClassifiesTimeout
+  runNamed "classifies terminal" testClassifiesTerminal
+  runNamed "classifies dead letter" testClassifiesDeadLetter
+  runNamed "redacts provider detail in message" testRedactsProviderDetail
+  runNamed "exercises message mapping for all codes" testCoversAllMessages
+  runNamed "renders failure codes and statuses" testRendersLabels
+
+testClassifiesRetryable :: IO ()
+testClassifiesRetryable = do
+  let summary = failureSummaryFor FailureRetryableVerification 2
+  assertEqual "classification" ClassificationRetryable (summaryClassification summary)
+  assertEqual "public status" PublicRetryScheduled (summaryPublicStatus summary)
+  assertEqual "retryable flag" True (summaryRetryable summary)
+  assertEqual "attempt number" 2 (summaryLastAttemptNumber summary)
+
+testClassifiesTimeout :: IO ()
+testClassifiesTimeout = do
+  let summary = failureSummaryFor FailureTimedOut 1
+  assertEqual "classification" ClassificationTimeout (summaryClassification summary)
+  assertEqual "public status" PublicTimedOut (summaryPublicStatus summary)
+  assertEqual "retryable flag" True (summaryRetryable summary)
+
+testClassifiesTerminal :: IO ()
+testClassifiesTerminal = do
+  let summary = failureSummaryFor FailureMalformedPayload 1
+  assertEqual "classification" ClassificationTerminal (summaryClassification summary)
+  assertEqual "public status" PublicFailedFinal (summaryPublicStatus summary)
+  assertEqual "retryable flag" False (summaryRetryable summary)
+
+testClassifiesDeadLetter :: IO ()
+testClassifiesDeadLetter = do
+  let summary = failureSummaryFor FailureOperatorReview 3
+  assertEqual "classification" ClassificationDeadLetter (summaryClassification summary)
+  assertEqual "public status" PublicDeadLettered (summaryPublicStatus summary)
+
+testRedactsProviderDetail :: IO ()
+testRedactsProviderDetail = do
+  let summary = failureSummaryFor FailureMalformedPayload 1
+  assertTrue
+    "message excludes credential/stack tokens"
+    ( not
+        ( "credential" `isInfixOf` summaryMessage summary
+            || "stack" `isInfixOf` summaryMessage summary
+            || "receipt:" `isInfixOf` summaryMessage summary
+        )
+    )
+
+testCoversAllMessages :: IO ()
+testCoversAllMessages = do
+  let codes =
+        [ FailureRetryableVerification,
+          FailureRetryableNotificationIngest,
+          FailureTimedOut,
+          FailureTerminal,
+          FailureMalformedPayload,
+          FailureMalformedNotification,
+          FailureTriggerNotSupported,
+          FailurePreconditionInvalid,
+          FailureMissingPurchaseArtifact,
+          FailureMissingNotificationPayload,
+          FailureInvalidTarget,
+          FailureOwnershipMismatch,
+          FailureHandoffRetry,
+          FailureDuplicateInFlight,
+          FailureStaleNotification,
+          FailureOperatorReview
+        ]
+  mapM_ (\failureCode ->
+    let summary = failureSummaryFor failureCode 1
+     in do
+          assertTrue
+            ("message non-empty for " ++ renderFailureCode failureCode)
+            (not (null (summaryMessage summary)))
+          assertTrue ("show summary for " ++ renderFailureCode failureCode) (not (null (show summary))))
+    codes
+  assertTrue "show visibility" (not (null (show StatusOnly)))
+  assertTrue "show completed visibility" (not (null (show CompletedCurrent)))
+  assertTrue "show classification retryable" (not (null (show ClassificationRetryable)))
+  assertTrue "show classification timeout" (not (null (show ClassificationTimeout)))
+  assertTrue "show classification terminal" (not (null (show ClassificationTerminal)))
+  assertTrue "show classification dead letter" (not (null (show ClassificationDeadLetter)))
+  assertTrue "show public retry-scheduled" (not (null (show PublicRetryScheduled)))
+  assertTrue "show public timed-out" (not (null (show PublicTimedOut)))
+  assertTrue "show public failed-final" (not (null (show PublicFailedFinal)))
+  assertTrue "show public dead-lettered" (not (null (show PublicDeadLettered)))
+
+testRendersLabels :: IO ()
+testRendersLabels = do
+  assertEqual "visibility status-only" "status-only" (renderVisibility StatusOnly)
+  assertEqual "visibility completed-current" "completed-current" (renderVisibility CompletedCurrent)
+  assertEqual "classification retryable" "retryable" (renderFailureClassification ClassificationRetryable)
+  assertEqual "classification timeout" "timeout" (renderFailureClassification ClassificationTimeout)
+  assertEqual "classification terminal" "terminal" (renderFailureClassification ClassificationTerminal)
+  assertEqual "classification dead letter" "dead-letter" (renderFailureClassification ClassificationDeadLetter)
+  assertEqual "public retry-scheduled" "retry-scheduled" (renderPublicStatus PublicRetryScheduled)
+  assertEqual "public timed-out" "timed-out" (renderPublicStatus PublicTimedOut)
+  assertEqual "public failed-final" "failed-final" (renderPublicStatus PublicFailedFinal)
+  assertEqual "public dead-lettered" "dead-lettered" (renderPublicStatus PublicDeadLettered)
+  assertEqual "code retryable-verification" "retryable-verification" (renderFailureCode FailureRetryableVerification)
+  assertEqual "code retryable-notification-ingest" "retryable-notification-ingest" (renderFailureCode FailureRetryableNotificationIngest)
+  assertEqual "code timed-out" "timed-out" (renderFailureCode FailureTimedOut)
+  assertEqual "code terminal" "terminal" (renderFailureCode FailureTerminal)
+  assertEqual "code malformed-payload" "malformed-payload" (renderFailureCode FailureMalformedPayload)
+  assertEqual "code malformed-notification" "malformed-notification" (renderFailureCode FailureMalformedNotification)
+  assertEqual "code trigger-not-supported" "trigger-not-supported" (renderFailureCode FailureTriggerNotSupported)
+  assertEqual "code precondition-invalid" "precondition-invalid" (renderFailureCode FailurePreconditionInvalid)
+  assertEqual "code missing-purchase-artifact" "missing-purchase-artifact" (renderFailureCode FailureMissingPurchaseArtifact)
+  assertEqual "code missing-notification-payload" "missing-notification-payload" (renderFailureCode FailureMissingNotificationPayload)
+  assertEqual "code invalid-target" "invalid-target" (renderFailureCode FailureInvalidTarget)
+  assertEqual "code ownership-mismatch" "ownership-mismatch" (renderFailureCode FailureOwnershipMismatch)
+  assertEqual "code handoff-retry" "handoff-retry" (renderFailureCode FailureHandoffRetry)
+  assertEqual "code duplicate-in-flight" "duplicate-in-flight" (renderFailureCode FailureDuplicateInFlight)
+  assertEqual "code stale-notification" "stale-notification" (renderFailureCode FailureStaleNotification)
+  assertEqual "code operator-review" "operator-review" (renderFailureCode FailureOperatorReview)

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/NotificationPortSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/NotificationPortSpec.hs
@@ -1,0 +1,122 @@
+module BillingWorker.NotificationPortSpec (run) where
+
+import BillingWorker.NotificationPort
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "accepts normalized payload" testAcceptsNormalizedPayload
+  runNamed "rejects missing provider identifier" testRejectsMissingProviderIdentifier
+  runNamed "rejects missing state name" testRejectsMissingStateName
+  runNamed "rejects missing period" testRejectsMissingPeriod
+  runNamed "rejects unknown state name" testRejectsUnknownStateName
+  runNamed "builds reconciled outcome" testBuildsReconciledOutcome
+  runNamed "builds retryable outcome" testBuildsRetryableOutcome
+  runNamed "builds non-retryable outcome" testBuildsNonRetryableOutcome
+  runNamed "builds timed-out outcome" testBuildsTimedOutOutcome
+  runNamed "builds stale outcome" testBuildsStaleOutcome
+  runNamed "parses and renders sources" testParsesAndRendersSources
+  runNamed "renders statuses" testRendersStatuses
+
+validPayload :: NotificationPayload
+validPayload =
+  NotificationPayload
+    { notificationProviderIdentifier = "apple-001",
+      notificationSubscriptionStateName = "grace",
+      notificationTermStart = "2026-04-01T00:00:00Z",
+      notificationTermEnd = "2026-05-01T00:00:00Z",
+      notificationGraceWindow = Just "2026-05-08T00:00:00Z",
+      notificationOriginalTimestamp = "2026-04-15T12:00:00Z"
+    }
+
+testAcceptsNormalizedPayload :: IO ()
+testAcceptsNormalizedPayload =
+  case validateNotificationPayload validPayload of
+    Right payload -> assertEqual "returned payload" validPayload payload
+    Left issue -> error ("expected Right but got Left " ++ show issue)
+
+testRejectsMissingProviderIdentifier :: IO ()
+testRejectsMissingProviderIdentifier =
+  case validateNotificationPayload validPayload {notificationProviderIdentifier = ""} of
+    Left issue -> assertEqual "missing provider" MissingProviderIdentifier issue
+    Right _ -> error "expected Left MissingProviderIdentifier"
+
+testRejectsMissingStateName :: IO ()
+testRejectsMissingStateName =
+  case validateNotificationPayload validPayload {notificationSubscriptionStateName = ""} of
+    Left issue -> assertEqual "missing state" MissingStateName issue
+    Right _ -> error "expected Left MissingStateName"
+
+testRejectsMissingPeriod :: IO ()
+testRejectsMissingPeriod =
+  case validateNotificationPayload validPayload {notificationTermEnd = ""} of
+    Left issue -> assertEqual "missing period" MissingNotificationPeriod issue
+    Right _ -> error "expected Left MissingNotificationPeriod"
+
+testRejectsUnknownStateName :: IO ()
+testRejectsUnknownStateName =
+  case validateNotificationPayload validPayload {notificationSubscriptionStateName = "trialing"} of
+    Left issue -> assertEqual "unknown state" UnknownStateName issue
+    Right _ -> error "expected Left UnknownStateName"
+
+testBuildsReconciledOutcome :: IO ()
+testBuildsReconciledOutcome = do
+  let outcome = reconciledNotificationOutcome "req-001" AppStoreNotification validPayload
+  assertEqual "status" NotificationReconciled (ingestStatus outcome)
+  assertEqual "request identifier" "req-001" (ingestRequestIdentifier outcome)
+  assertEqual "source" AppStoreNotification (ingestSource outcome)
+  assertEqual "payload present" (Just validPayload) (ingestPayload outcome)
+
+testBuildsRetryableOutcome :: IO ()
+testBuildsRetryableOutcome = do
+  let outcome = retryableNotificationOutcome "req-002" GooglePlayNotification "temporarily unavailable"
+  assertEqual "status" NotificationRetryableFailure (ingestStatus outcome)
+  assertEqual "reason" (Just "temporarily unavailable") (ingestFailureReason outcome)
+
+testBuildsNonRetryableOutcome :: IO ()
+testBuildsNonRetryableOutcome = do
+  let outcome = nonRetryableNotificationOutcome "req-003" AppStoreNotification "malformed"
+  assertEqual "status" NotificationNonRetryableFailure (ingestStatus outcome)
+
+testBuildsTimedOutOutcome :: IO ()
+testBuildsTimedOutOutcome = do
+  let outcome = timedOutNotificationOutcome "req-004" GooglePlayNotification
+  assertEqual "status" NotificationTimedOut (ingestStatus outcome)
+
+testBuildsStaleOutcome :: IO ()
+testBuildsStaleOutcome = do
+  let outcome = staleNotificationOutcome "req-005" AppStoreNotification validPayload
+  assertEqual "status" NotificationStale (ingestStatus outcome)
+  assertEqual "payload present" (Just validPayload) (ingestPayload outcome)
+
+testParsesAndRendersSources :: IO ()
+testParsesAndRendersSources = do
+  assertEqual "app-store" AppStoreNotification (parseNotificationSource "app-store")
+  assertEqual "google-play" GooglePlayNotification (parseNotificationSource "google-play")
+  case parseNotificationSource "unknown" of
+    UnsupportedNotificationSource "unknown" -> pure ()
+    other -> error ("expected UnsupportedNotificationSource but got " ++ show other)
+  assertEqual "render app-store" "app-store" (renderNotificationSource AppStoreNotification)
+  assertEqual "render google-play" "google-play" (renderNotificationSource GooglePlayNotification)
+  assertEqual "render unsupported" "unsupported:x" (renderNotificationSource (UnsupportedNotificationSource "x"))
+
+testRendersStatuses :: IO ()
+testRendersStatuses = do
+  assertEqual "reconciled" "reconciled" (renderNotificationIngestStatus NotificationReconciled)
+  assertEqual "retryable" "retryable-failure" (renderNotificationIngestStatus NotificationRetryableFailure)
+  assertEqual "non-retryable" "non-retryable-failure" (renderNotificationIngestStatus NotificationNonRetryableFailure)
+  assertEqual "timed-out" "timed-out" (renderNotificationIngestStatus NotificationTimedOut)
+  assertEqual "stale" "stale" (renderNotificationIngestStatus NotificationStale)
+  let malformed = malformedNotificationOutcome "req-m" AppStoreNotification validPayload {notificationProviderIdentifier = ""}
+  assertEqual "malformed status is reconciled" NotificationReconciled (ingestStatus malformed)
+  assertTrue "show app-store" (not (null (show AppStoreNotification)))
+  assertTrue "show google-play" (not (null (show GooglePlayNotification)))
+  assertTrue "show unsupported" (not (null (show (UnsupportedNotificationSource "x"))))
+  assertTrue "show payload" (not (null (show validPayload)))
+  assertTrue "show outcome" (not (null (show (reconciledNotificationOutcome "r" AppStoreNotification validPayload))))
+  assertTrue "show issue missing provider" (not (null (show MissingProviderIdentifier)))
+  assertTrue "show issue missing state" (not (null (show MissingStateName)))
+  assertTrue "show issue missing period" (not (null (show MissingNotificationPeriod)))
+  assertTrue "show issue unknown state" (not (null (show UnknownStateName)))
+  assertTrue "show status values" (not (null (show NotificationReconciled)))
+  assertTrue "show status stale" (not (null (show NotificationStale)))

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/PurchaseVerificationPortSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/PurchaseVerificationPortSpec.hs
@@ -1,0 +1,128 @@
+module BillingWorker.PurchaseVerificationPortSpec (run) where
+
+import BillingWorker.PurchaseVerificationPort
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "accepts verified payload" testAcceptsVerifiedPayload
+  runNamed "rejects missing subscription state" testRejectsMissingSubscriptionState
+  runNamed "rejects missing entitlement bundle" testRejectsMissingEntitlementBundle
+  runNamed "rejects missing quota profile" testRejectsMissingQuotaProfile
+  runNamed "rejects missing effective period" testRejectsMissingEffectivePeriod
+  runNamed "rejects unknown subscription state" testRejectsUnknownSubscriptionState
+  runNamed "rejects unknown entitlement bundle" testRejectsUnknownEntitlementBundle
+  runNamed "rejects unknown quota profile" testRejectsUnknownQuotaProfile
+  runNamed "builds successful outcome" testBuildsSuccessfulOutcome
+  runNamed "builds retryable outcome" testBuildsRetryableOutcome
+  runNamed "builds non-retryable outcome" testBuildsNonRetryableOutcome
+  runNamed "builds timed-out outcome" testBuildsTimedOutOutcome
+  runNamed "renders statuses" testRendersStatuses
+
+validPayload :: VerificationPayload
+validPayload =
+  VerificationPayload
+    { payloadSubscriptionStateName = "active",
+      payloadEntitlementBundleName = "premium-generation",
+      payloadQuotaProfileName = "standard-monthly",
+      payloadTermStart = "2026-04-01T00:00:00Z",
+      payloadTermEnd = "2026-05-01T00:00:00Z",
+      payloadGraceWindow = Just "2026-05-08T00:00:00Z"
+    }
+
+testAcceptsVerifiedPayload :: IO ()
+testAcceptsVerifiedPayload =
+  case validateVerificationPayload validPayload of
+    Right payload -> assertEqual "returned payload" validPayload payload
+    Left issue -> error ("expected Right but got Left " ++ show issue)
+
+testRejectsMissingSubscriptionState :: IO ()
+testRejectsMissingSubscriptionState =
+  case validateVerificationPayload validPayload {payloadSubscriptionStateName = ""} of
+    Left issue -> assertEqual "missing state" MissingSubscriptionState issue
+    Right _ -> error "expected Left MissingSubscriptionState"
+
+testRejectsMissingEntitlementBundle :: IO ()
+testRejectsMissingEntitlementBundle =
+  case validateVerificationPayload validPayload {payloadEntitlementBundleName = ""} of
+    Left issue -> assertEqual "missing bundle" MissingEntitlementBundle issue
+    Right _ -> error "expected Left MissingEntitlementBundle"
+
+testRejectsMissingQuotaProfile :: IO ()
+testRejectsMissingQuotaProfile =
+  case validateVerificationPayload validPayload {payloadQuotaProfileName = ""} of
+    Left issue -> assertEqual "missing quota" MissingQuotaProfile issue
+    Right _ -> error "expected Left MissingQuotaProfile"
+
+testRejectsMissingEffectivePeriod :: IO ()
+testRejectsMissingEffectivePeriod =
+  case validateVerificationPayload validPayload {payloadTermStart = ""} of
+    Left issue -> assertEqual "missing period" MissingEffectivePeriod issue
+    Right _ -> error "expected Left MissingEffectivePeriod"
+
+testRejectsUnknownSubscriptionState :: IO ()
+testRejectsUnknownSubscriptionState =
+  case validateVerificationPayload validPayload {payloadSubscriptionStateName = "trialing"} of
+    Left issue -> assertEqual "unknown state" UnknownSubscriptionState issue
+    Right _ -> error "expected Left UnknownSubscriptionState"
+
+testRejectsUnknownEntitlementBundle :: IO ()
+testRejectsUnknownEntitlementBundle =
+  case validateVerificationPayload validPayload {payloadEntitlementBundleName = "platinum"} of
+    Left issue -> assertEqual "unknown bundle" UnknownEntitlementBundle issue
+    Right _ -> error "expected Left UnknownEntitlementBundle"
+
+testRejectsUnknownQuotaProfile :: IO ()
+testRejectsUnknownQuotaProfile =
+  case validateVerificationPayload validPayload {payloadQuotaProfileName = "enterprise"} of
+    Left issue -> assertEqual "unknown quota" UnknownQuotaProfile issue
+    Right _ -> error "expected Left UnknownQuotaProfile"
+
+testBuildsSuccessfulOutcome :: IO ()
+testBuildsSuccessfulOutcome = do
+  let outcome = successfulVerificationOutcome "request-001" validPayload
+  assertEqual "status" VerificationVerified (outcomeStatus outcome)
+  assertEqual "request identifier" "request-001" (outcomeRequestIdentifier outcome)
+  assertEqual "payload present" (Just validPayload) (outcomePayload outcome)
+  assertEqual "no failure reason" Nothing (outcomeFailureReason outcome)
+
+testBuildsRetryableOutcome :: IO ()
+testBuildsRetryableOutcome = do
+  let outcome = retryableVerificationOutcome "request-002" "temporarily unavailable"
+  assertEqual "status" VerificationRetryableFailure (outcomeStatus outcome)
+  assertEqual "payload absent" Nothing (outcomePayload outcome)
+  assertEqual "redacted reason" (Just "temporarily unavailable") (outcomeFailureReason outcome)
+
+testBuildsNonRetryableOutcome :: IO ()
+testBuildsNonRetryableOutcome = do
+  let outcome = nonRetryableVerificationOutcome "request-003" "signature invalid"
+  assertEqual "status" VerificationNonRetryableFailure (outcomeStatus outcome)
+  assertEqual "redacted reason" (Just "signature invalid") (outcomeFailureReason outcome)
+
+testBuildsTimedOutOutcome :: IO ()
+testBuildsTimedOutOutcome = do
+  let outcome = timedOutVerificationOutcome "request-004"
+  assertEqual "status" VerificationTimedOut (outcomeStatus outcome)
+  assertEqual "payload absent" Nothing (outcomePayload outcome)
+
+testRendersStatuses :: IO ()
+testRendersStatuses = do
+  assertEqual "verified" "verified" (renderVerificationStatus VerificationVerified)
+  assertEqual "retryable" "retryable-failure" (renderVerificationStatus VerificationRetryableFailure)
+  assertEqual "non-retryable" "non-retryable-failure" (renderVerificationStatus VerificationNonRetryableFailure)
+  assertEqual "timed-out" "timed-out" (renderVerificationStatus VerificationTimedOut)
+  let malformed = malformedVerifiedOutcome "req-m" validPayload {payloadSubscriptionStateName = ""}
+  assertEqual "malformed status" VerificationVerified (outcomeStatus malformed)
+  assertTrue "show verified" (not (null (show VerificationVerified)))
+  assertTrue "show retryable" (not (null (show VerificationRetryableFailure)))
+  assertTrue "show non-retryable" (not (null (show VerificationNonRetryableFailure)))
+  assertTrue "show timed-out" (not (null (show VerificationTimedOut)))
+  assertTrue "show payload" (not (null (show validPayload)))
+  assertTrue "show outcome" (not (null (show (successfulVerificationOutcome "req-x" validPayload))))
+  assertTrue "show issue missing state" (not (null (show MissingSubscriptionState)))
+  assertTrue "show issue unknown state" (not (null (show UnknownSubscriptionState)))
+  assertTrue "show issue unknown bundle" (not (null (show UnknownEntitlementBundle)))
+  assertTrue "show issue unknown quota" (not (null (show UnknownQuotaProfile)))
+  assertTrue "show issue missing bundle" (not (null (show MissingEntitlementBundle)))
+  assertTrue "show issue missing quota" (not (null (show MissingQuotaProfile)))
+  assertTrue "show issue missing period" (not (null (show MissingEffectivePeriod)))

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/SubscriptionAuthorityPortSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/SubscriptionAuthorityPortSpec.hs
@@ -1,0 +1,51 @@
+module BillingWorker.SubscriptionAuthorityPortSpec (run) where
+
+import BillingWorker.SubscriptionAuthorityPort
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "builds authority update outcome" testBuildsAuthorityUpdateOutcome
+  runNamed "parses subscription state names" testParsesSubscriptionStateNames
+  runNamed "renders subscription state names" testRendersSubscriptionStateNames
+  runNamed "renders authority update statuses" testRendersAuthorityStatuses
+
+testBuildsAuthorityUpdateOutcome :: IO ()
+testBuildsAuthorityUpdateOutcome = do
+  let outcome = authorityUpdateFor "subscription-001" SubscriptionActive AuthorityApplied "idempotency-001"
+  assertEqual "subscription" "subscription-001" (authoritySubscription outcome)
+  assertEqual "target state" SubscriptionActive (authorityTargetState outcome)
+  assertEqual "status" AuthorityApplied (authorityStatus outcome)
+  assertEqual "idempotency key" "idempotency-001" (authorityIdempotencyKey outcome)
+
+testParsesSubscriptionStateNames :: IO ()
+testParsesSubscriptionStateNames = do
+  assertEqual "active" (Just SubscriptionActive) (parseSubscriptionStateName "active")
+  assertEqual "grace" (Just SubscriptionGrace) (parseSubscriptionStateName "grace")
+  assertEqual "expired" (Just SubscriptionExpired) (parseSubscriptionStateName "expired")
+  assertEqual "pending-sync" (Just SubscriptionPendingSync) (parseSubscriptionStateName "pending-sync")
+  assertEqual "revoked" (Just SubscriptionRevoked) (parseSubscriptionStateName "revoked")
+  assertEqual "unknown" Nothing (parseSubscriptionStateName "trialing")
+
+testRendersSubscriptionStateNames :: IO ()
+testRendersSubscriptionStateNames = do
+  assertEqual "active" "active" (renderSubscriptionStateName SubscriptionActive)
+  assertEqual "grace" "grace" (renderSubscriptionStateName SubscriptionGrace)
+  assertEqual "expired" "expired" (renderSubscriptionStateName SubscriptionExpired)
+  assertEqual "pending-sync" "pending-sync" (renderSubscriptionStateName SubscriptionPendingSync)
+  assertEqual "revoked" "revoked" (renderSubscriptionStateName SubscriptionRevoked)
+
+testRendersAuthorityStatuses :: IO ()
+testRendersAuthorityStatuses = do
+  assertEqual "applied" "applied" (renderAuthorityUpdateStatus AuthorityApplied)
+  assertEqual "reuse" "reuse-committed" (renderAuthorityUpdateStatus AuthorityReuseCommitted)
+  assertEqual "retryable" "retryable-failure" (renderAuthorityUpdateStatus AuthorityRetryableFailure)
+  assertEqual "non-retryable" "non-retryable-failure" (renderAuthorityUpdateStatus AuthorityNonRetryableFailure)
+  let outcome = authorityUpdateFor "s-001" SubscriptionGrace AuthorityReuseCommitted "idem-001"
+  assertTrue "show outcome" (not (null (show outcome)))
+  assertTrue "show active" (not (null (show SubscriptionActive)))
+  assertTrue "show grace" (not (null (show SubscriptionGrace)))
+  assertTrue "show expired" (not (null (show SubscriptionExpired)))
+  assertTrue "show pending-sync" (not (null (show SubscriptionPendingSync)))
+  assertTrue "show revoked" (not (null (show SubscriptionRevoked)))
+  assertTrue "show authority status" (not (null (show AuthorityApplied)))

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/WorkItemContractSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/WorkItemContractSpec.hs
@@ -1,0 +1,129 @@
+module BillingWorker.WorkItemContractSpec (run) where
+
+import BillingWorker.WorkItemContract
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "accepts default purchase work item" testAcceptsDefaultPurchaseWorkItem
+  runNamed "accepts default notification work item" testAcceptsDefaultNotificationWorkItem
+  runNamed "rejects unsupported trigger" testRejectsUnsupportedTrigger
+  runNamed "rejects precondition-invalid items" testRejectsPreconditionInvalid
+  runNamed "rejects missing purchase artifact" testRejectsMissingPurchaseArtifact
+  runNamed "rejects missing notification payload" testRejectsMissingNotificationPayload
+  runNamed "maps duplicate statuses to dispositions" testMapsDuplicateDispositions
+  runNamed "renders labels" testRendersLabels
+
+testAcceptsDefaultPurchaseWorkItem :: IO ()
+testAcceptsDefaultPurchaseWorkItem =
+  case validateWorkItem defaultPurchaseWorkItem of
+    Right validated -> do
+      assertEqual "identifier" "billing-work-item-001" (validatedIdentifier validated)
+      assertEqual "trigger" PurchaseArtifactSubmitted (validatedTrigger validated)
+      assertEqual "business key" "billing-business-key-001" (validatedBusinessKey validated)
+      assertEqual "subscription" "subscription-001" (validatedSubscription validated)
+      assertEqual "actor" "actor-001" (validatedActor validated)
+      assertEqual "purchase artifact" (Just "purchase-artifact-001") (validatedPurchaseArtifact validated)
+      assertEqual "notification payload" Nothing (validatedNotificationPayload validated)
+      assertEqual "request correlation" "correlation-001" (validatedRequestCorrelation validated)
+      assertEqual "accepted order" 1 (validatedAcceptedOrder validated)
+      assertEqual "equality" True (validated == validated)
+    Left intakeFailure -> error ("expected Right but got Left " ++ show intakeFailure)
+
+testAcceptsDefaultNotificationWorkItem :: IO ()
+testAcceptsDefaultNotificationWorkItem =
+  case validateWorkItem defaultNotificationWorkItem of
+    Right validated -> do
+      assertEqual "trigger" NotificationReceived (validatedTrigger validated)
+      assertEqual "notification payload present" True (validatedNotificationPayload validated /= Nothing)
+    Left intakeFailure -> error ("expected Right but got Left " ++ show intakeFailure)
+
+testRejectsUnsupportedTrigger :: IO ()
+testRejectsUnsupportedTrigger =
+  case validateWorkItem (defaultPurchaseWorkItem {workTrigger = UnsupportedTrigger "restore"}) of
+    Left failure -> assertEqual "trigger not supported" TriggerNotSupported failure
+    Right _ -> error "expected Left TriggerNotSupported"
+
+testRejectsPreconditionInvalid :: IO ()
+testRejectsPreconditionInvalid =
+  case validateWorkItem (defaultPurchaseWorkItem {workSubscription = ""}) of
+    Left failure -> assertEqual "precondition invalid" PreconditionInvalid failure
+    Right _ -> error "expected Left PreconditionInvalid"
+
+testRejectsMissingPurchaseArtifact :: IO ()
+testRejectsMissingPurchaseArtifact =
+  case validateWorkItem (defaultPurchaseWorkItem {workPurchaseArtifact = Nothing}) of
+    Left failure -> assertEqual "missing purchase artifact" MissingPurchaseArtifact failure
+    Right _ -> error "expected Left MissingPurchaseArtifact"
+
+testRejectsMissingNotificationPayload :: IO ()
+testRejectsMissingNotificationPayload =
+  case validateWorkItem (defaultNotificationWorkItem {workNotificationPayload = Nothing}) of
+    Left failure -> assertEqual "missing notification payload" MissingNotificationPayload failure
+    Right _ -> error "expected Left MissingNotificationPayload"
+
+testMapsDuplicateDispositions :: IO ()
+testMapsDuplicateDispositions = do
+  assertEqual "absent" ProcessFresh (duplicateDisposition DuplicateAbsent)
+  assertEqual "queued" IgnoreDuplicateInFlight (duplicateDisposition DuplicateQueued)
+  assertEqual "running" IgnoreDuplicateInFlight (duplicateDisposition DuplicateRunning)
+  assertEqual "retry-scheduled" IgnoreDuplicateInFlight (duplicateDisposition DuplicateRetryScheduled)
+  assertEqual "succeeded" ReuseCompletedDuplicate (duplicateDisposition DuplicateSucceeded)
+
+testRendersLabels :: IO ()
+testRendersLabels = do
+  assertEqual "render trigger purchase" "purchase-artifact-submitted" (renderWorkTrigger PurchaseArtifactSubmitted)
+  assertEqual "render trigger notification" "notification-received" (renderWorkTrigger NotificationReceived)
+  assertEqual "render trigger unsupported" "unsupported:restore" (renderWorkTrigger (UnsupportedTrigger "restore"))
+  assertEqual "render intake trigger" "trigger-not-supported" (renderIntakeFailure TriggerNotSupported)
+  assertEqual "render intake precondition" "precondition-invalid" (renderIntakeFailure PreconditionInvalid)
+  assertEqual "render intake missing purchase" "missing-purchase-artifact" (renderIntakeFailure MissingPurchaseArtifact)
+  assertEqual "render intake missing notification" "missing-notification-payload" (renderIntakeFailure MissingNotificationPayload)
+  assertEqual "render fresh" "fresh" (renderDuplicateDisposition ProcessFresh)
+  assertEqual "render inflight-noop" "inflight-noop" (renderDuplicateDisposition IgnoreDuplicateInFlight)
+  assertEqual "render reuse-completed" "reuse-completed" (renderDuplicateDisposition ReuseCompletedDuplicate)
+  assertEqual
+    "empty purchase artifact is missing"
+    (Left MissingPurchaseArtifact)
+    (fmap (const ()) (validateWorkItem (defaultPurchaseWorkItem {workPurchaseArtifact = Just ""})))
+  assertEqual
+    "empty notification payload is missing"
+    (Left MissingNotificationPayload)
+    (fmap (const ()) (validateWorkItem (defaultNotificationWorkItem {workNotificationPayload = Just ""})))
+  assertEqual
+    "missing identifier is precondition invalid"
+    (Left PreconditionInvalid)
+    (fmap (const ()) (validateWorkItem (defaultPurchaseWorkItem {workIdentifier = ""})))
+  assertEqual
+    "missing business key is precondition invalid"
+    (Left PreconditionInvalid)
+    (fmap (const ()) (validateWorkItem (defaultPurchaseWorkItem {workBusinessKey = ""})))
+  assertEqual
+    "missing actor is precondition invalid"
+    (Left PreconditionInvalid)
+    (fmap (const ()) (validateWorkItem (defaultPurchaseWorkItem {workActor = ""})))
+  assertEqual
+    "missing correlation is precondition invalid"
+    (Left PreconditionInvalid)
+    (fmap (const ()) (validateWorkItem (defaultPurchaseWorkItem {workRequestCorrelation = ""})))
+  assertEqual
+    "non-positive accepted order is precondition invalid"
+    (Left PreconditionInvalid)
+    (fmap (const ()) (validateWorkItem (defaultPurchaseWorkItem {workAcceptedOrder = 0})))
+  assertTrue "show trigger purchase" (not (null (show PurchaseArtifactSubmitted)))
+  assertTrue "show trigger notification" (not (null (show NotificationReceived)))
+  assertTrue "show trigger unsupported" (not (null (show (UnsupportedTrigger "x"))))
+  assertTrue "show work item" (not (null (show defaultPurchaseWorkItem)))
+  assertTrue "show validated" (not (null (show (validateWorkItem defaultPurchaseWorkItem))))
+  assertTrue "show intake failure" (not (null (show TriggerNotSupported)))
+  assertTrue "show intake precondition" (not (null (show PreconditionInvalid)))
+  assertTrue "show intake missing purchase" (not (null (show MissingPurchaseArtifact)))
+  assertTrue "show intake missing notification" (not (null (show MissingNotificationPayload)))
+  assertTrue "show duplicate absent" (not (null (show DuplicateAbsent)))
+  assertTrue "show duplicate queued" (not (null (show DuplicateQueued)))
+  assertTrue "show duplicate running" (not (null (show DuplicateRunning)))
+  assertTrue "show duplicate retry-scheduled" (not (null (show DuplicateRetryScheduled)))
+  assertTrue "show duplicate succeeded" (not (null (show DuplicateSucceeded)))
+  assertTrue "show process fresh" (not (null (show ProcessFresh)))
+  assertTrue "show ignore duplicate" (not (null (show IgnoreDuplicateInFlight)))
+  assertTrue "show reuse completed" (not (null (show ReuseCompletedDuplicate)))

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/WorkerRuntimeSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/WorkerRuntimeSpec.hs
@@ -1,0 +1,167 @@
+module BillingWorker.WorkerRuntimeSpec (run) where
+
+import Data.List (isInfixOf)
+
+import BillingWorker.WorkerRuntime
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "renders scenario labels" testRendersScenarioLabels
+  runNamed "parses scenario labels" testParsesScenarioLabels
+  runNamed "purchase success scenario report" testPurchaseSuccessReport
+  runNamed "purchase retryable scenario report" testPurchaseRetryableReport
+  runNamed "purchase terminal scenario report" testPurchaseTerminalReport
+  runNamed "purchase timeout scenario report" testPurchaseTimeoutReport
+  runNamed "duplicate inflight scenario report" testDuplicateInflightReport
+  runNamed "duplicate succeeded scenario report" testDuplicateSucceededReport
+  runNamed "retry exhausted scenario report" testRetryExhaustedReport
+  runNamed "invalid target scenario report" testInvalidTargetReport
+  runNamed "ownership mismatch scenario report" testOwnershipMismatchReport
+  runNamed "notification reconciled scenario report" testNotificationReconciledReport
+  runNamed "notification retryable scenario report" testNotificationRetryableReport
+  runNamed "notification terminal scenario report" testNotificationTerminalReport
+  runNamed "notification stale scenario report" testNotificationStaleReport
+  runNamed "notification dead letter scenario report" testNotificationDeadLetterReport
+  runNamed "renders scenario report" testRendersScenarioReport
+
+testRendersScenarioLabels :: IO ()
+testRendersScenarioLabels = do
+  assertEqual "label success" "success" (workerScenarioLabel ScenarioSuccess)
+  assertEqual "label retryable" "retryable-failure" (workerScenarioLabel ScenarioRetryableFailure)
+  assertEqual "label terminal" "terminal-failure" (workerScenarioLabel ScenarioTerminalFailure)
+  assertEqual "label timed-out" "timed-out" (workerScenarioLabel ScenarioTimeout)
+  assertEqual "label duplicate-running" "duplicate-running" (workerScenarioLabel ScenarioDuplicateRunning)
+  assertEqual "label duplicate-succeeded" "duplicate-succeeded" (workerScenarioLabel ScenarioDuplicateSucceeded)
+  assertEqual "label retry-exhausted" "retry-exhausted" (workerScenarioLabel ScenarioRetryExhausted)
+  assertEqual "label invalid-target" "invalid-target" (workerScenarioLabel ScenarioInvalidTarget)
+  assertEqual "label ownership-mismatch" "ownership-mismatch" (workerScenarioLabel ScenarioOwnershipMismatch)
+  assertEqual "label notification-reconciled" "notification-reconciled" (workerScenarioLabel ScenarioNotificationReconciled)
+  assertEqual "label notification-retryable" "notification-retryable" (workerScenarioLabel ScenarioNotificationRetryable)
+  assertEqual "label notification-terminal" "notification-terminal" (workerScenarioLabel ScenarioNotificationTerminal)
+  assertEqual "label notification-stale" "notification-stale" (workerScenarioLabel ScenarioNotificationStale)
+  assertEqual "label notification-dead-letter" "notification-dead-letter" (workerScenarioLabel ScenarioNotificationDeadLetter)
+  assertTrue "show ScenarioSuccess" (not (null (show ScenarioSuccess)))
+  assertTrue "show report" (not (null (show (runScenarioReport ScenarioSuccess))))
+
+testParsesScenarioLabels :: IO ()
+testParsesScenarioLabels = do
+  assertEqual "success" (Just ScenarioSuccess) (parseWorkerScenarioLabel "success")
+  assertEqual "retryable-failure" (Just ScenarioRetryableFailure) (parseWorkerScenarioLabel "retryable-failure")
+  assertEqual "terminal-failure" (Just ScenarioTerminalFailure) (parseWorkerScenarioLabel "terminal-failure")
+  assertEqual "timed-out" (Just ScenarioTimeout) (parseWorkerScenarioLabel "timed-out")
+  assertEqual "duplicate-running" (Just ScenarioDuplicateRunning) (parseWorkerScenarioLabel "duplicate-running")
+  assertEqual "duplicate-succeeded" (Just ScenarioDuplicateSucceeded) (parseWorkerScenarioLabel "duplicate-succeeded")
+  assertEqual "retry-exhausted" (Just ScenarioRetryExhausted) (parseWorkerScenarioLabel "retry-exhausted")
+  assertEqual "invalid-target" (Just ScenarioInvalidTarget) (parseWorkerScenarioLabel "invalid-target")
+  assertEqual "ownership-mismatch" (Just ScenarioOwnershipMismatch) (parseWorkerScenarioLabel "ownership-mismatch")
+  assertEqual "notification-reconciled" (Just ScenarioNotificationReconciled) (parseWorkerScenarioLabel "notification-reconciled")
+  assertEqual "notification-retryable" (Just ScenarioNotificationRetryable) (parseWorkerScenarioLabel "notification-retryable")
+  assertEqual "notification-terminal" (Just ScenarioNotificationTerminal) (parseWorkerScenarioLabel "notification-terminal")
+  assertEqual "notification-stale" (Just ScenarioNotificationStale) (parseWorkerScenarioLabel "notification-stale")
+  assertEqual "notification-dead-letter" (Just ScenarioNotificationDeadLetter) (parseWorkerScenarioLabel "notification-dead-letter")
+  assertEqual "unknown" Nothing (parseWorkerScenarioLabel "unknown")
+
+testPurchaseSuccessReport :: IO ()
+testPurchaseSuccessReport = do
+  let report = runScenarioReport ScenarioSuccess
+  assertEqual "final state" "succeeded" (reportFinalState report)
+  assertEqual "visibility" "completed-current" (reportVisibility report)
+  assertEqual "failure code" "none" (reportFailureCode report)
+  assertEqual "handoff completed" True (reportHandoffCompleted report)
+  assertEqual "completed saved" True (reportCompletedSaved report)
+  assertEqual "source" "purchase-verification" (reportSource report)
+
+testPurchaseRetryableReport :: IO ()
+testPurchaseRetryableReport = do
+  let report = runScenarioReport ScenarioRetryableFailure
+  assertEqual "final state" "retry-scheduled-1" (reportFinalState report)
+  assertEqual "failure code" "retryable-verification" (reportFailureCode report)
+  assertEqual "public status" "retry-scheduled" (reportPublicStatus report)
+  assertEqual "retryable" True (reportRetryable report)
+  assertEqual "completed saved" False (reportCompletedSaved report)
+
+testPurchaseTerminalReport :: IO ()
+testPurchaseTerminalReport = do
+  let report = runScenarioReport ScenarioTerminalFailure
+  assertEqual "final state" "failed-final" (reportFinalState report)
+  assertEqual "failure code" "terminal" (reportFailureCode report)
+  assertEqual "public status" "failed-final" (reportPublicStatus report)
+  assertEqual "retryable" False (reportRetryable report)
+
+testPurchaseTimeoutReport :: IO ()
+testPurchaseTimeoutReport = do
+  let report = runScenarioReport ScenarioTimeout
+  assertEqual "final state" "retry-scheduled-1" (reportFinalState report)
+  assertEqual "failure code" "timed-out" (reportFailureCode report)
+  assertEqual "public status" "timed-out" (reportPublicStatus report)
+
+testDuplicateInflightReport :: IO ()
+testDuplicateInflightReport = do
+  let report = runScenarioReport ScenarioDuplicateRunning
+  assertEqual "final state" "running" (reportFinalState report)
+  assertEqual "duplicate" "inflight-noop" (reportDuplicateDisposition report)
+
+testDuplicateSucceededReport :: IO ()
+testDuplicateSucceededReport = do
+  let report = runScenarioReport ScenarioDuplicateSucceeded
+  assertEqual "final state" "succeeded" (reportFinalState report)
+  assertEqual "duplicate" "reuse-completed" (reportDuplicateDisposition report)
+  assertEqual "current retained" True (reportCurrentRetained report)
+
+testRetryExhaustedReport :: IO ()
+testRetryExhaustedReport = do
+  let report = runScenarioReport ScenarioRetryExhausted
+  assertEqual "final state" "failed-final" (reportFinalState report)
+
+testInvalidTargetReport :: IO ()
+testInvalidTargetReport = do
+  let report = runScenarioReport ScenarioInvalidTarget
+  assertEqual "final state" "failed-final" (reportFinalState report)
+  assertEqual "failure code" "precondition-invalid" (reportFailureCode report)
+
+testOwnershipMismatchReport :: IO ()
+testOwnershipMismatchReport = do
+  let report = runScenarioReport ScenarioOwnershipMismatch
+  assertEqual "final state" "dead-lettered" (reportFinalState report)
+  assertEqual "failure code" "ownership-mismatch" (reportFailureCode report)
+
+testNotificationReconciledReport :: IO ()
+testNotificationReconciledReport = do
+  let report = runScenarioReport ScenarioNotificationReconciled
+  assertEqual "final state" "succeeded" (reportFinalState report)
+  assertEqual "source" "notification-reconciliation" (reportSource report)
+
+testNotificationRetryableReport :: IO ()
+testNotificationRetryableReport = do
+  let report = runScenarioReport ScenarioNotificationRetryable
+  assertEqual "final state" "retry-scheduled-1" (reportFinalState report)
+  assertEqual "failure code" "retryable-notification-ingest" (reportFailureCode report)
+
+testNotificationTerminalReport :: IO ()
+testNotificationTerminalReport = do
+  let report = runScenarioReport ScenarioNotificationTerminal
+  assertEqual "final state" "failed-final" (reportFinalState report)
+  assertEqual "failure code" "malformed-notification" (reportFailureCode report)
+
+testNotificationStaleReport :: IO ()
+testNotificationStaleReport = do
+  let report = runScenarioReport ScenarioNotificationStale
+  assertEqual "final state" "failed-final" (reportFinalState report)
+  assertEqual "failure code" "stale-notification" (reportFailureCode report)
+
+testNotificationDeadLetterReport :: IO ()
+testNotificationDeadLetterReport = do
+  let report = runScenarioReport ScenarioNotificationDeadLetter
+  assertEqual "final state" "dead-lettered" (reportFinalState report)
+  assertEqual "failure code" "operator-review" (reportFailureCode report)
+
+testRendersScenarioReport :: IO ()
+testRendersScenarioReport = do
+  let report = runScenarioReport ScenarioSuccess
+      rendered = renderScenarioReport report
+  assertTrue "starts with result prefix" ("VOCAS_BILLING_RESULT" `isInfixOf` rendered)
+  assertTrue "contains scenario" ("scenario=success" `isInfixOf` rendered)
+  assertTrue "contains final state" ("final_state=succeeded" `isInfixOf` rendered)
+  assertTrue "contains handoff completed" ("handoff_completed=true" `isInfixOf` rendered)
+  assertTrue "contains source" ("source=purchase-verification" `isInfixOf` rendered)

--- a/applications/backend/billing-worker/tests/unit/BillingWorker/WorkflowStateMachineSpec.hs
+++ b/applications/backend/billing-worker/tests/unit/BillingWorker/WorkflowStateMachineSpec.hs
@@ -1,0 +1,312 @@
+module BillingWorker.WorkflowStateMachineSpec (run) where
+
+import BillingWorker.BillingPersistence
+  ( emptyBillingStore
+  )
+import BillingWorker.CurrentSubscriptionHandoff
+  ( CurrentAction (..),
+    ExistingCurrent (..),
+    HandoffStatus (..)
+  )
+import BillingWorker.FailureSummary
+  ( BillingFailureSummary (..),
+    FailureCode (..),
+    Visibility (..)
+  )
+import BillingWorker.NotificationPort
+  ( NotificationPayload (..),
+    NotificationSource (..),
+    malformedNotificationOutcome,
+    nonRetryableNotificationOutcome,
+    reconciledNotificationOutcome,
+    retryableNotificationOutcome,
+    staleNotificationOutcome,
+    timedOutNotificationOutcome
+  )
+import BillingWorker.PurchaseVerificationPort
+  ( VerificationPayload (..),
+    malformedVerifiedOutcome,
+    nonRetryableVerificationOutcome,
+    retryableVerificationOutcome,
+    successfulVerificationOutcome,
+    timedOutVerificationOutcome
+  )
+import BillingWorker.WorkItemContract
+  ( DuplicateDisposition (..),
+    IntakeFailure (..),
+    defaultNotificationWorkItem,
+    defaultPurchaseWorkItem,
+    validateWorkItem
+  )
+import BillingWorker.WorkflowStateMachine
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "queued -> running -> succeeded on verified payload" testSuccessPath
+  runNamed "retryable verification maps to retry-scheduled" testRetryableVerification
+  runNamed "timeout below limit maps to retry-scheduled" testTimeoutBelowLimit
+  runNamed "timeout at limit maps to failed-final" testTimeoutAtLimit
+  runNamed "non-retryable verification maps to failed-final" testNonRetryableVerification
+  runNamed "malformed verification payload maps to failed-final" testMalformedVerifiedPayload
+  runNamed "handoff retryable failure retains current" testHandoffRetry
+  runNamed "notification reconciled succeeds" testNotificationReconciled
+  runNamed "stale notification maps to failed-final" testStaleNotification
+  runNamed "malformed notification maps to failed-final" testMalformedNotification
+  runNamed "duplicate inflight keeps status-only" testDuplicateInflight
+  runNamed "duplicate succeeded reuses record" testDuplicateSucceeded
+  runNamed "intake failure produces failed-final" testIntakeFailure
+  runNamed "ownership mismatch produces dead-lettered" testOwnershipMismatch
+  runNamed "deadLetter outcome produces dead-lettered" testDeadLetter
+  runNamed "renders workflow state labels" testRendersStateLabels
+
+validatedPurchase =
+  case validateWorkItem defaultPurchaseWorkItem of
+    Right validated -> validated
+    Left intakeFailure -> error ("expected Right but got Left " ++ show intakeFailure)
+
+validatedNotification =
+  case validateWorkItem defaultNotificationWorkItem of
+    Right validated -> validated
+    Left intakeFailure -> error ("expected Right but got Left " ++ show intakeFailure)
+
+verifiedPayload :: VerificationPayload
+verifiedPayload =
+  VerificationPayload
+    { payloadSubscriptionStateName = "active",
+      payloadEntitlementBundleName = "premium-generation",
+      payloadQuotaProfileName = "standard-monthly",
+      payloadTermStart = "2026-04-01T00:00:00Z",
+      payloadTermEnd = "2026-05-01T00:00:00Z",
+      payloadGraceWindow = Just "2026-05-08T00:00:00Z"
+    }
+
+notificationPayload :: NotificationPayload
+notificationPayload =
+  NotificationPayload
+    { notificationProviderIdentifier = "apple-001",
+      notificationSubscriptionStateName = "grace",
+      notificationTermStart = "2026-04-01T00:00:00Z",
+      notificationTermEnd = "2026-05-01T00:00:00Z",
+      notificationGraceWindow = Just "2026-05-08T00:00:00Z",
+      notificationOriginalTimestamp = "2026-04-15T12:00:00Z"
+    }
+
+freshBudget :: RetryBudget
+freshBudget = RetryBudget {retryAttempt = 1, retryLimit = 3}
+
+testSuccessPath :: IO ()
+testSuccessPath = do
+  let outcome =
+        runVerificationOutcome
+          freshBudget
+          NoCurrent
+          emptyBillingStore
+          validatedPurchase
+          (successfulVerificationOutcome "req-001" verifiedPayload)
+          HandoffApplied
+  assertEqual "final state" Succeeded (workflowFinalState outcome)
+  assertEqual "visibility" CompletedCurrent (workflowVisibility outcome)
+  assertEqual "trail" [Queued, Running, Succeeded] (workflowTrail outcome)
+  assertEqual "handoff completed" True (workflowHandoffCompleted outcome)
+  assertTrue "completed record present" (workflowCompletedRecord outcome /= Nothing)
+
+testRetryableVerification :: IO ()
+testRetryableVerification = do
+  let outcome =
+        runVerificationOutcome
+          freshBudget
+          NoCurrent
+          emptyBillingStore
+          validatedPurchase
+          (retryableVerificationOutcome "req-002" "provider-unavailable")
+          HandoffApplied
+  assertEqual "final state" (RetryScheduled 1) (workflowFinalState outcome)
+  assertEqual "visibility" StatusOnly (workflowVisibility outcome)
+  assertEqual "handoff not completed" False (workflowHandoffCompleted outcome)
+  assertEqual "no completed record" Nothing (workflowCompletedRecord outcome)
+
+testTimeoutBelowLimit :: IO ()
+testTimeoutBelowLimit = do
+  let outcome =
+        runVerificationOutcome
+          freshBudget
+          NoCurrent
+          emptyBillingStore
+          validatedPurchase
+          (timedOutVerificationOutcome "req-003")
+          HandoffApplied
+  assertEqual "final state" (RetryScheduled 1) (workflowFinalState outcome)
+
+testTimeoutAtLimit :: IO ()
+testTimeoutAtLimit = do
+  let exhaustedBudget = RetryBudget {retryAttempt = 3, retryLimit = 3}
+      outcome =
+        runVerificationOutcome
+          exhaustedBudget
+          NoCurrent
+          emptyBillingStore
+          validatedPurchase
+          (timedOutVerificationOutcome "req-004")
+          HandoffApplied
+  assertEqual "final state" FailedFinal (workflowFinalState outcome)
+
+testNonRetryableVerification :: IO ()
+testNonRetryableVerification = do
+  let outcome =
+        runVerificationOutcome
+          freshBudget
+          NoCurrent
+          emptyBillingStore
+          validatedPurchase
+          (nonRetryableVerificationOutcome "req-005" "signature-invalid")
+          HandoffApplied
+  assertEqual "final state" FailedFinal (workflowFinalState outcome)
+  assertEqual "visibility" StatusOnly (workflowVisibility outcome)
+
+testMalformedVerifiedPayload :: IO ()
+testMalformedVerifiedPayload = do
+  let malformed = verifiedPayload {payloadEntitlementBundleName = ""}
+      outcome =
+        runVerificationOutcome
+          freshBudget
+          NoCurrent
+          emptyBillingStore
+          validatedPurchase
+          (malformedVerifiedOutcome "req-006" malformed)
+          HandoffApplied
+  assertEqual "final state" FailedFinal (workflowFinalState outcome)
+  assertEqual
+    "failure code"
+    (Just FailureMalformedPayload)
+    (fmap summaryCode (workflowFailureSummary outcome))
+
+testHandoffRetry :: IO ()
+testHandoffRetry = do
+  let outcome =
+        runVerificationOutcome
+          freshBudget
+          (ExistingCurrent "existing-001")
+          emptyBillingStore
+          validatedPurchase
+          (successfulVerificationOutcome "req-007" verifiedPayload)
+          HandoffRetryableFailure
+  assertEqual "final state" (RetryScheduled 1) (workflowFinalState outcome)
+  assertEqual "visibility" StatusOnly (workflowVisibility outcome)
+  assertTrue
+    "retains existing current"
+    (case workflowCurrentAction outcome of
+        CurrentRetained (Just "existing-001") -> True
+        _ -> False)
+
+testNotificationReconciled :: IO ()
+testNotificationReconciled = do
+  let outcome =
+        runNotificationOutcome
+          freshBudget
+          NoCurrent
+          emptyBillingStore
+          validatedNotification
+          (reconciledNotificationOutcome "req-008" AppStoreNotification notificationPayload)
+          HandoffApplied
+  assertEqual "final state" Succeeded (workflowFinalState outcome)
+  assertEqual "visibility" CompletedCurrent (workflowVisibility outcome)
+
+testStaleNotification :: IO ()
+testStaleNotification = do
+  let outcome =
+        runNotificationOutcome
+          freshBudget
+          NoCurrent
+          emptyBillingStore
+          validatedNotification
+          (staleNotificationOutcome "req-009" AppStoreNotification notificationPayload)
+          HandoffApplied
+  assertEqual "final state" FailedFinal (workflowFinalState outcome)
+  assertEqual
+    "failure code"
+    (Just FailureStaleNotification)
+    (fmap summaryCode (workflowFailureSummary outcome))
+
+testMalformedNotification :: IO ()
+testMalformedNotification = do
+  let malformed = notificationPayload {notificationProviderIdentifier = ""}
+      outcome =
+        runNotificationOutcome
+          freshBudget
+          NoCurrent
+          emptyBillingStore
+          validatedNotification
+          (malformedNotificationOutcome "req-010" GooglePlayNotification malformed)
+          HandoffApplied
+  assertEqual "final state" FailedFinal (workflowFinalState outcome)
+  assertEqual
+    "failure code"
+    (Just FailureMalformedNotification)
+    (fmap summaryCode (workflowFailureSummary outcome))
+
+testDuplicateInflight :: IO ()
+testDuplicateInflight = do
+  let outcome = duplicateOutcome IgnoreDuplicateInFlight NoCurrent emptyBillingStore Nothing
+  assertEqual "final state" Running (workflowFinalState outcome)
+  assertEqual "visibility" StatusOnly (workflowVisibility outcome)
+  assertEqual "duplicate" IgnoreDuplicateInFlight (workflowDuplicateDisposition outcome)
+  assertEqual "trail" [Queued, Running] (workflowTrail outcome)
+  assertEqual "no completed record" Nothing (workflowCompletedRecord outcome)
+  assertEqual "no save action" Nothing (workflowSaveAction outcome)
+  assertEqual "handoff not completed" False (workflowHandoffCompleted outcome)
+  assertTrue "failure summary present" (workflowFailureSummary outcome /= Nothing)
+  assertEqual "store preserved" emptyBillingStore (workflowStore outcome)
+  assertEqual "duplicate inflight equality" outcome outcome
+
+testDuplicateSucceeded :: IO ()
+testDuplicateSucceeded = do
+  let outcome = duplicateOutcome ReuseCompletedDuplicate NoCurrent emptyBillingStore Nothing
+  assertEqual "final state" Succeeded (workflowFinalState outcome)
+  assertEqual "duplicate" ReuseCompletedDuplicate (workflowDuplicateDisposition outcome)
+
+testIntakeFailure :: IO ()
+testIntakeFailure = do
+  let outcome = intakeFailureOutcome NoCurrent emptyBillingStore PreconditionInvalid
+  assertEqual "final state" FailedFinal (workflowFinalState outcome)
+  assertEqual
+    "failure code"
+    (Just FailurePreconditionInvalid)
+    (fmap summaryCode (workflowFailureSummary outcome))
+
+testOwnershipMismatch :: IO ()
+testOwnershipMismatch = do
+  let outcome = ownershipMismatchOutcome NoCurrent emptyBillingStore
+  assertEqual "final state" DeadLettered (workflowFinalState outcome)
+  assertEqual
+    "failure code"
+    (Just FailureOwnershipMismatch)
+    (fmap summaryCode (workflowFailureSummary outcome))
+
+testDeadLetter :: IO ()
+testDeadLetter = do
+  let outcome = deadLetterOutcome NoCurrent emptyBillingStore
+  assertEqual "final state" DeadLettered (workflowFinalState outcome)
+
+testRendersStateLabels :: IO ()
+testRendersStateLabels = do
+  assertEqual "queued" "queued" (renderWorkflowState Queued)
+  assertEqual "running" "running" (renderWorkflowState Running)
+  assertEqual "retry-scheduled" "retry-scheduled-2" (renderWorkflowState (RetryScheduled 2))
+  assertEqual "timed-out" "timed-out-1" (renderWorkflowState (TimedOut 1))
+  assertEqual "succeeded" "succeeded" (renderWorkflowState Succeeded)
+  assertEqual "failed-final" "failed-final" (renderWorkflowState FailedFinal)
+  assertEqual "dead-lettered" "dead-lettered" (renderWorkflowState DeadLettered)
+  assertTrue "show queued" (not (null (show Queued)))
+  assertTrue "show running" (not (null (show Running)))
+  assertTrue "show retry-scheduled" (not (null (show (RetryScheduled 1))))
+  assertTrue "show timed-out" (not (null (show (TimedOut 1))))
+  assertTrue "show succeeded" (not (null (show Succeeded)))
+  assertTrue "show failed-final" (not (null (show FailedFinal)))
+  assertTrue "show dead-lettered" (not (null (show DeadLettered)))
+  let budget = RetryBudget {retryAttempt = 1, retryLimit = 3}
+  assertTrue "show retry budget" (not (null (show budget)))
+  let outcome = intakeFailureOutcome NoCurrent emptyBillingStore TriggerNotSupported
+  assertTrue "show workflow outcome" (not (null (show outcome)))
+  let freshDuplicate = duplicateOutcome ProcessFresh NoCurrent emptyBillingStore Nothing
+  assertEqual "process-fresh duplicate queued" Queued (workflowFinalState freshDuplicate)

--- a/applications/backend/billing-worker/tests/unit/Main.hs
+++ b/applications/backend/billing-worker/tests/unit/Main.hs
@@ -1,0 +1,25 @@
+module Main (main) where
+
+import qualified BillingWorker.BillingPersistenceSpec
+import qualified BillingWorker.CurrentSubscriptionHandoffSpec
+import qualified BillingWorker.EntitlementRecalcPortSpec
+import qualified BillingWorker.FailureSummarySpec
+import qualified BillingWorker.NotificationPortSpec
+import qualified BillingWorker.PurchaseVerificationPortSpec
+import qualified BillingWorker.SubscriptionAuthorityPortSpec
+import qualified BillingWorker.WorkItemContractSpec
+import qualified BillingWorker.WorkerRuntimeSpec
+import qualified BillingWorker.WorkflowStateMachineSpec
+
+main :: IO ()
+main = do
+  BillingWorker.WorkItemContractSpec.run
+  BillingWorker.FailureSummarySpec.run
+  BillingWorker.PurchaseVerificationPortSpec.run
+  BillingWorker.SubscriptionAuthorityPortSpec.run
+  BillingWorker.EntitlementRecalcPortSpec.run
+  BillingWorker.NotificationPortSpec.run
+  BillingWorker.BillingPersistenceSpec.run
+  BillingWorker.CurrentSubscriptionHandoffSpec.run
+  BillingWorker.WorkflowStateMachineSpec.run
+  BillingWorker.WorkerRuntimeSpec.run

--- a/applications/backend/explanation-worker/hie.yaml
+++ b/applications/backend/explanation-worker/hie.yaml
@@ -1,0 +1,19 @@
+cradle:
+  cabal:
+    - path: "./app"
+      component: "exe:explanation-worker"
+
+    - path: "./src"
+      component: "lib:explanation-worker"
+
+    - path: "./tests/unit"
+      component: "test:unit"
+
+    - path: "./tests/feature"
+      component: "test:feature"
+
+    - path: "./tests/support/TestSupport.hs"
+      component: "test:unit"
+
+    - path: "./tests/support/FeatureSupport.hs"
+      component: "test:feature"

--- a/applications/backend/image-worker/hie.yaml
+++ b/applications/backend/image-worker/hie.yaml
@@ -1,0 +1,19 @@
+cradle:
+  cabal:
+    - path: "./app"
+      component: "exe:image-worker"
+
+    - path: "./src"
+      component: "lib:image-worker"
+
+    - path: "./tests/unit"
+      component: "test:unit"
+
+    - path: "./tests/feature"
+      component: "test:feature"
+
+    - path: "./tests/support/TestSupport.hs"
+      component: "test:unit"
+
+    - path: "./tests/support/FeatureSupport.hs"
+      component: "test:feature"

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  applications/backend/billing-worker
+  applications/backend/explanation-worker
+  applications/backend/image-worker
+
+write-ghc-environment-files: never
+with-compiler: ghc-9.2.8

--- a/docker/applications/billing-worker/Dockerfile
+++ b/docker/applications/billing-worker/Dockerfile
@@ -1,11 +1,30 @@
-FROM debian:bookworm-slim
+FROM haskell:9.2.8 AS builder
+
+WORKDIR /workspace/applications/backend/billing-worker
+
+COPY applications/backend/billing-worker/cabal.project cabal.project
+COPY applications/backend/billing-worker/billing-worker.cabal billing-worker.cabal
+COPY applications/backend/billing-worker/app app
+COPY applications/backend/billing-worker/src src
+COPY applications/backend/billing-worker/tests/feature tests/feature
+COPY applications/backend/billing-worker/tests/support tests/support
+COPY applications/backend/billing-worker/tests/unit tests/unit
+
+RUN env CABAL_DIR=/tmp/cabal cabal install exe:billing-worker \
+    --disable-tests \
+    --install-method=copy \
+    --installdir=/out \
+    --overwrite-policy=always
+
+FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends netcat-openbsd \
+    && apt-get install --yes --no-install-recommends ca-certificates libffi8 libgmp10 netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 
+COPY --from=builder /out/billing-worker /usr/local/bin/billing-worker
 COPY docker/applications/billing-worker/entrypoint.sh /usr/local/bin/vocas-worker-entrypoint
 
-RUN chmod +x /usr/local/bin/vocas-worker-entrypoint
+RUN chmod +x /usr/local/bin/vocas-worker-entrypoint /usr/local/bin/billing-worker
 
 ENTRYPOINT ["/usr/local/bin/vocas-worker-entrypoint"]

--- a/docker/applications/billing-worker/entrypoint.sh
+++ b/docker/applications/billing-worker/entrypoint.sh
@@ -7,8 +7,6 @@ poll_interval="${VOCAS_WORKER_POLL_INTERVAL_SECONDS:-30}"
 
 echo "[vocastock] ${worker_name} booting as long-running consumer"
 
-trap 'echo "[vocastock] ${worker_name} stopping"; exit 0' TERM INT
-
 check_dependency() {
   dependency_name="$1"
   endpoint="$2"
@@ -33,10 +31,8 @@ check_dependency "storage" "${STORAGE_EMULATOR_HOST:-}"
 check_dependency "auth" "${FIREBASE_AUTH_EMULATOR_HOST:-}"
 check_dependency "pubsub" "${PUBSUB_EMULATOR_HOST:-}"
 
-sleep "${stable_window}"
-echo "[vocastock] ${worker_name} entered stable-run mode"
+export VOCAS_WORKER_NAME="${worker_name}"
+export VOCAS_WORKER_STABLE_RUN_SECONDS="${stable_window}"
+export VOCAS_WORKER_POLL_INTERVAL_SECONDS="${poll_interval}"
 
-while :; do
-  echo "[vocastock] ${worker_name} awaiting queue/subscription work"
-  sleep "${poll_interval}"
-done
+exec /usr/local/bin/billing-worker "$@"

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,73 +1,55 @@
 cradle:
-  multi:
+  cabal:
     - path: "./applications/backend/explanation-worker/app"
-      config:
-        cradle:
-          cabal:
-            component: "exe:explanation-worker"
+      component: "exe:explanation-worker"
 
     - path: "./applications/backend/explanation-worker/src"
-      config:
-        cradle:
-          cabal:
-            component: "lib:explanation-worker"
+      component: "lib:explanation-worker"
 
     - path: "./applications/backend/explanation-worker/tests/unit"
-      config:
-        cradle:
-          cabal:
-            component: "test:unit"
+      component: "explanation-worker:test:unit"
 
     - path: "./applications/backend/explanation-worker/tests/feature"
-      config:
-        cradle:
-          cabal:
-            component: "test:feature"
-
-    - path: "./applications/backend/explanation-worker/tests/support/FeatureSupport.hs"
-      config:
-        cradle:
-          cabal:
-            component: "test:feature"
+      component: "explanation-worker:test:feature"
 
     - path: "./applications/backend/explanation-worker/tests/support/TestSupport.hs"
-      config:
-        cradle:
-          cabal:
-            component: "test:unit"
+      component: "explanation-worker:test:unit"
+
+    - path: "./applications/backend/explanation-worker/tests/support/FeatureSupport.hs"
+      component: "explanation-worker:test:feature"
 
     - path: "./applications/backend/image-worker/app"
-      config:
-        cradle:
-          cabal:
-            component: "exe:image-worker"
+      component: "exe:image-worker"
 
     - path: "./applications/backend/image-worker/src"
-      config:
-        cradle:
-          cabal:
-            component: "lib:image-worker"
+      component: "lib:image-worker"
 
     - path: "./applications/backend/image-worker/tests/unit"
-      config:
-        cradle:
-          cabal:
-            component: "test:unit"
+      component: "image-worker:test:unit"
 
     - path: "./applications/backend/image-worker/tests/feature"
-      config:
-        cradle:
-          cabal:
-            component: "test:feature"
-
-    - path: "./applications/backend/image-worker/tests/support/FeatureSupport.hs"
-      config:
-        cradle:
-          cabal:
-            component: "test:feature"
+      component: "image-worker:test:feature"
 
     - path: "./applications/backend/image-worker/tests/support/TestSupport.hs"
-      config:
-        cradle:
-          cabal:
-            component: "test:unit"
+      component: "image-worker:test:unit"
+
+    - path: "./applications/backend/image-worker/tests/support/FeatureSupport.hs"
+      component: "image-worker:test:feature"
+
+    - path: "./applications/backend/billing-worker/app"
+      component: "exe:billing-worker"
+
+    - path: "./applications/backend/billing-worker/src"
+      component: "lib:billing-worker"
+
+    - path: "./applications/backend/billing-worker/tests/unit"
+      component: "billing-worker:test:unit"
+
+    - path: "./applications/backend/billing-worker/tests/feature"
+      component: "billing-worker:test:feature"
+
+    - path: "./applications/backend/billing-worker/tests/support/TestSupport.hs"
+      component: "billing-worker:test:unit"
+
+    - path: "./applications/backend/billing-worker/tests/support/FeatureSupport.hs"
+      component: "billing-worker:test:feature"

--- a/scripts/ci/run_application_container_smoke.sh
+++ b/scripts/ci/run_application_container_smoke.sh
@@ -189,6 +189,52 @@ while IFS= read -r validation_scenario; do
   printf "image_worker_validation.%s=%s\n" "$validation_scenario" "$validation_line" >> "$summary_file"
 done < <(vocas_image_worker_validation_scenarios)
 
+failure_stage="billing-worker-validation"
+while IFS= read -r validation_scenario; do
+  validation_log="$(vocas_repo_root)/.artifacts/ci/logs/billing-worker-validation.${validation_scenario}.log"
+  if ! docker compose \
+    --env-file "$env_file" \
+    -f "$compose_file" \
+    run \
+    --rm \
+    --no-deps \
+    -e VOCAS_WORKER_RUN_MODE=validate \
+    -e VOCAS_BILLING_WORKFLOW_SCENARIO="$validation_scenario" \
+    billing-worker >"$validation_log" 2>&1 </dev/null; then
+    cat "$validation_log" >&2 || true
+    vocas_die "billing-worker validation failed for scenario ${validation_scenario}"
+  fi
+
+  validation_line="$(grep '^VOCAS_BILLING_RESULT ' "$validation_log" | tail -n 1 || true)"
+  [[ -n "$validation_line" ]] || vocas_die "missing billing-worker validation result for ${validation_scenario}"
+
+  case "$validation_scenario" in
+    success)
+      printf "%s\n" "$validation_line" | grep -q 'final_state=succeeded' \
+        || vocas_die "billing success validation did not reach succeeded"
+      ;;
+    retryable-failure)
+      printf "%s\n" "$validation_line" | grep -q 'final_state=retry-scheduled-1' \
+        || vocas_die "billing retryable validation did not reach retry-scheduled"
+      ;;
+    terminal-failure)
+      printf "%s\n" "$validation_line" | grep -q 'final_state=failed-final' \
+        || vocas_die "billing terminal validation did not reach failed-final"
+      ;;
+    notification-reconciled)
+      printf "%s\n" "$validation_line" | grep -q 'final_state=succeeded' \
+        || vocas_die "billing notification-reconciled validation did not reach succeeded"
+      printf "%s\n" "$validation_line" | grep -q 'source=notification-reconciliation' \
+        || vocas_die "billing notification-reconciled validation did not route to notification-reconciliation source"
+      ;;
+    *)
+      vocas_die "unsupported billing-worker validation scenario: ${validation_scenario}"
+      ;;
+  esac
+
+  printf "billing_worker_validation.%s=%s\n" "$validation_scenario" "$validation_line" >> "$summary_file"
+done < <(vocas_billing_worker_validation_scenarios)
+
 elapsed="$(( $(date +%s) - start_epoch ))"
 vocas_write_duration "application-container-smoke" "$elapsed"
 vocas_print_budget_summary "application-container-smoke" "$elapsed" "$ready_budget"

--- a/scripts/lib/vocastock_env.sh
+++ b/scripts/lib/vocastock_env.sh
@@ -279,6 +279,14 @@ vocas_image_worker_validation_scenarios() {
     "terminal-failure"
 }
 
+vocas_billing_worker_validation_scenarios() {
+  printf "%s\n" \
+    "success" \
+    "retryable-failure" \
+    "terminal-failure" \
+    "notification-reconciled"
+}
+
 vocas_prepare_application_smoke_env_file() {
   local base_env_file="$1"
   local smoke_env_file gateway_port command_port query_port

--- a/specs/023-billing-worker-implementation/contracts/billing-visibility-handoff-contract.md
+++ b/specs/023-billing-worker-implementation/contracts/billing-visibility-handoff-contract.md
@@ -1,0 +1,35 @@
+# Contract: Billing Visibility And Handoff
+
+## Purpose
+
+completed `BillingRecord` の保存、`Subscription.currentEntitlementSnapshot` handoff、
+status-only visibility の境界を固定する。
+
+## Visibility Rules
+
+| Concern | Rule |
+|---------|------|
+| completed `BillingRecord` の entitlement snapshot 本体 | `succeeded` になるまで confirmed entitlement snapshot として扱ってはならない |
+| `queued` / `running` / `retry-scheduled` / `timed-out` / `failed-final` / `dead-lettered` | status-only だけを許可する |
+| 既存 `currentEntitlementSnapshot` | 新しい verification / reconciliation 試行が non-success の間は維持する |
+| failure summary | provider / adapter detail (raw receipt、credential、stack trace) を redacted した要約だけを持つ |
+
+## Handoff Rules
+
+- completed `BillingRecord` 保存後に `Subscription.currentEntitlementSnapshot` handoff を行う
+- handoff が完了するまでは candidate snapshot を `hidden-until-handoff` として扱う
+- handoff retry は既存 candidate snapshot を再利用し、再検証や再 reconciliation を必須にしない
+- handoff が unrecoverable failure になった場合も partial snapshot を confirmed として表示してはならない
+
+## Non-Success Rules
+
+- retryable failure は `retry-scheduled` へ進み、既存 current があれば継続表示してよい
+- timeout と terminal failure は candidate snapshot を新 current にしてはならない
+- `dead-lettered` は operator review が必要な status-only failure とする
+- notification reconciliation の retry / timeout / failure 中は、認証経路を通らない新規 `premium-generation` unlock を付与してはならない
+
+## Current Snapshot Actions
+
+- `switched`: handoff 成功、新 snapshot を current に採用
+- `retained`: non-success 経路、既存 current を維持
+- `superseded`: 新 snapshot の保存は成立したが current が別 workflow で既に先行更新されており、今回の candidate は current にしない (status-only に留める)

--- a/specs/023-billing-worker-implementation/contracts/billing-work-item-contract.md
+++ b/specs/023-billing-worker-implementation/contracts/billing-work-item-contract.md
@@ -1,0 +1,35 @@
+# Contract: Billing Work Item
+
+## Purpose
+
+submitted 済み purchase artifact と normalized store notification が、どの形で `billing-worker` へ渡るかを固定する。
+
+## Intake Contract
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `trigger` | Yes | initial slice では `purchase-artifact-submitted` または `notification-received` |
+| `businessKey` | Yes | replay / duplicate 判定に使う |
+| `subscription` | Yes | target `SubscriptionIdentifier` |
+| `actor` | Yes | ownership 整合確認用 |
+| `purchaseArtifact` | Conditional | `trigger = purchase-artifact-submitted` 時に必須。canonical receipt/token 参照 |
+| `notificationPayload` | Conditional | `trigger = notification-received` 時に必須。normalized notification 内容 |
+| `requestCorrelation` | Yes | upstream request と worker log の相関 |
+
+## Acceptance Rules
+
+- `purchase-artifact-submitted` では `purchaseArtifact` が必須、`notificationPayload` は持たない
+- `notification-received` では `notificationPayload` が必須、`purchaseArtifact` は持たない
+- worker は上記以外の `trigger` 値を initial slice で処理してはならない
+- `subscription` 不在、ownership mismatch、前提不正は completed `BillingRecord` なしの failure outcome とする
+
+## Duplicate Rules
+
+- 同一 `businessKey` の replay / duplicate arrival は idempotent に扱う
+- `queued`、`running`、`retry-scheduled` 中の duplicate は新しい verification / notification ingest を開始してはならない
+- `succeeded` 済み `businessKey` の duplicate は existing completed snapshot を再利用してよい
+
+## Ownership Rules
+
+- `actor` と `subscription` の ownership が一致しない場合、worker は `dead-lettered` へ進める
+- notification 経路では `subscription` に紐づく actor が一意に resolve できない場合、`failed-final` へ進める

--- a/specs/023-billing-worker-implementation/contracts/billing-worker-runtime-boundary-contract.md
+++ b/specs/023-billing-worker-implementation/contracts/billing-worker-runtime-boundary-contract.md
@@ -1,0 +1,44 @@
+# Contract: Billing Worker Runtime Boundary
+
+## Purpose
+
+023 で実装する `billing-worker` runtime surface と scope 外を固定する。
+
+## In Scope
+
+| Concern | Scope |
+|---------|-------|
+| worker runtime | Haskell long-running consumer |
+| stable-run contract | `long-running consumer` を canonical success signal とする |
+| workflow state machine | purchase verification workflow + notification reconciliation workflow |
+| purchase verification adapter | `PurchaseVerificationPort` 越しの caller-owned adapter |
+| subscription authority adapter | `SubscriptionAuthorityPort` 越しの authoritative state update adapter |
+| entitlement recalculation | `EntitlementRecalcPort` による subscription state → entitlement bundle + quota profile 導出 |
+| store notification adapter | `NotificationPort` 越しの normalized notification intake adapter |
+| persistence | completed `BillingRecord` 保存と `Subscription.currentEntitlementSnapshot` handoff port |
+| testing | Haskell unit mirror + Haskell feature suite with Docker / Firebase emulator |
+| runtime validation | `docker/applications/billing-worker/`、compose、local stack validation |
+
+## Out Of Scope
+
+| Concern | Why Deferred |
+|---------|--------------|
+| public HTTP / GraphQL endpoint | worker boundary ではない |
+| internal HTTP surface (Servant) | canonical success signal は stable-run で足り、pull-based consumer に HTTP layer は不要 |
+| restore workflow | 012 に別 runtime trace あり、後続 slice に分離 |
+| `query-api` の read projection 実装変更 | query visibility の正本は 017 に属する |
+| `explanation-worker` / `image-worker` | 別 worker responsibility |
+| store product catalog 管理 / pricing change / tax / intro offer / coupon / family plan | 014 の scope 外、商用施策は別 feature |
+| Apple / Google 固有 SDK 実 adapter | port contract のみで足り、実 adapter は Production 導入フェーズ |
+| provider 固有最適化 | initial slice の scope 外 |
+| public schema 拡張 | gateway / API feature の責務 |
+
+## Rules
+
+- worker は confirmed entitlement snapshot を直接 user-facing response として返してはならない
+- 外向き HTTP endpoint を必須にしてはならない
+- pull-based stable-run 以外の canonical success signal (HTTP readiness、push-based RPC 等) を worker に持ち込まない
+- worker container の canonical success signal は queue / subscription 待受プロセスとしての stable-run である
+- runtime 追加後も 016 の container smoke 契約と矛盾してはならない
+- runtime validation は `success`、`retryable-failure`、`terminal-failure`、`notification-reconciled` を別 record として
+  `application-container-smoke.summary` に残し、local stack validation から再利用できなければならない

--- a/specs/023-billing-worker-implementation/contracts/purchase-verification-workflow-contract.md
+++ b/specs/023-billing-worker-implementation/contracts/purchase-verification-workflow-contract.md
@@ -1,0 +1,56 @@
+# Contract: Purchase Verification Workflow
+
+## Purpose
+
+`billing-worker` が扱う purchase verification workflow の runtime state、retry、timeout、
+terminal outcome、authoritative state 更新順序を固定する。
+
+## State Machine
+
+| Runtime State | Entry Condition | Exit Condition | Visibility Rule |
+|---------------|-----------------|----------------|-----------------|
+| `queued` | submitted purchase artifact を受信 | worker が処理開始 | status-only のみ |
+| `running` | verification adapter 実行中 | verified、retryable failure、timeout、non-retryable failure | status-only のみ |
+| `retry-scheduled` | retryable verification failure または handoff retry | next retry 到来で `queued` | status-only のみ、authoritative state を paid へ進めない |
+| `timed-out` | verification が所定時間内に完了しない | retry 可能なら `retry-scheduled`、不可なら `failed-final` | status-only のみ、purchase state は `verifying` に留める |
+| `succeeded` | completed `BillingRecord` 保存と current handoff が両方成功 | terminal | confirmed entitlement snapshot を unlock 根拠にしてよい |
+| `failed-final` | non-retryable failure または retry exhaustion | terminal | status-only failure、purchase state は `rejected` または `verifying` 維持 |
+| `dead-lettered` | operator review が必要 | operator resolution | status-only failure、既存 mirror 維持 |
+
+## Transition Rules
+
+- `succeeded` へ進む前に completed `BillingRecord` 保存と `Subscription.currentEntitlementSnapshot` handoff の両方が完了していなければならない
+- retryable verification failure は `retry-scheduled` へ写像する
+- timeout は `timed-out` を経由し、retry 可否に応じて `retry-scheduled` か `failed-final` へ進む
+- malformed / incomplete verified payload は `failed-final` として扱う
+- `dead-lettered` は operator review が必要な terminal failure に限定する (例: ownership mismatch、critical partial commit 失敗)
+
+## Verification Adapter Output
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `requestIdentifier` | Yes | verification adapter 側 request 参照 |
+| `status` | Yes | `verified`、`retryable-failure`、`non-retryable-failure`、`timed-out` |
+| `verifiedPayload` | No | `verified` 時のみ存在。subscription term、plan code、grace window を含む |
+| `failureReason` | No | non-success 時の redacted 要約 |
+
+## Completed Payload Requirements
+
+- `subscriptionStateName` が `active` / `grace` / `expired` / `pending-sync` / `revoked` のいずれかであること
+- `entitlementBundleName` が `free-basic` / `premium-generation` のいずれかであること
+- `quotaProfileName` が `free-monthly` / `standard-monthly` / `pro-monthly` のいずれかであること
+- `effectivePeriod` (term start / end、必要に応じて grace window) が含まれていること
+- incomplete / inconsistent payload は `succeeded` として扱ってはならない
+
+## Mapping Rules
+
+- `status = verified` でも completed payload requirement を満たさない場合は `failed-final` に写像する
+- `retryable-failure` は worker state `retry-scheduled` へ写像する
+- `timed-out` は worker state `timed-out` へ写像する
+- `non-retryable-failure` は worker state `failed-final` へ写像する
+
+## Idempotency Rules
+
+- 同一 `businessKey` で completed `BillingRecord` を重複保存してはならない
+- 同一 `businessKey` で `currentEntitlementSnapshot` を二重に切り替えてはならない
+- worker restart 後も existing workflow state を参照して duplicate completion を防がなければならない

--- a/specs/023-billing-worker-implementation/contracts/store-notification-workflow-contract.md
+++ b/specs/023-billing-worker-implementation/contracts/store-notification-workflow-contract.md
@@ -1,0 +1,55 @@
+# Contract: Store Notification Reconciliation Workflow
+
+## Purpose
+
+`billing-worker` が扱う store notification reconciliation workflow の runtime state、
+retry、timeout、terminal outcome、authoritative state 補正順序を固定する。
+notification は後追いの補正経路であり、新規 paid entitlement を付与しないことを明示する。
+
+## State Machine
+
+| Runtime State | Entry Condition | Exit Condition | Visibility Rule |
+|---------------|-----------------|----------------|-----------------|
+| `queued` | normalized notification を受信 | worker が処理開始 | status-only のみ、既存 mirror 維持 |
+| `running` | source-of-truth 補正中 | reconciled、retryable failure、timeout、non-retryable failure | status-only のみ |
+| `retry-scheduled` | retryable ingest / verification failure | next retry 到来で `queued` | status-only のみ、新規 paid entitlement を付与しない |
+| `timed-out` | reconciliation が所定時間内に完了しない | retry 可能なら `retry-scheduled`、不可なら `failed-final` | status-only のみ、`pending-sync` のまま表示可 |
+| `succeeded` | subscription authority / entitlement snapshot 補正完了 + current handoff 完了 | terminal | 補正済み entitlement snapshot を unlock 根拠にしてよい |
+| `failed-final` | non-retryable failure または retry exhaustion | terminal | status-only failure、既存 mirror 維持 |
+| `dead-lettered` | operator review が必要 | operator resolution | status-only failure、既存 mirror 維持 |
+
+## Transition Rules
+
+- `succeeded` へ進む前に completed `BillingRecord` (notification 経由の state 補正 + 再計算 snapshot) 保存と `Subscription.currentEntitlementSnapshot` handoff の両方が完了していなければならない
+- retryable notification ingest failure は `retry-scheduled` へ写像する
+- timeout は `timed-out` を経由し、retry 可否に応じて `retry-scheduled` か `failed-final` へ進む
+- malformed / signature-invalid notification は `failed-final` として扱う
+- 注文順序逆転 (例: 既に `revoked` なのに古い `active` notification が届く) は stale 判定で `failed-final` または no-op succeeded として扱い、authority state を退行させない
+
+## Notification Adapter Output
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `requestIdentifier` | Yes | notification adapter 側 request 参照 |
+| `status` | Yes | `reconciled`、`retryable-failure`、`non-retryable-failure`、`timed-out` |
+| `reconciledPayload` | No | `reconciled` 時のみ存在。normalized subscription state / term / grace window |
+| `failureReason` | No | non-success 時の redacted 要約 |
+
+## Reconciled Payload Requirements
+
+- `subscriptionStateName` が `active` / `grace` / `expired` / `pending-sync` / `revoked` のいずれかであること
+- `effectivePeriod` (term start / end、grace window) が normalized されていること
+- notification 独自の field (provider notification ID、environment、received timestamp) は `VerificationAttemptRecord.providerRequestIdentifier` 等に redacted な形で記録してよい
+- incomplete / inconsistent payload は `reconciled` として扱ってはならない
+
+## No-New-Unlock Rule
+
+- notification reconciliation の経路では、認証経路 (purchase verification) を通過していない actor に対し新たに `premium-generation` entitlement bundle を付与してはならない
+- notification 経由での昇格は既存 `verified` purchase state が存在する場合に限り許可される
+- notification 経由で `free-basic` / `free-monthly` へのフォールバック、`grace` → `expired` / `revoked` への遷移は許可される
+
+## Idempotency Rules
+
+- 同一 `businessKey` (actor + subscription + notification identifier) で authority state を二重補正してはならない
+- worker restart 後も existing workflow state を参照して duplicate reconciliation を防がなければならない
+- stale notification は authority state を退行させず、`failed-final` または no-op succeeded で処理する

--- a/specs/023-billing-worker-implementation/data-model.md
+++ b/specs/023-billing-worker-implementation/data-model.md
@@ -1,0 +1,165 @@
+# Data Model: Billing Worker Implementation
+
+## Overview
+
+023 は `billing-worker` の workflow 実装を最小スライスで追加する。domain aggregate 自体の定義を
+変える feature ではなく、submitted 済み purchase artifact と normalized store notification の
+processing unit、runtime state、completed billing record handoff、failure summary を worker 側で
+どう保持するかを固定する。正本 domain は `specs/010-subscription-component-boundaries/data-model.md`
+と `specs/014-billing-entitlement-policy/data-model.md` を参照する。
+
+## Entities
+
+### BillingWorkItem
+
+**Purpose**: submitted 済み purchase artifact または normalized store notification を worker が処理する単位。
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `identifier` | `BillingWorkItemIdentifier` | work item の一意識別子 |
+| `businessKey` | `BillingBusinessKey` | replay / duplicate 判定用の業務キー |
+| `subscription` | `SubscriptionIdentifier` | 処理対象 `Subscription` |
+| `actor` | `ActorIdentifier` | ownership 整合確認に使う actor 参照 |
+| `trigger` | enum | initial slice では `purchase-artifact-submitted` または `notification-received` |
+| `purchaseArtifact` | `PurchaseArtifactReference`? | `purchase-artifact-submitted` 時に存在する canonical 参照 |
+| `notificationPayload` | `NormalizedNotificationPayload`? | `notification-received` 時に存在する normalized 内容 |
+| `requestCorrelation` | string | upstream request と worker log を相関させる値 |
+| `workflowState` | `BillingWorkflowState` | 現在の lifecycle 状態 |
+
+**Validation Rules**:
+
+- initial slice では `trigger = purchase-artifact-submitted` または `trigger = notification-received` だけを受け付ける
+- `businessKey` は同一 workflow に対して一意でなければならない
+- `actor` と `subscription` の ownership が一致しない場合は success へ進めない
+- `purchase-artifact-submitted` では `purchaseArtifact` が必須、`notification-received` では `notificationPayload` が必須
+
+### BillingWorkflowState
+
+**Purpose**: billing workflow の runtime lifecycle と retry 制御を保持する。
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `runtimeStatus` | enum | `queued`、`running`、`retry-scheduled`、`timed-out`、`succeeded`、`failed-final`、`dead-lettered` |
+| `attemptCount` | integer | 開始済み attempt 数 |
+| `retryBudgetRemaining` | integer | 追加 retry 可能回数 |
+| `nextAttemptAt` | timestamp? | `retry-scheduled` 時の再開予定 |
+| `timeoutAt` | timestamp? | 現在 attempt の timeout 境界 |
+| `candidateSnapshot` | `SubscriptionAuthoritySnapshotCandidate`? | 保存済みだが handoff 未完了の completed snapshot |
+| `failureSummary` | `BillingFailureSummary`? | status-only 表示用の失敗要約 |
+
+**Invariants**:
+
+- `succeeded` は completed `BillingRecord` 保存と current handoff 完了の両方が終わった時だけ許可される
+- `retry-scheduled`、`timed-out`、`failed-final`、`dead-lettered` では confirmed されていない entitlement snapshot を user-visible unlock 根拠として扱ってはならない
+- `candidateSnapshot` が存在する場合、再検証ではなく handoff completion の再試行を優先できる
+
+### VerificationAttemptRecord
+
+**Purpose**: 各 verification attempt (purchase verification / notification ingest 共通) の実行結果を記録する。
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `attemptNumber` | integer | 1 始まりの attempt 番号 |
+| `providerRequestIdentifier` | string? | verification adapter / notification adapter 側 request 参照 |
+| `startedAt` | timestamp | attempt 開始時刻 |
+| `finishedAt` | timestamp? | attempt 終了時刻 |
+| `outcome` | enum | `verified`、`reconciled`、`retryable-failure`、`timed-out`、`non-retryable-failure`、`handoff-retry` |
+| `redactedFailureReason` | string? | status-only に使える要約済み理由 |
+
+**Rules**:
+
+- provider / adapter の内部 detail (raw receipt、credential、provider stack trace) は `redactedFailureReason` にそのまま持ち込まない
+- 同一 `attemptNumber` を二重に finalization してはならない
+
+### SubscriptionAuthoritySnapshotCandidate
+
+**Purpose**: completed `BillingRecord` 保存までは成功しているが、current handoff 完了待ちの candidate snapshot。
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subscription` | `SubscriptionIdentifier` | 対象 `Subscription` |
+| `purchaseStateName` | enum | `verified` (purchase verification 経由) または既存状態 (notification reconciliation 経由) |
+| `subscriptionStateName` | enum | `active`、`grace`、`expired`、`pending-sync`、`revoked` |
+| `entitlementBundleName` | enum | `free-basic`、`premium-generation` |
+| `quotaProfileName` | enum | `free-monthly`、`standard-monthly`、`pro-monthly` |
+| `effectivePeriod` | `SubscriptionEffectivePeriod` | term start / end / grace window |
+| `calculatedAt` | timestamp | 算出時刻 |
+| `source` | enum | `purchase-verification` または `notification-reconciliation` |
+| `visibility` | enum | `hidden-until-handoff` または `current-applied` |
+| `sourceWorkItem` | `BillingWorkItemIdentifier` | 元の work item |
+
+**Rules**:
+
+- `visibility = hidden-until-handoff` の間は confirmed entitlement snapshot として扱わない
+- 同一 work item で candidate を複数作成してはならない
+- notification reconciliation 経路では `purchaseStateName` を `verified` へ昇格させず、既存状態を維持する
+
+### CurrentSubscriptionHandoff
+
+**Purpose**: `Subscription.currentEntitlementSnapshot` の切替結果を保持する。
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subscription` | `SubscriptionIdentifier` | 切替対象 |
+| `previousCurrent` | `EntitlementSnapshotIdentifier`? | 直前 current |
+| `candidate` | `EntitlementSnapshotIdentifier` | 新たに採用を試みる completed snapshot |
+| `handoffStatus` | enum | `pending-switch`、`applied`、`kept-existing` |
+| `appliedAt` | timestamp? | 切替完了時刻 |
+
+**Rules**:
+
+- `applied` になった時だけ `Subscription.currentEntitlementSnapshot` を更新できる
+- retryable / terminal failure 時は `kept-existing` を許可し、既存 current を維持する
+
+### BillingFailureSummary
+
+**Purpose**: `query-api` が status-only で表示する failure 要約を保持する。
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `classification` | enum | `retryable`、`timeout`、`terminal`、`dead-letter` |
+| `publicStatus` | enum | `retry-scheduled`、`timed-out`、`failed-final`、`dead-lettered` |
+| `retryable` | bool | 再試行余地の有無 |
+| `message` | string | redacted 済みの user-facing 要約 |
+| `lastAttemptNumber` | integer | 直近 attempt |
+
+**Rules**:
+
+- `message` に provider credential、raw receipt payload、internal stack trace を含めてはならない
+- `publicStatus = retry-scheduled` の間は confirmed entitlement snapshot を unlock 根拠として返してはならない
+
+## Relationships
+
+- `BillingWorkItem` は 1 つの `BillingWorkflowState` を持つ
+- `BillingWorkflowState` は 0..n の `VerificationAttemptRecord` を持ちうる
+- `BillingWorkflowState.candidateSnapshot` は 0..1 の `SubscriptionAuthoritySnapshotCandidate` を参照する
+- `SubscriptionAuthoritySnapshotCandidate` は 0..1 の `CurrentSubscriptionHandoff` を伴う
+- `BillingFailureSummary` は `BillingWorkflowState` に付随し、`query-api` の status-only read へ渡される
+
+## State Transitions
+
+1. submitted purchase artifact または normalized notification から `BillingWorkItem` を作る
+2. `queued -> running` で対応する adapter (verification または notification ingest) を開始する
+3. adapter outcome:
+   - retryable failure -> `retry-scheduled`
+   - timeout -> `timed-out`
+   - non-retryable failure -> `failed-final`
+   - verified / reconciled payload -> `SubscriptionAuthoritySnapshotCandidate` 保存へ進む
+4. candidate 保存後:
+   - handoff success -> `succeeded`
+   - handoff retryable failure -> `retry-scheduled` または handoff retry path
+   - handoff unrecoverable failure -> `failed-final` または `dead-lettered`
+5. `succeeded` の時だけ `Subscription.currentEntitlementSnapshot` が新 candidate に切り替わる
+
+## Concept Separation (憲章 VI 遵守)
+
+| 概念 | 所在 | billing-worker が扱うか |
+|------|------|------------------------|
+| purchase state (`initiated` / `submitted` / `verifying` / `verified` / `rejected`) | Subscription 集約 | ✅ 更新する |
+| authoritative subscription state (`active` / `grace` / `expired` / `pending-sync` / `revoked`) | Subscription 集約 | ✅ 更新する |
+| entitlement bundle (`free-basic` / `premium-generation`) | EntitlementSnapshot | ✅ snapshot 経由で commit する |
+| quota profile (`free-monthly` / `standard-monthly` / `pro-monthly`) | EntitlementSnapshot | ✅ snapshot 経由で commit する |
+| feature gate decision | Feature Gate component (010) | ❌ 読み出し側の責務 |
+| usage limit 消費判定 | Usage Metering / Quota Gate (010) | ❌ 別コンポーネント責務 |
+| Frequency / Sophistication / Proficiency | Learner / Vocabulary 集約 | ❌ 学習指標は別概念 |
+| 登録状態 / 生成状態 | VocabularyExpression / Explanation / VisualImage | ❌ explanation / image worker の責務 |

--- a/specs/023-billing-worker-implementation/plan.md
+++ b/specs/023-billing-worker-implementation/plan.md
@@ -1,0 +1,166 @@
+# Implementation Plan: Billing Worker Implementation
+
+**Branch**: `023-billing-worker-implementation` | **Date**: 2026-04-21 | **Spec**: [/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/spec.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/spec.md)
+**Input**: Feature specification from `/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/spec.md`
+
+## Summary
+
+`billing-worker` の初期実装を `applications/backend/billing-worker/` に追加する。runtime は
+004 / 015 / 016 の正本どおり Haskell worker + Pub/Sub trigger + Firestore-aligned state を
+前提とし、submitted 済みの purchase artifact と normalized store notification を処理対象とする。
+worker は `queued`、`running`、`retry-scheduled`、`timed-out`、`succeeded`、`failed-final`、
+`dead-lettered` の lifecycle を持ち、completed `BillingRecord` (purchase state 更新 + entitlement snapshot)
+の保存と `Subscription.currentEntitlementSnapshot` handoff の両方が成立した時だけ success と扱う。
+confirmed されていない entitlement snapshot は user-visible unlock 根拠にせず、既存 current は
+non-success では維持する。実装は Haskell module 群と port / adapter 境界に分割し、Haskell unit
+テスト、Haskell の Docker/Firebase feature suite、worker container / local stack validation、
+023 artifact 同期までを含める。restore workflow、store product catalog 管理、provider 固有最適化、
+public GraphQL 拡張は scope 外とする。
+
+## Technical Context
+
+**Language/Version**: Haskell via GHC `9.2.8`、`GHC2021`、Bash、Markdown 1.x  
+**Primary Dependencies**: `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/`、package-local Cabal manifest、`/Users/lihs/workspace/vocastock/docker/applications/billing-worker/`、`/Users/lihs/workspace/vocastock/docker/applications/compose.yaml`、`/Users/lihs/workspace/vocastock/scripts/ci/run_application_container_smoke.sh`、`/Users/lihs/workspace/vocastock/scripts/bootstrap/validate_local_stack.sh`、`/Users/lihs/workspace/vocastock/docs/internal/domain/common.md`、`/Users/lihs/workspace/vocastock/docs/internal/domain/service.md`、`/Users/lihs/workspace/vocastock/docs/external/adr.md`、`/Users/lihs/workspace/vocastock/docs/external/requirements.md`、`/Users/lihs/workspace/vocastock/specs/004-tech-stack-definition/`、`/Users/lihs/workspace/vocastock/specs/010-subscription-component-boundaries/`、`/Users/lihs/workspace/vocastock/specs/012-persistence-workflow-design/`、`/Users/lihs/workspace/vocastock/specs/014-billing-entitlement-policy/`、`/Users/lihs/workspace/vocastock/specs/015-command-query-topology/`、`/Users/lihs/workspace/vocastock/specs/016-application-docker-env/`、`/Users/lihs/workspace/vocastock/specs/021-explanation-worker-implementation/`  
+**Storage**: Firestore-aligned billing workflow state store abstraction、completed `BillingRecord` store abstraction、`Subscription.currentEntitlementSnapshot` handoff store abstraction、Git-managed repository files、local Docker/Firebase emulator runtime state  
+**Testing**: package-local `cabal test` unit suites under `tests/unit/*`、package-local `cabal test feature` suite under `tests/feature/*`、coverage-enabled Haskell test run、`bash /Users/lihs/workspace/vocastock/scripts/ci/run_application_container_smoke.sh`、`bash /Users/lihs/workspace/vocastock/scripts/bootstrap/validate_local_stack.sh --reuse-running --with-application-containers`  
+**Target Platform**: internal Haskell worker on Cloud Run-aligned container runtime、local Docker + Firebase emulator validation path  
+**Project Type**: backend worker service implementation  
+**Performance Goals**: success / retryable failure / terminal failure / notification-reconciled の 4 系統が再現可能であること、worker の stable-run contract を壊さないこと、confirmed でない entitlement snapshot の露出を 0 件にすること、worker-owned coverage 90% 以上を達成すること  
+**Constraints**: 004 の `Workflow = Haskell` と `Pub/Sub + Cloud Run worker + Firestore state` baseline を守ること、worker は public endpoint や query response を own しないこと、success は completed `BillingRecord` 保存と `currentEntitlementSnapshot` handoff の両成立が必要であること、duplicate / replay は business key 単位で idempotent に扱うこと、provider / adapter 詳細は failure summary に漏らさないこと、feature テストは Docker / Firebase emulator を使うこと、テストは `tests/unit/*` / `tests/feature/*` / `tests/support/*` に配置すること、purchase state と authoritative subscription state を同じ runtime state で表現しないこと、notification reconciliation は補正経路であり timeout / failure 中に新規 paid entitlement を付与しないこと  
+**Scale/Scope**: 1 worker app、1 submitted purchase artifact family + 1 normalized notification family、1 billing lifecycle state machine、1 confirmed-only visibility handoff rule、1 Haskell package skeleton、1 Haskell feature suite、runtime / docs touchpoint 一式
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Domain impact is explicitly `no domain semantic change`. `specs/010-subscription-component-boundaries/data-model.md` と `specs/014-billing-entitlement-policy/data-model.md` を source of truth として参照し、worker 実装は既存 aggregate / port semantics をコードへ写像する。
+- [x] Async generation flow defines lifecycle states, retry behavior, timeout handling, dead-letter handling, and user-visible status rules. confirmed でない entitlement snapshot は unlock 根拠にしない。
+- [x] External purchase verification、store notification ingestion、subscription authority、entitlement recalculation、HTTP runtime dependencies remain behind ports/adapters. worker は provider SDK や Firestore / Pub/Sub detail を domain language に持ち込まない。
+- [x] User stories remain independently implementable and testable. purchase verification、failure/retry/idempotency、notification reconciliation は別 artifact としてレビュー可能である。
+- [x] subscription state、purchase state、entitlement bundle、quota profile、feature gate decision、usage limit を混同しない。worker は billing workflow (purchase + notification) だけを own する。
+- [x] Identifier naming follows the constitution. `id` / `xxxId` を新しい正本語彙として導入せず、aggregate 自身は `identifier`、関連参照は `subscription`、`actor`、`entitlementSnapshot` などの概念名を使う。
+
+Post-design re-check: PASS. Verified against
+`/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/research.md`,
+`/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/data-model.md`,
+`/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/billing-work-item-contract.md`,
+`/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/purchase-verification-workflow-contract.md`,
+`/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/store-notification-workflow-contract.md`,
+`/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/billing-visibility-handoff-contract.md`, and
+`/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/billing-worker-runtime-boundary-contract.md`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-billing-worker-implementation/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── billing-visibility-handoff-contract.md
+│   ├── billing-work-item-contract.md
+│   ├── billing-worker-runtime-boundary-contract.md
+│   ├── purchase-verification-workflow-contract.md
+│   └── store-notification-workflow-contract.md
+├── spec.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+applications/
+└── backend/
+    ├── README.md
+    └── billing-worker/
+        ├── cabal.project
+        ├── billing-worker.cabal
+        ├── app/
+        │   └── Main.hs
+        ├── src/
+        │   └── BillingWorker/
+        │       ├── WorkItemContract.hs
+        │       ├── WorkflowStateMachine.hs
+        │       ├── PurchaseVerificationPort.hs
+        │       ├── SubscriptionAuthorityPort.hs
+        │       ├── EntitlementRecalcPort.hs
+        │       ├── NotificationPort.hs
+        │       ├── BillingPersistence.hs
+        │       ├── CurrentSubscriptionHandoff.hs
+        │       ├── FailureSummary.hs
+        │       └── WorkerRuntime.hs
+        └── tests/
+            ├── feature/
+            │   ├── Main.hs
+            │   └── BillingWorker/
+            │       └── FeatureSpec.hs
+            ├── support/
+            │   ├── FeatureSupport.hs
+            │   └── TestSupport.hs
+            └── unit/
+                ├── Main.hs
+                └── BillingWorker/
+                    ├── WorkItemContractSpec.hs
+                    ├── WorkflowStateMachineSpec.hs
+                    ├── PurchaseVerificationPortSpec.hs
+                    ├── SubscriptionAuthorityPortSpec.hs
+                    ├── EntitlementRecalcPortSpec.hs
+                    ├── NotificationPortSpec.hs
+                    ├── BillingPersistenceSpec.hs
+                    ├── CurrentSubscriptionHandoffSpec.hs
+                    ├── FailureSummarySpec.hs
+                    └── WorkerRuntimeSpec.hs
+
+docker/
+└── applications/
+    ├── compose.yaml
+    └── billing-worker/
+        ├── Dockerfile
+        └── entrypoint.sh
+
+scripts/
+├── bootstrap/
+│   └── validate_local_stack.sh
+├── ci/
+│   └── run_application_container_smoke.sh
+└── lib/
+    └── vocastock_env.sh
+
+specs/
+├── 004-tech-stack-definition/
+├── 010-subscription-component-boundaries/
+├── 012-persistence-workflow-design/
+├── 014-billing-entitlement-policy/
+├── 015-command-query-topology/
+├── 016-application-docker-env/
+├── 021-explanation-worker-implementation/
+└── 023-billing-worker-implementation/
+```
+
+**Structure Decision**: 実装の中心は `applications/backend/billing-worker/` に置き、
+Haskell package-local Cabal package として worker runtime を新設する。`app/Main.hs` は boot と
+stable-run 起動だけを担い、worker-owned logic は `src/BillingWorker/` の責務別 module
+へ分割する。`WorkItemContract` は intake payload と duplicate key 判定を、`WorkflowStateMachine`
+は lifecycle 遷移と retry / timeout / dead-letter rule を、`PurchaseVerificationPort`、
+`SubscriptionAuthorityPort`、`EntitlementRecalcPort`、`NotificationPort` は confirmed-only 生成 /
+reconciliation adapter 契約を、`BillingPersistence` と `CurrentSubscriptionHandoff` は success を
+構成する二段階確定を担う。unit テストは `src/BillingWorker/` を mirror した Haskell spec を
+`tests/unit/BillingWorker/` に置き、feature テストは `tests/feature/Main.hs` +
+`tests/feature/BillingWorker/FeatureSpec.hs` + `tests/support/FeatureSupport.hs` の Haskell
+suite として構成し、Docker container と Firebase emulator を起動して worker の success /
+retryable / terminal / notification-reconciled path を end-to-end 検証する。`billing-worker` は
+外向き HTTP surface を持たず、stable-run long-running consumer のみを canonical success signal とする。
+runtime 正本は `docker/applications/billing-worker/` と `docker/applications/compose.yaml`、
+validation 正本は `scripts/ci/run_application_container_smoke.sh` と
+`scripts/bootstrap/validate_local_stack.sh` に同期する。
+
+## Complexity Tracking
+
+> No constitution violations requiring justification were identified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |

--- a/specs/023-billing-worker-implementation/quickstart.md
+++ b/specs/023-billing-worker-implementation/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: Billing Worker Implementation
+
+## Goal
+
+`billing-worker` が submitted 済み purchase artifact と normalized store notification を worker runtime として処理し、
+completed `BillingRecord` (purchase state 更新 + entitlement snapshot) の保存と
+`Subscription.currentEntitlementSnapshot` handoff が両方成立した時だけ success にし、
+retryable / terminal failure では status-only だけを残し、notification reconciliation 中は新規 paid entitlement を
+付与しないことを確認する。
+
+## Review Flow
+
+1. [research.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/research.md) を読み、
+   Haskell runtime baseline、stable-run のみの canonical success signal、submitted purchase artifact + normalized
+   notification に絞った initial slice、二段階 success、malformed payload の terminal 扱い、duplicate handling、
+   notification reconciliation が新規 unlock を付与しない方針、テスト方針の判断理由を確認する
+2. [data-model.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/data-model.md) で、
+   `BillingWorkItem`、`BillingWorkflowState`、`SubscriptionAuthoritySnapshotCandidate`、
+   `CurrentSubscriptionHandoff`、`BillingFailureSummary` を確認する
+3. [billing-work-item-contract.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/billing-work-item-contract.md)
+   と [purchase-verification-workflow-contract.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/purchase-verification-workflow-contract.md)
+   で intake、purchase state transition、retry / timeout / dead-letter rule を確認する
+4. [store-notification-workflow-contract.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/store-notification-workflow-contract.md)
+   で notification intake、補正方針、新規 unlock 付与禁止ルールを確認する
+5. [billing-visibility-handoff-contract.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/billing-visibility-handoff-contract.md)
+   で confirmed-only visibility、candidate handoff、entitlement snapshot commit contract を確認する
+6. [billing-worker-runtime-boundary-contract.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/billing-worker-runtime-boundary-contract.md)
+   で stable-run、Docker/Firebase feature test、scope 外責務を確認する
+
+## Implementation Verification
+
+1. `cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test`
+2. `cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test --enable-coverage`
+3. `cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test feature`
+4. `bash /Users/lihs/workspace/vocastock/scripts/ci/run_application_container_smoke.sh`
+5. `bash /Users/lihs/workspace/vocastock/scripts/bootstrap/validate_local_stack.sh --reuse-running --with-application-containers`
+
+`run_application_container_smoke.sh` 完了後は
+`/Users/lihs/workspace/vocastock/.artifacts/ci/logs/application-container-smoke.summary`
+に `billing_worker_validation.success`、
+`billing_worker_validation.retryable-failure`、
+`billing_worker_validation.terminal-failure`、
+`billing_worker_validation.notification-reconciled`
+が個別 record として残ることを確認する。
+
+## What Must Be True
+
+1. `billing-worker` は submitted 済み purchase artifact と normalized store notification だけを処理すること
+2. worker runtime は `queued`、`running`、`retry-scheduled`、`timed-out`、`succeeded`、`failed-final`、`dead-lettered` を区別すること
+3. success は completed `BillingRecord` 保存と `Subscription.currentEntitlementSnapshot` handoff 完了の両方が必要であること
+4. handoff 完了前の candidate snapshot は confirmed entitlement snapshot として扱わないこと
+5. retryable failure、timeout、terminal failure は completed `BillingRecord` を作らず、status-only 要約だけを残すこと
+6. malformed / incomplete verification payload は `failed-final` として扱い、partial snapshot を保存しないこと
+7. duplicate / replay work は business key 単位で idempotent に扱い、authoritative subscription state や entitlement snapshot の重複切替を起こさないこと
+8. notification reconciliation は補正経路であり、retry / timeout / failure 中に新規 paid entitlement を付与しないこと
+9. worker は public endpoint や query response を own せず、canonical success signal は stable-run であること
+10. feature テストは Haskell のコードから Docker container と Firebase emulator を使って動くこと
+11. runtime validation では `success`、`retryable-failure`、`terminal-failure`、`notification-reconciled` を別シナリオとして再現し、`VOCAS_BILLING_RESULT` を summary に記録すること
+
+## Deferred Scope
+
+- restore workflow の worker 側実装 (012 に別 runtime trace あり)
+- Apple App Store / Google Play 固有 SDK の実 adapter 実装
+- store product catalog 管理 / pricing change / tax / intro offer / coupon / family plan
+- image workflow と `image-worker` の追加変更
+- explanation workflow との cross-concern
+- provider 固有最適化 / モデル選定 hardening
+- public GraphQL operation の拡張

--- a/specs/023-billing-worker-implementation/research.md
+++ b/specs/023-billing-worker-implementation/research.md
@@ -1,0 +1,112 @@
+# Research: Billing Worker Implementation
+
+## Decision 1: worker runtime は package-local Cabal package の Haskell 実装に固定する
+
+- **Decision**: `billing-worker` は `applications/backend/billing-worker/` 配下の
+  package-local Cabal package として実装し、worker-owned logic は Haskell module へ分割する。
+- **Rationale**: 004 の正本で workflow boundary は Haskell、async execution baseline は
+  `Pub/Sub + Cloud Run worker + Firestore state` と固定されている。既存の `explanation-worker`
+  と `image-worker` がこのパターンで実装済みのため、同じ構造に揃えて CI / toolchain / Dockerfile
+  multi-stage build の再利用を最大化する。
+- **Alternatives considered**:
+  - Rust で worker を実装する: 004 / 015 の runtime baseline に反する
+  - shell-only stub のまま放置する: 憲章 III "非同期生成は完了結果のみ公開" を満たす workflow state machine が表現できない
+
+## Decision 2: initial slice は submitted purchase artifact と normalized store notification に限定する
+
+- **Decision**: worker intake は upstream accepted command dispatch から dispatch された purchase
+  verification work item と、store から受信した normalized server notification work item の 2 系統に
+  限定する。restore workflow は 012 に別経路があるため deferred scope とする。
+- **Rationale**: 023 の最小価値は、012 の subscription workflow state machine のうち
+  `Purchase Verification Workflow` と `Notification Reconciliation Workflow` を worker 側で
+  実現し、purchase state / subscription state / entitlement snapshot を confirmed-only で反映
+  することにある。restore workflow は purchase verification と同じ最終保存対象を更新する補正
+  経路であり、同時に実装すると intake 責務境界が広がるため後続 slice に分離する。
+- **Alternatives considered**:
+  - restore workflow も同時実装する: intake と runtime の責務が両方広がり、023 の independent test 要件が崩れる
+  - 非 store origin の notification 経路も含める: 010 / 014 で外部境界が `mobile storefront` / `purchase verification` / `store notification` に限定されており、逸脱になる
+
+## Decision 3: success は「completed BillingRecord 保存」と「currentEntitlementSnapshot handoff 完了」の二段階確定にする
+
+- **Decision**: worker は purchase verification adapter から `verified` 相当を受けても、
+  completed `BillingRecord` (purchase state 更新 + entitlement snapshot) の保存と
+  `Subscription.currentEntitlementSnapshot` handoff の両方が完了するまで `succeeded` としない。
+  保存後に handoff が失敗した場合は candidate snapshot を workflow state に保持し、再検証ではなく
+  handoff の再試行を優先する。
+- **Rationale**: FR-004 と 012 の state machine contract では、completed entitlement snapshot が
+  unlock 根拠になる条件は current handoff 完了まで含む。保存後 handoff 失敗を再検証へ戻すと
+  duplicate BillingRecord を増やしやすく、current 切替の idempotency も崩れる。010 の
+  authority rule も backend 側の authoritative state update を snapshot commit と同時に行う
+  ことを要求している。
+- **Alternatives considered**:
+  - BillingRecord 保存成功時点で `succeeded` とする: confirmed-only visibility が崩れる
+  - handoff failure 時に毎回再検証する: duplicate commit と余計な provider call を招く
+
+## Decision 4: 不完全または不整合な「verified payload」は non-retryable failure として扱う
+
+- **Decision**: verification adapter が `verified` 相当を返しても、`subscriptionStateName`、
+  `entitlementBundleName`、`quotaProfileName`、`effectivePeriod` など completed
+  `BillingRecord` / entitlement snapshot に必要な payload が欠けている場合は `failed-final` へ
+  写像する。
+- **Rationale**: 010 / 014 の contract は entitlement snapshot が完全な bundle / quota profile
+  を含むことを要求しており、不完全 payload を partial success や retryable failure として扱うと
+  confirmed-only visibility rule が壊れる。malformed payload は同じ adapter 実装を再試行しても
+  改善しない可能性が高く、運用上は terminal failure として扱う方が安全である。
+- **Alternatives considered**:
+  - 不完全 payload を status-only で隠す: entitlement snapshot の invariants を壊す
+  - 無条件に retry-scheduled へ送る: 同じ malformed payload を繰り返すだけで収束しない
+
+## Decision 5: duplicate / replay は business key と terminal outcome に基づいて idempotent に扱う
+
+- **Decision**: work item は business key (例: `actor + subscription + trigger + artifactReference`)
+  を持ち、同一 key の replay / duplicate arrival は existing workflow state を参照して no-op
+  または completed candidate reuse として扱う。queued、running、retry-scheduled 中は重複
+  verification を開始せず、succeeded 後は completed snapshot を再利用し、
+  `currentEntitlementSnapshot` の再切替を起こさない。
+- **Rationale**: 012 の lifecycle と 015 の worker allocation では、worker が duplicate work に
+  よって authoritative subscription state や entitlement snapshot を重複切替しないことが
+  前提になっている。`verified → active → revoked` のような順序が破綻すると 014 の state effect
+  が再現できない。
+- **Alternatives considered**:
+  - message arrival ごとに再検証する: duplicate commit と current switch を招く
+  - upstream duplicate 判定だけに依存する: worker restart / replay 時の自己防衛が弱い
+
+## Decision 6: notification reconciliation は subscription state 補正のみに限定し、新規 paid entitlement を付与しない
+
+- **Decision**: store notification は subscription state の補正経路であり、`grace` → `expired` →
+  `revoked` や `active` → `grace` のような既存 authority state の更新だけを行う。notification
+  単独で未確認 actor に新規 paid entitlement を付与してはならない。
+- **Rationale**: 012 の notification reconciliation workflow contract は "retry / timeout /
+  failure 中に新規 paid entitlement を付与しない" と規定している。notification は store が
+  source-of-truth を補正するための後追い signal であり、purchase verification が終わって
+  いない actor へ先回りして unlock を与えると confirmed-only visibility rule が崩れる。
+- **Alternatives considered**:
+  - notification から paid entitlement を推論する: verification 経路を迂回し、confirmed-only rule に反する
+  - notification を無視する: `grace` / `expired` / `revoked` 補正が機能せず、010 / 014 の state effect が実装できない
+
+## Decision 7: テストは Haskell unit mirror と Haskell Docker/Firebase feature suite を併用する
+
+- **Decision**: worker-owned logic は `tests/unit/BillingWorker/*Spec.hs` で source module ごとに
+  mirror した Haskell unit テストを用意し、feature path は Haskell suite から Docker container と
+  Firebase emulator を起動して success / retryable / terminal / notification-reconciled path を
+  検証する。
+- **Rationale**: `explanation-worker` で同じ pattern が既に確立しており、Cabal component、
+  coverage、editor support を一貫させやすい。Haskell unit だけでは runtime / container /
+  emulator 経路を検証できず、逆に feature だけでは state machine の細部検証が弱い。
+- **Alternatives considered**:
+  - shell script で worker feature test を書く: typed fixture と coverage 連携が弱い
+  - Haskell test だけで unit/E2E を兼用する: runtime / container / emulator と state machine の責務が混ざる
+
+## Decision 8: HTTP runtime adapter は持たず stable-run long-running consumer のみを canonical success signal とする
+
+- **Decision**: `billing-worker` は Servant による internal HTTP surface を **持たない**。
+  `explanation-worker` は Pub/Sub push 受信や internal health/admin surface 用に Servant を採用
+  しているが、billing-worker は pull-based consumer として stable-run だけを success signal とし、
+  HTTP 層は導入しない。
+- **Rationale**: 016 の container contract では worker の canonical success signal は
+  `long-running consumer` の stable-run であり、HTTP endpoint は必須ではない。billing-worker は
+  payment provider や store server notification を pull ベースで扱えば十分で、追加の HTTP surface は
+  責務を広げるだけになる。image-worker も HTTP を持たない同じ pattern を採用している。
+- **Alternatives considered**:
+  - Servant internal HTTP surface を追加する: canonical success signal は stable-run で足り、追加 HTTP は overkill
+  - HTTP-push 専用 consumer にする: pull-based stable-run に比べ canonical success signal の単純さが失われる

--- a/specs/023-billing-worker-implementation/spec.md
+++ b/specs/023-billing-worker-implementation/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Billing Worker Implementation
+
+**Feature Branch**: `023-billing-worker-implementation`  
+**Created**: 2026-04-21  
+**Status**: Draft  
+**Input**: User description: "6. billing-worker の実装を設計書に従って実装する。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 購入 artifact を authoritative subscription state へ反映できる (Priority: P1)
+
+学習者として、購入した paid plan の artifact が verification adapter 越しに正しく検証され、
+その結果だけが authoritative subscription state と entitlement snapshot へ反映されてほしい。
+そうすることで、purchase が `verified` になるまで premium 機能が unlock されず、
+完了した entitlement snapshot だけが UI の mirror へ流れることを保証したい。
+
+**Why this priority**: `billing-worker` の最小価値は、submitted 済みの purchase artifact を
+`verified` purchase state と paid subscription entitlement へ到達させ、confirmed でない
+unlock を発生させないことにあるため。
+
+**Independent Test**: 第三者が成果物だけを読み、submitted 済みの purchase artifact が
+`queued` から `succeeded` へ進み、完了時だけ authoritative subscription state と
+entitlement snapshot が切り替わることを 10 分以内に説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** actor に紐づく submitted purchase artifact が verification dispatch 済みである, **When** `billing-worker` がその artifact を成功裏に検証する, **Then** purchase state が `verified` へ進み、authoritative subscription state と entitlement snapshot が新しい bundle / quota profile で更新される
+2. **Given** purchase verification 要求が `queued` または `running` である, **When** 利用者が read 側から状態を確認する, **Then** confirmed entitlement ではなく status-only だけが利用可能である
+3. **Given** 既存の entitlement snapshot が存在する, **When** 新しい purchase verification 試行が完了前に失敗する, **Then** 既存の snapshot と mirror は維持され、premium unlock の根拠とはしない
+
+---
+
+### User Story 2 - 失敗、再試行、重複要求を一貫して扱える (Priority: P2)
+
+運用担当者として、`billing-worker` が retryable failure、timeout、terminal failure、duplicate work を一貫して扱ってほしい。
+そうすることで、同じ購入 artifact で subscription state が二重に切り替わったり、未確認 entitlement が confirmed 扱いされたり
+することを防ぎたい。
+
+**Why this priority**: billing workflow は非同期処理であり、失敗分類と idempotent handling が曖昧だと
+012 の subscription workflow state machine と 010 の authority 境界が崩れるため。
+
+**Independent Test**: 第三者が成果物だけを読み、retryable / terminal / duplicate / invalid-target の各ケースで
+worker がどの状態へ遷移し、何を user-visible にしてはいけないかを 10 分以内に説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** purchase verification が retryable failure を返す, **When** `billing-worker` が failure を処理する, **Then** authoritative subscription state は paid へ進めず `retry-scheduled` へ遷移する
+2. **Given** purchase verification が timeout または retry exhaustion に達する, **When** `billing-worker` が処理を終える, **Then** `failed-final` または `dead-lettered` へ遷移し、status-only failure として扱う
+3. **Given** 同じ business key の purchase verification 要求が再送または重複到着する, **When** `billing-worker` がそれを処理する, **Then** authoritative subscription state や entitlement snapshot の重複切替を起こさない
+
+---
+
+### User Story 3 - store notification を取り込み subscription state を補正できる (Priority: P3)
+
+backend 運用担当者として、App Store / Google Play の server notification を normalized 形式で取り込み、
+authoritative subscription state と entitlement snapshot を補正できてほしい。そうすることで、端末経由の
+purchase verification が遅れても、store 側の signal で `grace` / `expired` / `revoked` への遷移が正しく
+反映されるようにしたい。
+
+**Why this priority**: notification reconciliation が欠けると、`grace` 中の有料 entitlement 維持、
+`expired` への free tier 戻し、`revoked` の hard-stop が信頼できなくなり、014 の access policy が破綻するため。
+
+**Independent Test**: 第三者が成果物だけを読み、normalized notification が `queued` から `succeeded` へ進み、
+subscription state と entitlement snapshot が補正される流れ、および notification 受信中に新規 paid entitlement が
+付与されないことを 10 分以内に説明できれば成立する。
+
+**Acceptance Scenarios**:
+
+1. **Given** normalized store notification を受信する, **When** `billing-worker` が notification を reconcile する, **Then** subscription state が `grace` / `expired` / `revoked` のいずれかに補正され、entitlement snapshot が再計算される
+2. **Given** notification ingest が retryable failure を返す, **When** `billing-worker` が処理を継続する, **Then** 既存の mirror は維持され、新規 paid entitlement を付与しない
+3. **Given** notification が malformed または signature invalid である, **When** `billing-worker` が処理する, **Then** `failed-final` または `dead-lettered` として扱い、status-only failure だけを残す
+
+### Edge Cases
+
+- 同じ purchase artifact に対する verification 要求が `queued` または `running` の間に再送される場合
+- submitted purchase artifact が処理開始時点で subscription 不在、actor と ownership 不整合、または無効な product ID を参照している場合
+- verification adapter が `verified` 相当を返しても、entitlement snapshot に必要な情報 (subscription term、plan code、grace window 等) が不完全な場合
+- purchase state の `verified` 更新は成立したが、entitlement snapshot の commit が未完了の場合
+- 既存の entitlement snapshot を保持したまま restore / reverify 相当の試行が timeout した場合
+- provider / adapter の詳細 failure reason が user-facing status にそのまま漏れそうな場合
+- worker restart 中に `running` work が残り、再開時に subscription state の二重遷移を起こしそうな場合
+- notification の到着順序が逆転し、`grace → revoked` の後で `active` の古い notification を誤って反映しそうな場合
+
+## Domain & Async Impact *(mandatory when applicable)*
+
+- **Domain Models Affected**: `specs/010-subscription-component-boundaries/data-model.md`、`specs/014-billing-entitlement-policy/data-model.md`、`docs/internal/domain/common.md`、`docs/internal/domain/service.md`
+- **Invariants / Terminology**: `Subscription` は authoritative `active` / `grace` / `expired` / `pending-sync` / `revoked` を保持し、purchase state (`initiated` / `submitted` / `verifying` / `verified` / `rejected`)、entitlement bundle、quota profile、feature gate decision、usage limit、subscription state を混同しない
+- **Async Lifecycle**: billing workflow は少なくとも `queued`、`running`、`retry-scheduled`、`timed-out`、`succeeded`、`failed-final`、`dead-lettered` を区別し、同一業務キーは idempotent に扱う
+- **User Visibility Rule**: user-facing read は常に `query-api` 経由とし、confirmed entitlement snapshot だけを unlock 根拠にする。`queued`、`running`、`retry-scheduled`、`timed-out`、`failed-final`、`dead-lettered` では status-only だけを許可する
+- **Identifier Naming Rule**: identifier type は `XxxIdentifier` を維持し、aggregate 自身の識別子は `identifier`、関連参照は `subscription`、`actor`、`entitlementSnapshot` のような概念名を使う
+- **External Ports / Adapters**: accepted command dispatch intake、`PurchaseVerificationPort`、`SubscriptionAuthorityPort`、`EntitlementRecalcPort`、`NotificationPort`、workflow state persistence、completed `BillingRecord` persistence、`Subscription.currentEntitlementSnapshot` handoff
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 成果物は、`billing-worker` を purchase verification workflow と store notification reconciliation workflow 専用の worker deployment unit として定義しなければならない
+- **FR-002**: 成果物は、actor-owned `Subscription` を対象とする submitted 済み purchase artifact を受け取り、workflow state を進行させなければならない
+- **FR-003**: 成果物は、initial slice として store (App Store / Google Play) を source とする submitted 済み purchase artifact と normalized notification を処理対象に含めなければならない
+- **FR-004**: 成果物は、completed `BillingRecord` (purchase state 更新 + entitlement snapshot) の保存と `Subscription.currentEntitlementSnapshot` の handoff が両方成立したときだけ success として扱わなければならない
+- **FR-005**: 成果物は、`queued`、`running`、`retry-scheduled`、`timed-out`、`failed-final`、`dead-lettered` のいずれでも、confirmed されていない entitlement snapshot を user-visible unlock 根拠として扱ってはならない
+- **FR-006**: 成果物は、新しい verification 試行が success 前に失敗した場合、既存の `currentEntitlementSnapshot` を維持しなければならない
+- **FR-007**: 成果物は、少なくとも `queued`、`running`、`retry-scheduled`、`timed-out`、`succeeded`、`failed-final`、`dead-lettered` を billing workflow の区別可能な状態として扱わなければならない
+- **FR-008**: 成果物は、retryable failure、timeout、non-retryable failure を区別し、それぞれ retry scheduling または terminal failure へ写像しなければならない
+- **FR-009**: 成果物は、同一業務キーの replay / duplicate work を idempotent に扱い、authoritative subscription state や entitlement snapshot の重複切替を起こしてはならない
+- **FR-010**: 成果物は、処理開始時に subscription 不在、actor と ownership 不整合、または前提不正が判明した work item を completed `BillingRecord` なしの failure outcome として扱わなければならない
+- **FR-011**: 成果物は、user-facing には status-only で十分な failure summary を保持できるようにしつつ、provider / adapter の詳細内部情報を completed payload や公開応答へ漏らしてはならない
+- **FR-012**: 成果物は、`billing-worker` が query response、public GraphQL binding、explanation generation workflow、image generation workflow を own してはならないことを明示しなければならない
+- **FR-013**: 成果物は、validation 経路として success、retryable failure、terminal failure、notification-reconciled の少なくとも 4 系統を再現可能にしなければならない
+- **FR-014**: 成果物は、この feature の scope を purchase verification workflow と store notification reconciliation workflow に限定し、restore workflow、provider 固有最適化、store product catalog 管理、pricing change、tax、intro offer、coupon、public schema 拡張を deferred scope として明示しなければならない
+
+### Key Entities *(include if feature involves data)*
+
+- **BillingWorkItem**: submitted 済み purchase artifact または normalized notification を表す処理単位。target `Subscription`、actor、業務キー、起点理由 (`purchase-artifact-submitted` / `notification-received`)、現在の workflow state を持つ
+- **BillingWorkflowState**: `queued` から terminal state までの lifecycle、attempt 回数、retry eligibility、timeout 判定を表す状態
+- **SubscriptionAuthoritySnapshot**: user-visible にしてよい commit 済みの subscription state、entitlement bundle、quota profile、effective period を保持する snapshot
+- **CurrentSubscriptionHandoff**: completed `SubscriptionAuthoritySnapshot` を `Subscription.currentEntitlementSnapshot` として採用するか、既存 current を維持するかの判断結果
+- **BillingFailureSummary**: status-only 表示に使う failure 要約。retryable か terminal か、再試行余地があるかを示す
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: レビュー担当者が 10 分以内に、submitted purchase artifact が completed `BillingRecord` と `currentEntitlementSnapshot` handoff へ到達する条件を説明できる
+- **SC-002**: validation で、success 1 系統、retryable failure 1 系統、terminal failure 1 系統、notification-reconciled 1 系統を再現しても、confirmed されていない entitlement snapshot が user-visible unlock と誤認されるケースが 0 件である
+- **SC-003**: duplicate / replay work を含む検証で、同一業務要求に対する authoritative subscription state や entitlement snapshot の重複切替が 0 件である
+- **SC-004**: レビュー時に `billing-worker`、`command-api`、`query-api`、`explanation-worker`、`image-worker` の責務境界について判断不能ケースが 0 件である
+
+## Assumptions
+
+- initial slice は既存の accepted purchase intake を再利用し、`startExplanation` 等のドメイン側 gate は upstream で判定済みとする
+- standalone `requestRestorePurchase` command の public intake は、upstream acceptance が未実装なら後続 slice で接続してよい
+- purchase verification adapter、store notification adapter の実実装は contract を満たす stub / mock でもよく、Apple / Google 固有 SDK 適用は後続 slice で扱う
+- auth/session handoff、duplicate purchase 判定、quota / entitlement gate は worker ではなく upstream boundary で処理済みである
+- user-visible read は `query-api` が継続して担当し、worker は completed entitlement snapshot を直接返さない
+- restore workflow は 012 で別経路として定義されているため、本 feature の主要対象外とする
+- deployment catalog と worker runtime 契約は `specs/015-command-query-topology/` および `specs/016-application-docker-env/` の正本を踏襲する
+
+## Dependencies
+
+- `specs/010-subscription-component-boundaries/` — subscription boundary 正本
+- `specs/014-billing-entitlement-policy/` — product catalog、entitlement bundle、quota profile、feature gate matrix、state effect
+- `specs/012-persistence-workflow-design/` — subscription workflow state machine、persistence allocation
+- `specs/015-command-query-topology/` — worker deployment topology
+- `specs/016-application-docker-env/` — container contract
+- `specs/021-explanation-worker-implementation/` — worker implementation pattern reference
+
+## Deferred Scope
+
+- restore workflow の worker 側実装 (012 に別 runtime trace あり)
+- Apple App Store / Google Play 固有 SDK の実 adapter 実装
+- store product catalog 管理 / pricing change / tax / intro offer / coupon / family plan
+- image workflow と `image-worker` の追加変更
+- explanation workflow との cross-concern
+- provider 固有最適化 / モデル選定 hardening
+- public GraphQL operation の拡張

--- a/specs/023-billing-worker-implementation/tasks.md
+++ b/specs/023-billing-worker-implementation/tasks.md
@@ -1,0 +1,177 @@
+# Tasks: Billing Worker Implementation
+
+**Input**: Design documents from [/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/)  
+**Prerequisites**: [plan.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/plan.md) (required), [spec.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/spec.md) (required), [research.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/research.md), [data-model.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/data-model.md), [contracts/](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts), [quickstart.md](/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/quickstart.md)
+
+**Tests**: `cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test`、`cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test feature`、`cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test --enable-coverage`、`bash /Users/lihs/workspace/vocastock/scripts/ci/run_application_container_smoke.sh`、`bash /Users/lihs/workspace/vocastock/scripts/bootstrap/validate_local_stack.sh --reuse-running --with-application-containers` を前提に、Haskell unit と Haskell feature の両方を task に含める。feature テストは Haskell コードから Docker container と Firebase emulator を使い、worker-owned coverage 90% 以上を満たす。  
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this belongs to (`US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: `billing-worker` の package baseline、責務別 source/test layout、review entrypoints を整える
+
+- [ ] T001 Create the package baseline in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/cabal.project` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/billing-worker.cabal`
+- [ ] T002 [P] Create the worker source skeleton in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/app/Main.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkItemContract.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkflowStateMachine.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/PurchaseVerificationPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/SubscriptionAuthorityPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/EntitlementRecalcPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/NotificationPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/BillingPersistence.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/CurrentSubscriptionHandoff.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/FailureSummary.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkerRuntime.hs`
+- [ ] T003 [P] Create the Haskell unit and Haskell feature test skeleton in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/Main.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/WorkItemContractSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/WorkflowStateMachineSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/PurchaseVerificationPortSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/SubscriptionAuthorityPortSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/EntitlementRecalcPortSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/NotificationPortSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/BillingPersistenceSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/CurrentSubscriptionHandoffSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/FailureSummarySpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/WorkerRuntimeSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/feature/Main.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/feature/BillingWorker/FeatureSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/support/TestSupport.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/support/FeatureSupport.hs`
+- [ ] T004 [P] Normalize the review and verification entrypoints in `/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/quickstart.md` so the planned Cabal package layout, Haskell feature suite, and validation commands stay aligned
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: すべての user story が共有する worker runtime shell、state/port/failure 基盤、build/runtime wiring を先に固定する
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T005 Create the shared stable-run boot shell and worker configuration entrypoint in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkerRuntime.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/app/Main.hs`
+- [ ] T006 [P] Define work item, business key, trigger classification, and intake validation entities in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkItemContract.hs`
+- [ ] T007 [P] Define purchase verification, subscription authority, entitlement recalc, notification, persistence, and current handoff port contracts in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/PurchaseVerificationPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/SubscriptionAuthorityPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/EntitlementRecalcPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/NotificationPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/BillingPersistence.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/CurrentSubscriptionHandoff.hs`
+- [ ] T008 [P] Define redacted failure summary and status-only mapping primitives in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/FailureSummary.hs`
+- [ ] T009 Implement the baseline lifecycle state shell for `queued`, `running`, `retry-scheduled`, `timed-out`, `succeeded`, `failed-final`, and `dead-lettered` in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkflowStateMachine.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkerRuntime.hs`
+- [ ] T010 Wire package build/test targets and container runtime boot in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/billing-worker.cabal`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/feature/Main.hs`, `/Users/lihs/workspace/vocastock/docker/applications/billing-worker/Dockerfile`, `/Users/lihs/workspace/vocastock/docker/applications/billing-worker/entrypoint.sh`, and `/Users/lihs/workspace/vocastock/docker/applications/compose.yaml`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - 購入 artifact を authoritative subscription state へ反映できる (Priority: P1) 🎯 MVP
+
+**Goal**: submitted 済み purchase artifact を completed `BillingRecord` と `currentEntitlementSnapshot` handoff へ到達させる
+
+**Independent Test**: `cabal test` と Haskell feature suite の結果を読むだけで、submitted work item が `queued` から `succeeded` へ進み、完了時だけ `currentEntitlementSnapshot` が切り替わり、non-success 時は既存 current が維持されることを説明できること
+
+### Tests for User Story 1
+
+- [ ] T011 [P] [US1] Add Haskell unit coverage for `queued -> running -> succeeded`, completed `BillingRecord` assembly, current handoff completion, and existing `currentEntitlementSnapshot` retention across non-success outcomes in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/WorkflowStateMachineSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/BillingPersistenceSpec.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/CurrentSubscriptionHandoffSpec.hs`
+- [ ] T012 [P] [US1] Add Haskell feature coverage for submitted purchase-artifact success, in-flight status-only visibility, and retained `currentEntitlementSnapshot` after retryable / timeout / terminal non-success paths in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/feature/BillingWorker/FeatureSpec.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/support/FeatureSupport.hs`
+
+### Implementation for User Story 1
+
+- [ ] T013 [US1] Implement purchase-artifact intake validation and `trigger = purchase-artifact-submitted` gating in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkItemContract.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkerRuntime.hs`
+- [ ] T014 [US1] Implement verified payload validation, authority update, entitlement snapshot derivation, and persistence success flow in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/PurchaseVerificationPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/SubscriptionAuthorityPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/EntitlementRecalcPort.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/BillingPersistence.hs`
+- [ ] T015 [US1] Implement current entitlement snapshot handoff and existing-current preservation while processing is incomplete in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/CurrentSubscriptionHandoff.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkflowStateMachine.hs`
+- [ ] T016 [US1] Implement the end-to-end success orchestration and Docker-driven happy-path fixture wiring in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkerRuntime.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/app/Main.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/support/FeatureSupport.hs`
+
+**Checkpoint**: User Story 1 should provide an independently testable purchase-verification MVP
+
+---
+
+## Phase 4: User Story 2 - 失敗、再試行、重複要求を一貫して扱える (Priority: P2)
+
+**Goal**: retryable failure、timeout、terminal failure、duplicate/replay を state machine と visibility ルールに従って一貫処理する
+
+**Independent Test**: `cabal test` と Haskell feature suite の結果を読むだけで、retryable / terminal / duplicate / invalid-target / ownership-mismatch の各ケースで worker がどの状態へ遷移し、何を user-visible にしてはいけないかを説明できること
+
+### Tests for User Story 2
+
+- [ ] T017 [P] [US2] Add Haskell unit coverage for retryable failure, timeout, malformed payload terminal failure, invalid target, ownership mismatch, duplicate/replay idempotency, and redacted failure summary in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/PurchaseVerificationPortSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/WorkflowStateMachineSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/WorkItemContractSpec.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/FailureSummarySpec.hs`
+- [ ] T018 [P] [US2] Add Haskell feature coverage for `retry-scheduled`, `failed-final` / `dead-lettered`, invalid target / ownership mismatch failure mapping, retained current on failure, and duplicate work no-op behavior in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/feature/BillingWorker/FeatureSpec.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/support/FeatureSupport.hs`
+
+### Implementation for User Story 2
+
+- [ ] T019 [US2] Implement retryable / timeout / non-retryable classification, retry-budget transitions, and retained-current failure summaries in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkflowStateMachine.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/FailureSummary.hs`
+- [ ] T020 [US2] Implement malformed verified-payload rejection plus invalid target / ownership mismatch terminal mapping in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/PurchaseVerificationPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/BillingPersistence.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkItemContract.hs`
+- [ ] T021 [US2] Implement duplicate/replay detection and idempotent save/switch guards that preserve existing `currentEntitlementSnapshot` across non-success paths in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkItemContract.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/BillingPersistence.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/CurrentSubscriptionHandoff.hs`
+- [ ] T022 [US2] Integrate failure handling, restart-safe replay lookup, invalid-target / ownership mismatch dispatch outcomes, and operator-review dead-letter routing in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkerRuntime.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/app/Main.hs`
+
+**Checkpoint**: User Story 2 should make failure classification, retry handling, and idempotency independently reviewable
+
+---
+
+## Phase 5: User Story 3 - store notification を取り込み subscription state を補正できる (Priority: P3)
+
+**Goal**: normalized store notification を取り込み、subscription state と entitlement snapshot を補正する経路を確立し、retry / timeout / failure 中に新規 paid entitlement を付与しないことを保証する
+
+**Independent Test**: `cabal test` と Haskell feature suite の結果を読むだけで、normalized notification が `queued` から `succeeded` へ進んで subscription state / entitlement snapshot が補正され、notification 経路の retry / timeout / failure 中は新規 premium unlock を付与しないことを説明できること
+
+### Tests for User Story 3
+
+- [ ] T023 [P] [US3] Add Haskell unit coverage for notification parse / normalization, retryable / timeout / terminal / stale notification outcomes, no-new-unlock enforcement, and dead-letter routing in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/NotificationPortSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/WorkflowStateMachineSpec.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/FailureSummarySpec.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/EntitlementRecalcPortSpec.hs`
+- [ ] T024 [P] [US3] Add Haskell feature coverage for long-running consumer startup, notification-reconciled success, notification retryable / terminal paths, and stable-run behavior in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/feature/BillingWorker/FeatureSpec.hs` and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/support/FeatureSupport.hs`
+
+### Implementation for User Story 3
+
+- [ ] T025 [US3] Implement normalized notification intake, stale notification detection, subscription state reconciliation, and no-new-unlock enforcement in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/NotificationPort.hs`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/SubscriptionAuthorityPort.hs`, and `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/WorkflowStateMachine.hs`
+- [ ] T026 [US3] Replace the shell-only consumer stub with packaged worker execution while preserving dependency probes and stable-run logging in `/Users/lihs/workspace/vocastock/docker/applications/billing-worker/entrypoint.sh`, `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/app/Main.hs`, and `/Users/lihs/workspace/vocastock/docker/applications/billing-worker/Dockerfile`
+- [ ] T027 [US3] Extend `/Users/lihs/workspace/vocastock/scripts/ci/run_application_container_smoke.sh`, `/Users/lihs/workspace/vocastock/scripts/lib/vocastock_env.sh`, and `/Users/lihs/workspace/vocastock/scripts/bootstrap/validate_local_stack.sh` so billing-worker success, retryable failure, terminal failure, and notification-reconciled validation paths are executable and recorded separately via Docker/Firebase
+- [ ] T028 [US3] Reconcile `/Users/lihs/workspace/vocastock/applications/backend/README.md`, `/Users/lihs/workspace/vocastock/docker/applications/compose.yaml`, and `/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/billing-worker-runtime-boundary-contract.md` so billing-worker ownership excludes query response, public API, explanation workflow, and image workflow
+
+**Checkpoint**: User Story 3 should make notification reconciliation and runtime boundary independently testable
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: mirror layout、artifact 同期、coverage、runtime 文書整合を最終化する
+
+- [ ] T029 [P] Mirror the final Haskell source layout into `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/tests/unit/BillingWorker/` so every module under `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/src/BillingWorker/` has a corresponding unit spec file
+- [ ] T030 [P] Update `/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/quickstart.md` and `/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/contracts/*.md` if shipped state names, port fields, visibility wording, or runtime entrypoints drift during implementation
+- [ ] T031 Run `cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test`, `cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test feature`, `cd /Users/lihs/workspace/vocastock/applications/backend/billing-worker && cabal test --enable-coverage`, `bash /Users/lihs/workspace/vocastock/scripts/ci/run_application_container_smoke.sh`, and `bash /Users/lihs/workspace/vocastock/scripts/bootstrap/validate_local_stack.sh --reuse-running --with-application-containers`, then reconcile shipped behavior in `/Users/lihs/workspace/vocastock/applications/backend/billing-worker/`, `/Users/lihs/workspace/vocastock/docker/applications/billing-worker/`, and `/Users/lihs/workspace/vocastock/specs/023-billing-worker-implementation/` while enforcing coverage 90% 以上 and confirming success, retryable failure, terminal failure, and notification-reconciled are recorded as separate validation outcomes
+- [ ] T032 [P] Cross-check `/Users/lihs/workspace/vocastock/docs/external/adr.md`, `/Users/lihs/workspace/vocastock/docs/external/requirements.md`, and `/Users/lihs/workspace/vocastock/applications/backend/README.md` so billing-worker runtime/ownership wording stays aligned with shipped behavior
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on other stories
+- **User Story 2 (P2)**: Can start after Foundational - builds on the shared lifecycle shell but remains independently testable
+- **User Story 3 (P3)**: Can start after Foundational - builds on the shared runtime shell but remains independently testable
+
+### Within Each User Story
+
+- Haskell unit tests and Haskell feature tests should be written before the corresponding implementation tasks are considered complete
+- Work item intake and verified payload validation should stabilize before the end-to-end runtime orchestration is finalized
+- Failure classification should be implemented before duplicate/replay integration is finalized
+- Runtime validation scripts and container boot flow should complete before final coverage and artifact reconciliation
+
+### Parallel Opportunities
+
+- `T002`, `T003`, and `T004` can run in parallel after `T001`
+- `T006`, `T007`, and `T008` can run in parallel within Foundational
+- `T011` and `T012` can run in parallel within US1
+- `T017` and `T018` can run in parallel within US2
+- `T023` and `T024` can run in parallel within US3
+- `T029`, `T030`, and `T032` can run in parallel in Phase 6
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Confirm the worker can drive a submitted purchase artifact from `queued` to `succeeded` and switch `currentEntitlementSnapshot` only on completion
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational to stabilize the Haskell package, lifecycle shell, port boundaries, and Docker runtime
+2. Add User Story 1 and validate the completed billing record + current handoff happy path
+3. Add User Story 2 and validate retryable / terminal / duplicate handling plus status-only failure semantics
+4. Add User Story 3 and validate notification reconciliation and stable-run runtime behavior
+5. Finish with coverage, artifact sync, and runtime wording reconciliation
+
+---
+
+## Notes
+
+- [P] tasks target different files and can proceed in parallel after dependencies
+- Tests are included because 023 explicitly requires success / retryable / terminal / notification-reconciled validation, feature tests must use Docker/Firebase, and worker-owned coverage must stay at or above 90%
+- Keep 023 terminology aligned with `BillingWorkItem`, `BillingWorkflowState`, `SubscriptionAuthoritySnapshotCandidate`, `CurrentSubscriptionHandoff`, `BillingFailureSummary`, `queued`, `retry-scheduled`, `failed-final`, `dead-lettered`
+- Do not expand scope into `explanation-worker`, `image-worker`, restore workflow, store product catalog management, pricing changes, provider-specific optimization, or public GraphQL schema extensions


### PR DESCRIPTION
## Summary

- `applications/backend/billing-worker/` に Haskell worker を新設し、purchase verification workflow と store notification reconciliation workflow の 2 系統を owning application 配下に実装 (10 モジュール、unit suite 1:1 mirror)
- Docker 関連 (`docker/applications/billing-worker/`) を shell-only stub から Haskell 9.2.8 multi-stage build に置き換え、CI smoke (`scripts/ci/run_application_container_smoke.sh`) へ 4 scenario (success / retryable-failure / terminal-failure / notification-reconciled) の validation block を追加
- Spec Kit 文書 `specs/023-billing-worker-implementation/` を 021 テンプレートに倣って追加し、010 / 014 / 012 を正本として参照しつつ user stories と contracts を定義。憲章 v2.1.0 の Constitution Check は PASS
- Haskell LSP (HLS 2.9.0.1 / GHC 9.2.8) がエディタで解決できるよう、root `cabal.project` を新設し `hie.yaml` を fully qualified component 名で再編、per-worker `hie.yaml` を safety-net として配置

## Test plan

- [x] `cd applications/backend/billing-worker && cabal build all`
- [x] `cd applications/backend/billing-worker && cabal test unit` (全 PASS)
- [x] `cd applications/backend/billing-worker && cabal test unit --enable-coverage` — **Program coverage 92% (255/276 top-level definitions)**、全モジュール 86%+
- [x] `cd applications/backend/billing-worker && cabal build test:feature` (Docker + Firebase emulator suite コンパイル確認)
- [x] `bash scripts/bootstrap/validate_application_containers.sh` (billing-worker Dockerfile + entrypoint.sh が contract-valid)
- [x] 14 WorkerScenario を `VOCAS_WORKER_RUN_MODE=validate` で個別実行し、`VOCAS_BILLING_RESULT` の `final_state` が期待値に到達することを確認
- [x] `haskell-language-server-wrapper --test` で billing-worker 全 9 ファイル / explanation-worker / image-worker が `0 files failed` で解決
- [ ] `bash scripts/ci/run_application_container_smoke.sh` (CI で実行、Haskell image 初回ビルドが完了すること)
- [ ] `bash scripts/bootstrap/validate_local_stack.sh --with-application-containers` (Firebase emulator + application container 全体の smoke)

## Constitution Check (v2.1.0)

- **I. アプリケーション単位のドメイン所有**: billing domain は `billing-worker/src/BillingWorker/` 配下に完結、shared package を汚染しない
- **III. 非同期生成は完了結果のみ公開**: `queued / running / retry-scheduled / timed-out / succeeded / failed-final / dead-lettered` を区別、candidate snapshot は `hidden-until-handoff`
- **IV. 外部依存はポート越し**: 4 ports (purchase verification / subscription authority / entitlement recalc / notification)
- **V. 仕様駆動で独立に届ける**: 3 user stories が独立にテスト可能
- **VI. 学習概念を混同しない**: purchase state / subscription state / entitlement bundle / quota profile を別概念として維持
- **Naming**: `BillingWorkItemIdentifier`, `SubscriptionIdentifier`, `actor`, `subscription` 等

## Deferred scope

- Restore workflow の worker 側実装 (012 に別 runtime trace あり)
- Apple App Store / Google Play 固有 SDK の実 adapter (port contract のみで停止)
- store product catalog 管理 / pricing change / tax / intro offer / coupon / family plan
- Haskell feature suite の実行 (Docker + Firebase emulator 起動が必要、ローカル確認は compile 段階まで)

🤖 Generated with [Claude Code](https://claude.com/claude-code)