### PR TITLE
feat(mobile): reproduce screens.jsx screens (Proficiency, Login flow, Generating, Settings, Detail variants)

### DIFF
--- a/applications/mobile/lib/src/app_bindings.dart
+++ b/applications/mobile/lib/src/app_bindings.dart
@@ -10,6 +10,7 @@ import 'application/command/purchase_commands.dart';
 import 'application/command/register_vocabulary_expression_command.dart';
 import 'application/gate/subscription_feature_gate.dart';
 import 'application/reader/completed_detail_readers.dart';
+import 'application/reader/learning_state_reader.dart';
 import 'application/reader/subscription_status_reader.dart';
 import 'application/reader/vocabulary_catalog_reader.dart';
 import 'application/reader/vocabulary_expression_detail_reader.dart';
@@ -72,6 +73,13 @@ final actorHandoffStatusProvider = StreamProvider<ActorHandoffStatus>((ref) {
 /// Pure-function feature gate; no infrastructure dependency.
 final subscriptionFeatureGateProvider = Provider<SubscriptionFeatureGate>((ref) {
   return const SubscriptionFeatureGate();
+});
+
+/// Stub learning-state reader that derives proficiency deterministically
+/// from the catalog entry identifier. Real backend reader (spec 005
+/// LearningState aggregate) will override this provider.
+final learningStateReaderProvider = Provider<LearningStateReader>((ref) {
+  return const StubLearningStateReader();
 });
 
 /// Stub vocabulary catalog backing both the reader and registration command.

--- a/applications/mobile/lib/src/application/reader/learning_state_reader.dart
+++ b/applications/mobile/lib/src/application/reader/learning_state_reader.dart
@@ -1,0 +1,33 @@
+import '../../domain/identifier/identifier.dart';
+import '../../domain/status/proficiency_level.dart';
+
+/// Reads the learner's proficiency assignment for a VocabularyExpression.
+///
+/// Real implementation depends on spec 005 LearningState aggregate; until
+/// that reader lands, a stub derives the level deterministically from the
+/// entry identifier so the Proficiency screen has something to render.
+abstract class LearningStateReader {
+  ProficiencyLevel? proficiencyFor(VocabularyExpressionIdentifier identifier);
+}
+
+class StubLearningStateReader implements LearningStateReader {
+  const StubLearningStateReader();
+
+  static const List<ProficiencyLevel> _levels = <ProficiencyLevel>[
+    ProficiencyLevel.learning,
+    ProficiencyLevel.learned,
+    ProficiencyLevel.internalized,
+    ProficiencyLevel.fluent,
+  ];
+
+  @override
+  ProficiencyLevel? proficiencyFor(
+    VocabularyExpressionIdentifier identifier,
+  ) {
+    final hash = identifier.value.codeUnits.fold<int>(
+      0,
+      (acc, unit) => (acc + unit) & 0xff,
+    );
+    return _levels[hash % _levels.length];
+  }
+}

--- a/applications/mobile/lib/src/domain/status/proficiency_level.dart
+++ b/applications/mobile/lib/src/domain/status/proficiency_level.dart
@@ -1,0 +1,13 @@
+/// LearningState.proficiency enumeration (spec 005 concept-separation:
+/// `Proficiency` is owned by `LearningState`).
+///
+/// The values progress from initial exposure to full fluency. Subsequent
+/// specs (backend learning-state-reader) will surface real assignments;
+/// the Flutter client currently relies on a stub provider that
+/// deterministically derives a level from the catalog entry identifier.
+enum ProficiencyLevel {
+  learning,
+  learned,
+  internalized,
+  fluent,
+}

--- a/applications/mobile/lib/src/presentation/auth/login_screen.dart
+++ b/applications/mobile/lib/src/presentation/auth/login_screen.dart
@@ -6,17 +6,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../app_bindings.dart';
 import '../../domain/auth/actor_handoff_status.dart';
 import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_brand_mark.dart';
 import '../theme/widgets/vs_spinner.dart';
-import '../theme/widgets/vs_wordmark.dart';
 
 /// Spec 013 canonical `Login` screen (Auth route group).
 ///
-/// State variants:
-///  - `statusOnly`: idle, provider selector is available.
-///  - `loading`: sign-in in progress; selector is disabled and a spinner
-///    indicates which stage is running.
-///  - `retryableFailure`: handoff failed; provider selector is re-enabled
-///    and the reason is surfaced as a `UserFacingMessage`.
+/// Visual reference: `screens.jsx` `VSLoginWelcome`. Hero layout with brand
+/// mark, serif wordmark, uppercase tagline, a two-line Mincho headline
+/// ("多義の深さに、画像を添えて。"), a paper-toned OAuth button pair, and a
+/// dark ink primary CTA. Failure messages surface in muted vermilion.
 class LoginScreen extends ConsumerWidget {
   const LoginScreen({super.key});
 
@@ -34,64 +32,267 @@ class LoginScreen extends ConsumerWidget {
       backgroundColor: VsTokens.paper,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(24, 40, 24, 24),
+          padding: const EdgeInsets.fromLTRB(28, 24, 28, 20),
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
-              const VsWordmark(size: 15),
-              const SizedBox(height: 80),
-              Text(
-                'VOCASTOCK',
-                style: theme.textTheme.labelMedium,
+              const Spacer(),
+              const VsBrandMark(),
+              const SizedBox(height: 28),
+              RichText(
+                textAlign: TextAlign.center,
+                text: const TextSpan(
+                  style: TextStyle(
+                    fontFamily: VsTokens.serif,
+                    fontSize: 30,
+                    fontWeight: FontWeight.w600,
+                    fontStyle: FontStyle.italic,
+                    letterSpacing: -0.4,
+                    color: VsTokens.ink,
+                  ),
+                  children: <InlineSpan>[
+                    TextSpan(text: 'vocastock'),
+                    TextSpan(
+                      text: '·',
+                      style: TextStyle(
+                        color: VsTokens.accent,
+                        fontStyle: FontStyle.normal,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-              const SizedBox(height: 6),
+              const SizedBox(height: 10),
               Text(
-                '多義の深さに、\n画像を添えて。',
-                style: theme.textTheme.displayMedium,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                'AIが生成する辞書的な解説と、単語を視覚で捉える画像。',
-                style: theme.textTheme.bodyMedium?.copyWith(
+                'AI DICTIONARY FOR LEARNERS',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  letterSpacing: 3,
                   color: VsTokens.inkMute,
                 ),
               ),
-              const Spacer(),
-              ElevatedButton(
-                key: const Key('login.provider.basic'),
-                onPressed: isSigningIn
-                    ? null
-                    : () => unawaited(
-                          loginCommand.signIn(AuthProvider.basic),
-                        ),
-                child: const Text('メールでサインイン'),
+              const SizedBox(height: 48),
+              const _HeroHeadline(),
+              const SizedBox(height: 14),
+              Text(
+                '登録した英単語を、AIが複数のSense・例文・\n視覚イメージに分解します。',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  height: 1.7,
+                  color: VsTokens.inkSoft,
+                ),
               ),
-              const SizedBox(height: 8),
-              OutlinedButton(
-                key: const Key('login.provider.google'),
+              const Spacer(),
+              _OAuthButton(
+                keyValue: 'login.provider.google',
+                label: 'Google で続ける',
+                icon: Icons.g_mobiledata,
                 onPressed: isSigningIn
                     ? null
                     : () => unawaited(
                           loginCommand.signIn(AuthProvider.google),
                         ),
-                child: const Text('Google でサインイン'),
               ),
-              const SizedBox(height: 24),
-              if (isSigningIn)
-                const Center(child: VsSpinner(size: 18))
-              else if (failure != null)
-                Text(
-                  failure.message.text,
-                  key: const Key('login.failure-message'),
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: VsTokens.err,
-                  ),
-                )
+              const SizedBox(height: 10),
+              const _OrDivider(),
+              const SizedBox(height: 10),
+              _PrimaryCta(
+                keyValue: 'login.provider.basic',
+                label: 'メールで続ける',
+                onPressed: isSigningIn
+                    ? null
+                    : () => unawaited(loginCommand.signIn(AuthProvider.basic)),
+                loading: isSigningIn,
+              ),
+              const SizedBox(height: 14),
+              if (failure != null)
+                _FailureBanner(message: failure.message.text)
               else
-                const SizedBox(height: 18),
+                const SizedBox(height: 28),
+              const SizedBox(height: 12),
+              Text(
+                '続行することで利用規約とプライバシーポリシーに同意したものとみなします。',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontSize: 10,
+                  height: 1.6,
+                  color: VsTokens.inkMute,
+                ),
+              ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HeroHeadline extends StatelessWidget {
+  const _HeroHeadline();
+
+  @override
+  Widget build(BuildContext context) {
+    return RichText(
+      textAlign: TextAlign.center,
+      text: const TextSpan(
+        style: TextStyle(
+          fontFamily: VsTokens.serif,
+          fontSize: 22,
+          fontWeight: FontWeight.w500,
+          height: 1.5,
+          color: VsTokens.ink,
+        ),
+        children: <InlineSpan>[
+          TextSpan(text: '多義の深さに、\n'),
+          TextSpan(
+            text: '画像',
+            style: TextStyle(color: VsTokens.accent),
+          ),
+          TextSpan(text: 'を添えて。'),
+        ],
+      ),
+    );
+  }
+}
+
+class _OAuthButton extends StatelessWidget {
+  const _OAuthButton({
+    required this.keyValue,
+    required this.label,
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final String keyValue;
+  final String label;
+  final IconData icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        key: Key(keyValue),
+        onPressed: onPressed,
+        icon: Icon(icon, size: 20, color: VsTokens.ink),
+        label: Text(label),
+        style: OutlinedButton.styleFrom(
+          backgroundColor: VsTokens.paperSoft,
+          foregroundColor: VsTokens.ink,
+          side: const BorderSide(color: VsTokens.inkHair),
+          padding: const EdgeInsets.symmetric(vertical: 13),
+          shape: const RoundedRectangleBorder(
+            borderRadius:
+                BorderRadius.all(Radius.circular(VsTokens.radiusMd)),
+          ),
+          textStyle: const TextStyle(
+            fontFamily: VsTokens.sans,
+            fontSize: 13,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OrDivider extends StatelessWidget {
+  const _OrDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    const line = Expanded(
+      child: Divider(color: VsTokens.inkHair, thickness: 0.5, height: 0.5),
+    );
+    return Row(
+      children: <Widget>[
+        line,
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Text(
+            'または',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: VsTokens.inkMute,
+                  letterSpacing: 1,
+                ),
+          ),
+        ),
+        line,
+      ],
+    );
+  }
+}
+
+class _PrimaryCta extends StatelessWidget {
+  const _PrimaryCta({
+    required this.keyValue,
+    required this.label,
+    required this.onPressed,
+    this.loading = false,
+  });
+
+  final String keyValue;
+  final String label;
+  final VoidCallback? onPressed;
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        key: Key(keyValue),
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: VsTokens.ink,
+          foregroundColor: VsTokens.paper,
+          disabledBackgroundColor: VsTokens.inkMute,
+          disabledForegroundColor: VsTokens.paperSoft,
+          elevation: 0,
+          padding: const EdgeInsets.symmetric(vertical: 15),
+          shape: const RoundedRectangleBorder(
+            borderRadius:
+                BorderRadius.all(Radius.circular(VsTokens.radiusMd)),
+          ),
+          textStyle: const TextStyle(
+            fontFamily: VsTokens.sans,
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.3,
+          ),
+        ),
+        child: loading
+            ? const SizedBox(
+                width: 16,
+                height: 16,
+                child: VsSpinner(color: VsTokens.paper),
+              )
+            : Text(label),
+      ),
+    );
+  }
+}
+
+class _FailureBanner extends StatelessWidget {
+  const _FailureBanner({required this.message});
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: VsTokens.accentSoft,
+        borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+      ),
+      child: Text(
+        message,
+        key: const Key('login.failure-message'),
+        textAlign: TextAlign.center,
+        style: const TextStyle(
+          fontFamily: VsTokens.sans,
+          fontSize: 12,
+          height: 1.5,
+          color: VsTokens.err,
         ),
       ),
     );

--- a/applications/mobile/lib/src/presentation/auth/login_screen.dart
+++ b/applications/mobile/lib/src/presentation/auth/login_screen.dart
@@ -7,23 +7,67 @@ import '../../app_bindings.dart';
 import '../../domain/auth/actor_handoff_status.dart';
 import '../theme/vs_tokens.dart';
 import '../theme/widgets/vs_brand_mark.dart';
+import '../theme/widgets/vs_input_field.dart';
+import '../theme/widgets/vs_mode_toggle.dart';
+import '../theme/widgets/vs_otp_field.dart';
+import '../theme/widgets/vs_section_label.dart';
 import '../theme/widgets/vs_spinner.dart';
 
-/// Spec 013 canonical `Login` screen (Auth route group).
+/// Spec 013 canonical `Login` screen.
 ///
-/// Visual reference: `screens.jsx` `VSLoginWelcome`. Hero layout with brand
-/// mark, serif wordmark, uppercase tagline, a two-line Mincho headline
-/// ("多義の深さに、画像を添えて。"), a paper-toned OAuth button pair, and a
-/// dark ink primary CTA. Failure messages surface in muted vermilion.
-class LoginScreen extends ConsumerWidget {
+/// The screen hosts an internal state machine mirroring `screens.jsx`
+/// `VSLogin`: welcome → sign-in / sign-up → verify → done. Each step is a
+/// private widget; the route itself stays at `/login`.
+class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final statusAsync = ref.watch(actorHandoffStatusProvider);
-    final loginCommand = ref.watch(loginCommandProvider);
-    final theme = Theme.of(context);
+  ConsumerState<LoginScreen> createState() => _LoginScreenState();
+}
 
+enum _LoginStep { welcome, signIn, signUp, verify, done }
+
+class _LoginScreenState extends ConsumerState<LoginScreen> {
+  _LoginStep _step = _LoginStep.welcome;
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _verifying = false;
+  Timer? _doneTimer;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _doneTimer?.cancel();
+    super.dispose();
+  }
+
+  void _goto(_LoginStep next) => setState(() => _step = next);
+
+  Future<void> _submitSignIn() async {
+    final command = ref.read(loginCommandProvider);
+    unawaited(command.signIn(AuthProvider.basic));
+  }
+
+  void _submitSignUp() {
+    _goto(_LoginStep.verify);
+  }
+
+  void _onCodeCompleted(String _) {
+    setState(() => _verifying = true);
+    Future<void>.delayed(const Duration(milliseconds: 900), () {
+      if (!mounted) return;
+      _goto(_LoginStep.done);
+      _doneTimer = Timer(const Duration(seconds: 2), () {
+        if (!mounted) return;
+        unawaited(ref.read(loginCommandProvider).signIn(AuthProvider.basic));
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final statusAsync = ref.watch(actorHandoffStatusProvider);
     final status = statusAsync.value ?? const ActorHandoffNotStarted();
     final isSigningIn = status is ActorHandoffInProgress;
     final failure = status is ActorHandoffFailed ? status : null;
@@ -31,94 +75,511 @@ class LoginScreen extends ConsumerWidget {
     return Scaffold(
       backgroundColor: VsTokens.paper,
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(28, 24, 28, 20),
-          child: Column(
-            children: <Widget>[
-              const Spacer(),
-              const VsBrandMark(),
-              const SizedBox(height: 28),
-              RichText(
-                textAlign: TextAlign.center,
-                text: const TextSpan(
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          child: _buildStep(context, isSigningIn, failure),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStep(
+    BuildContext context,
+    bool isSigningIn,
+    ActorHandoffFailed? failure,
+  ) {
+    switch (_step) {
+      case _LoginStep.welcome:
+        return _WelcomeStep(
+          key: const ValueKey<String>('login.step.welcome'),
+          isSigningIn: isSigningIn,
+          failure: failure,
+          onGoogle: () => unawaited(
+            ref.read(loginCommandProvider).signIn(AuthProvider.google),
+          ),
+          onEmailContinue: () =>
+              unawaited(ref.read(loginCommandProvider).signIn(AuthProvider.basic)),
+          onSignUp: () => _goto(_LoginStep.signUp),
+        );
+      case _LoginStep.signIn:
+        return _EmailFormStep(
+          key: const ValueKey<String>('login.step.signin'),
+          mode: _LoginStep.signIn,
+          emailController: _emailController,
+          passwordController: _passwordController,
+          isSigningIn: isSigningIn,
+          failure: failure,
+          onBack: () => _goto(_LoginStep.welcome),
+          onModeChanged: _goto,
+          onSubmit: () => unawaited(_submitSignIn()),
+        );
+      case _LoginStep.signUp:
+        return _EmailFormStep(
+          key: const ValueKey<String>('login.step.signup'),
+          mode: _LoginStep.signUp,
+          emailController: _emailController,
+          passwordController: _passwordController,
+          isSigningIn: isSigningIn,
+          failure: failure,
+          onBack: () => _goto(_LoginStep.welcome),
+          onModeChanged: _goto,
+          onSubmit: _submitSignUp,
+        );
+      case _LoginStep.verify:
+        return _VerifyStep(
+          key: const ValueKey<String>('login.step.verify'),
+          email: _emailController.text.isEmpty
+              ? 'you@example.com'
+              : _emailController.text,
+          verifying: _verifying,
+          onBack: () => _goto(_LoginStep.signUp),
+          onCompleted: _onCodeCompleted,
+          onResend: () {},
+        );
+      case _LoginStep.done:
+        return const _DoneStep(key: ValueKey<String>('login.step.done'));
+    }
+  }
+}
+
+class _WelcomeStep extends StatelessWidget {
+  const _WelcomeStep({
+    required this.isSigningIn,
+    required this.failure,
+    required this.onGoogle,
+    required this.onEmailContinue,
+    required this.onSignUp,
+    super.key,
+  });
+
+  final bool isSigningIn;
+  final ActorHandoffFailed? failure;
+  final VoidCallback onGoogle;
+  final VoidCallback onEmailContinue;
+  final VoidCallback onSignUp;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(28, 40, 28, 20),
+      child: Column(
+        children: <Widget>[
+          const VsBrandMark(),
+          const SizedBox(height: 28),
+          RichText(
+            textAlign: TextAlign.center,
+            text: const TextSpan(
+              style: TextStyle(
+                fontFamily: VsTokens.serif,
+                fontSize: 30,
+                fontWeight: FontWeight.w600,
+                fontStyle: FontStyle.italic,
+                letterSpacing: -0.4,
+                color: VsTokens.ink,
+              ),
+              children: <InlineSpan>[
+                TextSpan(text: 'vocastock'),
+                TextSpan(
+                  text: '·',
                   style: TextStyle(
-                    fontFamily: VsTokens.serif,
-                    fontSize: 30,
-                    fontWeight: FontWeight.w600,
-                    fontStyle: FontStyle.italic,
-                    letterSpacing: -0.4,
-                    color: VsTokens.ink,
+                    color: VsTokens.accent,
+                    fontStyle: FontStyle.normal,
                   ),
-                  children: <InlineSpan>[
-                    TextSpan(text: 'vocastock'),
-                    TextSpan(
-                      text: '·',
-                      style: TextStyle(
-                        color: VsTokens.accent,
-                        fontStyle: FontStyle.normal,
-                      ),
-                    ),
-                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            'AI DICTIONARY FOR LEARNERS',
+            style: theme.textTheme.labelMedium?.copyWith(
+              letterSpacing: 3,
+              color: VsTokens.inkMute,
+            ),
+          ),
+          const SizedBox(height: 48),
+          const _HeroHeadline(),
+          const SizedBox(height: 14),
+          Text(
+            '登録した英単語を、AIが複数のSense・例文・\n視覚イメージに分解します。',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              height: 1.7,
+              color: VsTokens.inkSoft,
+            ),
+          ),
+          const SizedBox(height: 48),
+          _OAuthButton(
+            keyValue: 'login.provider.google',
+            label: 'Google で続ける',
+            icon: Icons.g_mobiledata,
+            onPressed: isSigningIn ? null : onGoogle,
+          ),
+          const SizedBox(height: 10),
+          const _OrDivider(),
+          const SizedBox(height: 10),
+          _PrimaryCta(
+            keyValue: 'login.provider.basic',
+            label: 'メールで続ける',
+            onPressed: isSigningIn ? null : onEmailContinue,
+          ),
+          const SizedBox(height: 10),
+          TextButton(
+            key: const Key('login.signup-link'),
+            onPressed: isSigningIn ? null : onSignUp,
+            style: TextButton.styleFrom(foregroundColor: VsTokens.accentDeep),
+            child: const Text('新規登録はこちら →'),
+          ),
+          const SizedBox(height: 14),
+          if (failure != null)
+            _FailureBanner(message: failure!.message.text)
+          else
+            const SizedBox(height: 20),
+          const SizedBox(height: 8),
+          Text(
+            '続行することで利用規約とプライバシーポリシーに同意したものとみなします。',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontSize: 10,
+              height: 1.6,
+              color: VsTokens.inkMute,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmailFormStep extends StatelessWidget {
+  const _EmailFormStep({
+    required this.mode,
+    required this.emailController,
+    required this.passwordController,
+    required this.isSigningIn,
+    required this.failure,
+    required this.onBack,
+    required this.onModeChanged,
+    required this.onSubmit,
+    super.key,
+  });
+
+  final _LoginStep mode;
+  final TextEditingController emailController;
+  final TextEditingController passwordController;
+  final bool isSigningIn;
+  final ActorHandoffFailed? failure;
+  final VoidCallback onBack;
+  final ValueChanged<_LoginStep> onModeChanged;
+  final VoidCallback onSubmit;
+
+  bool get _isSignUp => mode == _LoginStep.signUp;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(28, 12, 28, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: onBack,
+              icon: const Icon(Icons.chevron_left, size: 18),
+              label: const Text('戻る'),
+              style: TextButton.styleFrom(
+                foregroundColor: VsTokens.inkSoft,
+                padding: EdgeInsets.zero,
+                textStyle: const TextStyle(
+                  fontFamily: VsTokens.sans,
+                  fontSize: 13,
                 ),
               ),
-              const SizedBox(height: 10),
-              Text(
-                'AI DICTIONARY FOR LEARNERS',
-                style: theme.textTheme.labelMedium?.copyWith(
-                  letterSpacing: 3,
-                  color: VsTokens.inkMute,
-                ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          const Center(child: VsBrandMark(size: 48)),
+          const SizedBox(height: 28),
+          Text(
+            _isSignUp ? '新しい単語帳を、作ろう。' : 'おかえりなさい。',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.displaySmall?.copyWith(fontSize: 26),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            _isSignUp
+                ? '30秒で登録、登録語数に制限はありません'
+                : '続きからはじめましょう',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: VsTokens.inkMute,
+            ),
+          ),
+          const SizedBox(height: 20),
+          VsModeToggle<_LoginStep>(
+            selected: mode,
+            onChanged: onModeChanged,
+            options: const <VsModeOption<_LoginStep>>[
+              VsModeOption<_LoginStep>(
+                value: _LoginStep.signIn,
+                label: 'ログイン',
               ),
-              const SizedBox(height: 48),
-              const _HeroHeadline(),
-              const SizedBox(height: 14),
-              Text(
-                '登録した英単語を、AIが複数のSense・例文・\n視覚イメージに分解します。',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  height: 1.7,
-                  color: VsTokens.inkSoft,
-                ),
-              ),
-              const Spacer(),
-              _OAuthButton(
-                keyValue: 'login.provider.google',
-                label: 'Google で続ける',
-                icon: Icons.g_mobiledata,
-                onPressed: isSigningIn
-                    ? null
-                    : () => unawaited(
-                          loginCommand.signIn(AuthProvider.google),
-                        ),
-              ),
-              const SizedBox(height: 10),
-              const _OrDivider(),
-              const SizedBox(height: 10),
-              _PrimaryCta(
-                keyValue: 'login.provider.basic',
-                label: 'メールで続ける',
-                onPressed: isSigningIn
-                    ? null
-                    : () => unawaited(loginCommand.signIn(AuthProvider.basic)),
-                loading: isSigningIn,
-              ),
-              const SizedBox(height: 14),
-              if (failure != null)
-                _FailureBanner(message: failure.message.text)
-              else
-                const SizedBox(height: 28),
-              const SizedBox(height: 12),
-              Text(
-                '続行することで利用規約とプライバシーポリシーに同意したものとみなします。',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  fontSize: 10,
-                  height: 1.6,
-                  color: VsTokens.inkMute,
-                ),
+              VsModeOption<_LoginStep>(
+                value: _LoginStep.signUp,
+                label: '新規登録',
               ),
             ],
           ),
+          const SizedBox(height: 24),
+          const VsSectionLabel('EMAIL'),
+          const SizedBox(height: 8),
+          VsInputField(
+            key: const Key('login.email.field'),
+            controller: emailController,
+            autofocus: true,
+            enabled: !isSigningIn,
+            fontSize: 18,
+            keyboardType: TextInputType.emailAddress,
+            hint: 'you@example.com',
+          ),
+          const SizedBox(height: 18),
+          const VsSectionLabel('PASSWORD'),
+          const SizedBox(height: 8),
+          VsInputField(
+            key: const Key('login.password.field'),
+            controller: passwordController,
+            enabled: !isSigningIn,
+            fontSize: 18,
+            obscureText: true,
+            hint: '••••••••',
+            fontFamily: VsTokens.mono,
+          ),
+          if (_isSignUp) ...<Widget>[
+            const SizedBox(height: 4),
+            Text(
+              '8文字以上・英数字を含む',
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontSize: 10,
+                color: VsTokens.inkMute,
+              ),
+            ),
+          ],
+          if (_isSignUp) ...<Widget>[
+            const SizedBox(height: 18),
+            const _AgreementNotice(),
+          ],
+          const SizedBox(height: 28),
+          ElevatedButton(
+            key: _isSignUp
+                ? const Key('login.signup.submit')
+                : const Key('login.signin.submit'),
+            onPressed: isSigningIn ? null : onSubmit,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: VsTokens.ink,
+              foregroundColor: VsTokens.paper,
+              padding: const EdgeInsets.symmetric(vertical: 15),
+              shape: const RoundedRectangleBorder(
+                borderRadius:
+                    BorderRadius.all(Radius.circular(VsTokens.radiusMd)),
+              ),
+            ),
+            child: isSigningIn
+                ? const Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: VsSpinner(size: 14, color: VsTokens.paper),
+                      ),
+                      SizedBox(width: 8),
+                      Text('認証中...'),
+                    ],
+                  )
+                : Text(_isSignUp ? 'アカウントを作成' : 'ログイン'),
+          ),
+          if (failure != null) ...<Widget>[
+            const SizedBox(height: 14),
+            _FailureBanner(message: failure!.message.text),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _VerifyStep extends StatelessWidget {
+  const _VerifyStep({
+    required this.email,
+    required this.verifying,
+    required this.onBack,
+    required this.onCompleted,
+    required this.onResend,
+    super.key,
+  });
+
+  final String email;
+  final bool verifying;
+  final VoidCallback onBack;
+  final void Function(String) onCompleted;
+  final VoidCallback onResend;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(28, 12, 28, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: onBack,
+              icon: const Icon(Icons.chevron_left, size: 18),
+              label: const Text('戻る'),
+              style: TextButton.styleFrom(
+                foregroundColor: VsTokens.inkSoft,
+                padding: EdgeInsets.zero,
+                textStyle: const TextStyle(
+                  fontFamily: VsTokens.sans,
+                  fontSize: 13,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          const Center(child: VsBrandMark(size: 48)),
+          const SizedBox(height: 28),
+          Text(
+            '確認コードを入力',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.displaySmall?.copyWith(fontSize: 24),
+          ),
+          const SizedBox(height: 8),
+          Text.rich(
+            TextSpan(
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: VsTokens.inkSoft,
+                height: 1.6,
+              ),
+              children: <InlineSpan>[
+                TextSpan(
+                  text: email,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w500,
+                    color: VsTokens.ink,
+                  ),
+                ),
+                const TextSpan(text: ' に\n6桁のコードを送信しました'),
+              ],
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 28),
+          VsOtpField(
+            key: const Key('login.verify.code'),
+            onCompleted: onCompleted,
+          ),
+          const SizedBox(height: 20),
+          if (verifying)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                const VsSpinner(size: 14),
+                const SizedBox(width: 8),
+                Text(
+                  'コードを確認中...',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: VsTokens.inkSoft,
+                  ),
+                ),
+              ],
+            )
+          else ...<Widget>[
+            Text(
+              '届いていませんか？',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: VsTokens.inkMute,
+              ),
+            ),
+            TextButton(
+              onPressed: onResend,
+              child: const Text('コードを再送信'),
+            ),
+          ],
+          const Spacer(),
+          const _VerifyInfoBox(),
+        ],
+      ),
+    );
+  }
+}
+
+class _DoneStep extends StatelessWidget {
+  const _DoneStep({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(28),
+      child: Center(
+        child: Column(
+          key: const Key('login.done'),
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            TweenAnimationBuilder<double>(
+              duration: const Duration(milliseconds: 350),
+              tween: Tween<double>(begin: 0.96, end: 1),
+              curve: Curves.easeOut,
+              builder: (context, value, child) => Transform.scale(
+                scale: value,
+                child: Opacity(opacity: value, child: child),
+              ),
+              child: Stack(
+                alignment: Alignment.bottomRight,
+                children: <Widget>[
+                  const VsBrandMark(size: 80),
+                  Container(
+                    width: 28,
+                    height: 28,
+                    decoration: BoxDecoration(
+                      color: VsTokens.ok,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: VsTokens.paper, width: 2),
+                    ),
+                    child: const Icon(
+                      Icons.check,
+                      size: 14,
+                      color: VsTokens.paper,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'ようこそ、vocastock へ。',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.displaySmall?.copyWith(
+                fontSize: 22,
+                letterSpacing: -0.4,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '最初の単語を登録しましょう',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: VsTokens.inkSoft,
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -142,10 +603,7 @@ class _HeroHeadline extends StatelessWidget {
         ),
         children: <InlineSpan>[
           TextSpan(text: '多義の深さに、\n'),
-          TextSpan(
-            text: '画像',
-            style: TextStyle(color: VsTokens.accent),
-          ),
+          TextSpan(text: '画像', style: TextStyle(color: VsTokens.accent)),
           TextSpan(text: 'を添えて。'),
         ],
       ),
@@ -227,13 +685,11 @@ class _PrimaryCta extends StatelessWidget {
     required this.keyValue,
     required this.label,
     required this.onPressed,
-    this.loading = false,
   });
 
   final String keyValue;
   final String label;
   final VoidCallback? onPressed;
-  final bool loading;
 
   @override
   Widget build(BuildContext context) {
@@ -245,9 +701,6 @@ class _PrimaryCta extends StatelessWidget {
         style: ElevatedButton.styleFrom(
           backgroundColor: VsTokens.ink,
           foregroundColor: VsTokens.paper,
-          disabledBackgroundColor: VsTokens.inkMute,
-          disabledForegroundColor: VsTokens.paperSoft,
-          elevation: 0,
           padding: const EdgeInsets.symmetric(vertical: 15),
           shape: const RoundedRectangleBorder(
             borderRadius:
@@ -260,13 +713,7 @@ class _PrimaryCta extends StatelessWidget {
             letterSpacing: 0.3,
           ),
         ),
-        child: loading
-            ? const SizedBox(
-                width: 16,
-                height: 16,
-                child: VsSpinner(color: VsTokens.paper),
-              )
-            : Text(label),
+        child: Text(label),
       ),
     );
   }
@@ -294,6 +741,87 @@ class _FailureBanner extends StatelessWidget {
           height: 1.5,
           color: VsTokens.err,
         ),
+      ),
+    );
+  }
+}
+
+class _AgreementNotice extends StatelessWidget {
+  const _AgreementNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          width: 18,
+          height: 18,
+          decoration: BoxDecoration(
+            color: VsTokens.ink,
+            borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+          ),
+          child: const Icon(Icons.check, size: 12, color: VsTokens.paper),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Text(
+            '学習進捗を端末間で同期します。メールアドレスは '
+            'Learner.identifier として正規化されます。',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  fontSize: 11,
+                  color: VsTokens.inkSoft,
+                  height: 1.6,
+                ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _VerifyInfoBox extends StatelessWidget {
+  const _VerifyInfoBox();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: VsTokens.paperSoft,
+        border: Border.all(color: VsTokens.inkHair),
+        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+      ),
+      child: const Row(
+        children: <Widget>[
+          Icon(Icons.schedule_outlined, size: 14, color: VsTokens.inkMute),
+          SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'コード有効期限 10 分',
+                  style: TextStyle(
+                    fontFamily: VsTokens.sans,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w500,
+                    color: VsTokens.ink,
+                  ),
+                ),
+                SizedBox(height: 2),
+                Text(
+                  'EmailVerificationStatus: pending',
+                  style: TextStyle(
+                    fontFamily: VsTokens.mono,
+                    fontSize: 10,
+                    color: VsTokens.inkSoft,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/applications/mobile/lib/src/presentation/auth/session_resolving_screen.dart
+++ b/applications/mobile/lib/src/presentation/auth/session_resolving_screen.dart
@@ -11,8 +11,9 @@ import '../theme/widgets/vs_wordmark.dart';
 
 /// Spec 013 canonical `SessionResolving` screen (Auth route group).
 ///
-/// Always renders as `loading`. Displays the current handoff stage label as
-/// progress hint; does not expose actor reference itself.
+/// Visual reference: `screens.jsx` running / loading pattern. A compact
+/// wordmark at the top, a centered spinner with a Mincho stage label and a
+/// muted sans helper, and a cancel text button at the foot.
 class SessionResolvingScreen extends ConsumerWidget {
   const SessionResolvingScreen({super.key});
 
@@ -32,22 +33,21 @@ class SessionResolvingScreen extends ConsumerWidget {
       backgroundColor: VsTokens.paper,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
+          padding: const EdgeInsets.fromLTRB(24, 20, 24, 20),
           child: Column(
             children: <Widget>[
-              const SizedBox(height: 32),
               const Align(
                 alignment: Alignment.centerLeft,
-                child: VsWordmark(size: 15),
+                child: VsWordmark(size: 13),
               ),
               const Spacer(),
-              const VsSpinner(size: 20),
-              const SizedBox(height: 20),
+              const VsSpinner(size: 24),
+              const SizedBox(height: 24),
               Text(
                 stageLabel,
                 key: const Key('session-resolving.stage'),
                 textAlign: TextAlign.center,
-                style: theme.textTheme.titleMedium,
+                style: theme.textTheme.headlineSmall,
               ),
               const SizedBox(height: 6),
               Text(
@@ -61,9 +61,12 @@ class SessionResolvingScreen extends ConsumerWidget {
               TextButton(
                 key: const Key('session-resolving.cancel'),
                 onPressed: () => unawaited(logoutCommand.signOut()),
+                style: TextButton.styleFrom(
+                  foregroundColor: VsTokens.inkMute,
+                ),
                 child: const Text('キャンセル'),
               ),
-              const SizedBox(height: 24),
+              const SizedBox(height: 8),
             ],
           ),
         ),

--- a/applications/mobile/lib/src/presentation/catalog/explanation_generating_screen.dart
+++ b/applications/mobile/lib/src/presentation/catalog/explanation_generating_screen.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../router/router.dart';
+import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_chip.dart';
+import '../theme/widgets/vs_progress.dart';
+import '../theme/widgets/vs_section_label.dart';
+import '../theme/widgets/vs_skeleton.dart';
+import '../theme/widgets/vs_stage_step.dart';
+
+/// Mirror of `screens.jsx` `VSAddGenerating`.
+///
+/// Plays through five generation stages (normalize → sense extraction →
+/// frequency/sophistication → examples → etymology), each lasting 900ms.
+/// A skeleton preview hints at the completed Explanation. When the last
+/// stage finishes the screen auto-advances to `/catalog` after a 700ms
+/// pause.
+class ExplanationGeneratingScreen extends StatefulWidget {
+  const ExplanationGeneratingScreen({required this.text, super.key});
+
+  final String text;
+
+  @override
+  State<ExplanationGeneratingScreen> createState() =>
+      _ExplanationGeneratingScreenState();
+}
+
+class _ExplanationGeneratingScreenState
+    extends State<ExplanationGeneratingScreen> {
+  static const List<_Stage> _stages = <_Stage>[
+    _Stage(label: '正規化', sub: '表記ゆれを判定しています'),
+    _Stage(label: 'Sense 抽出', sub: '意味単位を検出しています'),
+    _Stage(
+      label: 'Frequency / Sophistication',
+      sub: '頻出度と難度を評価中',
+    ),
+    _Stage(label: '例文生成', sub: 'Sense ごとに例文を構成'),
+    _Stage(label: '語源・類似表現', sub: '補助情報を組み立てています'),
+  ];
+
+  int _stageIdx = 0;
+  bool _done = false;
+  Timer? _tickTimer;
+  Timer? _exitTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _tickTimer = Timer.periodic(const Duration(milliseconds: 900), _onTick);
+  }
+
+  void _onTick(Timer timer) {
+    if (!mounted) return;
+    if (_stageIdx < _stages.length - 1) {
+      setState(() => _stageIdx += 1);
+    } else if (!_done) {
+      setState(() => _done = true);
+      timer.cancel();
+      _exitTimer = Timer(const Duration(milliseconds: 700), () {
+        if (!mounted) return;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          GoRouter.of(context).go(AppRoutes.catalog);
+        });
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _tickTimer?.cancel();
+    _exitTimer?.cancel();
+    super.dispose();
+  }
+
+  double get _progress =>
+      _done ? 1 : (_stageIdx + 0.5) / _stages.length;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: VsTokens.paper,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  TextButton.icon(
+                    onPressed: () => context.go(AppRoutes.catalog),
+                    icon: const Icon(Icons.chevron_left, size: 18),
+                    label: const Text('戻る'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: VsTokens.inkSoft,
+                      padding: EdgeInsets.zero,
+                    ),
+                  ),
+                  const VsChip(
+                    label: '生成中',
+                    tone: VsChipTone.accent,
+                    icon: Icon(Icons.circle, size: 8),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              const VsSectionLabel(
+                'ExplanationGenerationStatus: running',
+              ),
+              const SizedBox(height: 6),
+              Text(
+                widget.text,
+                key: const Key('generating.text'),
+                style: const TextStyle(
+                  fontFamily: VsTokens.serif,
+                  fontSize: 44,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: -1,
+                  height: 1,
+                  color: VsTokens.ink,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '/…/',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontFamily: VsTokens.mono,
+                  fontSize: 12,
+                  color: VsTokens.inkMute,
+                ),
+              ),
+              const SizedBox(height: 24),
+              VsProgress(value: _progress),
+              const SizedBox(height: 24),
+              Column(
+                children: <Widget>[
+                  for (var i = 0; i < _stages.length; i++)
+                    VsStageStep(
+                      state: _stateFor(i),
+                      label: _stages[i].label,
+                      sub: _stages[i].sub,
+                      isLast: i == _stages.length - 1,
+                    ),
+                ],
+              ),
+              const SizedBox(height: 28),
+              const _SkeletonPreview(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // end build
+
+  VsStageState _stateFor(int index) {
+    if (_done) return VsStageState.done;
+    if (index < _stageIdx) return VsStageState.done;
+    if (index == _stageIdx) return VsStageState.active;
+    return VsStageState.pending;
+  }
+}
+
+@immutable
+class _Stage {
+  const _Stage({required this.label, required this.sub});
+  final String label;
+  final String sub;
+}
+
+class _SkeletonPreview extends StatelessWidget {
+  const _SkeletonPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: VsTokens.paperSoft,
+        border: Border.all(color: VsTokens.inkHair),
+        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+      ),
+      child: const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          VsSectionLabel('プレビュー（完了時に表示）'),
+          SizedBox(height: 12),
+          VsSkeleton(width: 180, height: 14),
+          SizedBox(height: 8),
+          VsSkeleton(height: 8),
+          SizedBox(height: 4),
+          VsSkeleton(width: 280, height: 8),
+          SizedBox(height: 12),
+          Row(
+            children: <Widget>[
+              VsSkeleton(width: 44, height: 16, radius: 8),
+              SizedBox(width: 6),
+              VsSkeleton(width: 52, height: 16, radius: 8),
+              SizedBox(width: 6),
+              VsSkeleton(width: 40, height: 16, radius: 8),
+            ],
+          ),
+          SizedBox(height: 14),
+          Text(
+            '要件：中間生成結果は表示せず、完了時のみ切り替わります。',
+            style: TextStyle(
+              fontFamily: VsTokens.sans,
+              fontSize: 10,
+              fontStyle: FontStyle.italic,
+              color: VsTokens.inkMute,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/catalog/vocabulary_catalog_screen.dart
+++ b/applications/mobile/lib/src/presentation/catalog/vocabulary_catalog_screen.dart
@@ -8,6 +8,7 @@ import '../../domain/status/image_generation_status.dart';
 import '../../domain/vocabulary/vocabulary_expression_entry.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_bottom_tab_bar.dart';
 import '../theme/widgets/vs_chip.dart';
 import '../theme/widgets/vs_icon_circle.dart';
 import '../theme/widgets/vs_illustration_panel.dart';
@@ -48,6 +49,7 @@ class _VocabularyCatalogScreenState
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
+      bottomNavigationBar: const VsBottomTabBar(),
       floatingActionButton: FloatingActionButton(
         key: const Key('catalog.add'),
         onPressed: () => context.go(AppRoutes.registration),
@@ -66,19 +68,9 @@ class _VocabularyCatalogScreenState
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: <Widget>[
                       const VsWordmark(size: 15),
-                      Row(
-                        children: <Widget>[
-                          VsIconCircle(
-                            key: const Key('catalog.proficiency'),
-                            icon: Icons.layers_outlined,
-                            onTap: () => context.go(AppRoutes.proficiency),
-                          ),
-                          const SizedBox(width: 8),
-                          VsIconCircle(
-                            icon: Icons.search,
-                            onTap: () {},
-                          ),
-                        ],
+                      VsIconCircle(
+                        icon: Icons.search,
+                        onTap: () {},
                       ),
                     ],
                   ),

--- a/applications/mobile/lib/src/presentation/catalog/vocabulary_catalog_screen.dart
+++ b/applications/mobile/lib/src/presentation/catalog/vocabulary_catalog_screen.dart
@@ -66,9 +66,19 @@ class _VocabularyCatalogScreenState
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: <Widget>[
                       const VsWordmark(size: 15),
-                      VsIconCircle(
-                        icon: Icons.search,
-                        onTap: () {},
+                      Row(
+                        children: <Widget>[
+                          VsIconCircle(
+                            key: const Key('catalog.proficiency'),
+                            icon: Icons.layers_outlined,
+                            onTap: () => context.go(AppRoutes.proficiency),
+                          ),
+                          const SizedBox(width: 8),
+                          VsIconCircle(
+                            icon: Icons.search,
+                            onTap: () {},
+                          ),
+                        ],
                       ),
                     ],
                   ),

--- a/applications/mobile/lib/src/presentation/catalog/vocabulary_catalog_screen.dart
+++ b/applications/mobile/lib/src/presentation/catalog/vocabulary_catalog_screen.dart
@@ -8,7 +8,6 @@ import '../../domain/status/image_generation_status.dart';
 import '../../domain/vocabulary/vocabulary_expression_entry.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
-import '../theme/widgets/vs_bottom_tab_bar.dart';
 import '../theme/widgets/vs_chip.dart';
 import '../theme/widgets/vs_icon_circle.dart';
 import '../theme/widgets/vs_illustration_panel.dart';
@@ -49,7 +48,6 @@ class _VocabularyCatalogScreenState
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
-      bottomNavigationBar: const VsBottomTabBar(),
       floatingActionButton: FloatingActionButton(
         key: const Key('catalog.add'),
         onPressed: () => context.go(AppRoutes.registration),

--- a/applications/mobile/lib/src/presentation/catalog/vocabulary_catalog_screen.dart
+++ b/applications/mobile/lib/src/presentation/catalog/vocabulary_catalog_screen.dart
@@ -9,59 +9,199 @@ import '../../domain/vocabulary/vocabulary_expression_entry.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
 import '../theme/widgets/vs_chip.dart';
-import '../theme/widgets/vs_screen_scaffold.dart';
+import '../theme/widgets/vs_icon_circle.dart';
+import '../theme/widgets/vs_illustration_panel.dart';
+import '../theme/widgets/vs_pill_tabs.dart';
 import '../theme/widgets/vs_spinner.dart';
+import '../theme/widgets/vs_wordmark.dart';
 
 /// Spec 013 canonical `VocabularyCatalog` screen.
 ///
-/// Renders summary-only entries; completed explanation / image bodies are
-/// navigated to via `VocabularyExpressionDetail` (Phase 4).
-class VocabularyCatalogScreen extends ConsumerWidget {
+/// Visual reference: `screens.jsx` `VSHome`. Wordmark header + search icon,
+/// Mincho 30 title, learner sub-line, pill filter tabs, and paper-toned
+/// entry cards with illustration thumbs and status chips. Completed
+/// explanation / image bodies remain navigable via
+/// `VocabularyExpressionDetail` (spec 013 source binding).
+class VocabularyCatalogScreen extends ConsumerStatefulWidget {
   const VocabularyCatalogScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<VocabularyCatalogScreen> createState() =>
+      _VocabularyCatalogScreenState();
+}
+
+enum _CatalogFilter { all, active, running, failed }
+
+class _VocabularyCatalogScreenState
+    extends ConsumerState<VocabularyCatalogScreen> {
+  _CatalogFilter _filter = _CatalogFilter.all;
+
+  @override
+  Widget build(BuildContext context) {
     final catalogAsync = ref.watch(vocabularyCatalogStreamProvider);
     final catalog = catalogAsync.value ??
         VocabularyCatalog(const <VocabularyExpressionEntry>[]);
     final theme = Theme.of(context);
 
-    return VsScreenScaffold(
-      eyebrow: 'VOCABULARY',
-      title: '単語帳',
-      caption: catalog.entries.isEmpty
-          ? 'まだ登録されていません'
-          : '登録 ${catalog.entries.length} 件',
+    final counts = _deriveCounts(catalog.entries);
+    final shown = _applyFilter(catalog.entries, _filter);
+
+    return Scaffold(
+      backgroundColor: VsTokens.paper,
       floatingActionButton: FloatingActionButton(
         key: const Key('catalog.add'),
         onPressed: () => context.go(AppRoutes.registration),
         child: const Icon(Icons.add),
       ),
-      body: catalog.isEmpty
-          ? Center(
-              child: Padding(
-                padding: const EdgeInsets.all(32),
-                child: Text(
-                  '語彙がまだ登録されていません',
-                  key: const Key('catalog.empty-placeholder'),
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: VsTokens.inkMute,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      const VsWordmark(size: 15),
+                      VsIconCircle(
+                        icon: Icons.search,
+                        onTap: () {},
+                      ),
+                    ],
                   ),
-                ),
+                  const SizedBox(height: 14),
+                  Text('単語帳', style: theme.textTheme.displaySmall),
+                  const SizedBox(height: 4),
+                  Text(
+                    '登録 ${catalog.entries.length} 件',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: VsTokens.inkMute,
+                    ),
+                  ),
+                ],
               ),
-            )
-          : ListView.separated(
-              key: const Key('catalog.list'),
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 120),
-              itemCount: catalog.entries.length,
-              separatorBuilder: (_, _) => const SizedBox(height: 8),
-              itemBuilder: (_, index) {
-                final entry = catalog.entries[index];
-                return _CatalogEntryCard(entry: entry);
-              },
             ),
+            const Divider(thickness: 0.5, height: 0.5),
+            const SizedBox(height: 12),
+            VsPillTabs<_CatalogFilter>(
+              selected: _filter,
+              onChanged: (value) => setState(() => _filter = value),
+              tabs: <VsPillTab<_CatalogFilter>>[
+                VsPillTab<_CatalogFilter>(
+                  value: _CatalogFilter.all,
+                  label: 'すべて',
+                  count: counts[_CatalogFilter.all],
+                ),
+                VsPillTab<_CatalogFilter>(
+                  value: _CatalogFilter.active,
+                  label: '完了',
+                  count: counts[_CatalogFilter.active],
+                ),
+                VsPillTab<_CatalogFilter>(
+                  value: _CatalogFilter.running,
+                  label: '生成中',
+                  count: counts[_CatalogFilter.running],
+                ),
+                VsPillTab<_CatalogFilter>(
+                  value: _CatalogFilter.failed,
+                  label: '失敗',
+                  count: counts[_CatalogFilter.failed],
+                ),
+              ],
+            ),
+            Expanded(
+              child: catalog.isEmpty
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(32),
+                        child: Text(
+                          '語彙がまだ登録されていません',
+                          key: const Key('catalog.empty-placeholder'),
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: VsTokens.inkMute,
+                          ),
+                        ),
+                      ),
+                    )
+                  : ListView.separated(
+                      key: const Key('catalog.list'),
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 120),
+                      itemCount: shown.length,
+                      separatorBuilder: (_, _) => const SizedBox(height: 8),
+                      itemBuilder: (_, index) {
+                        final entry = shown[index];
+                        return _CatalogEntryCard(entry: entry);
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
     );
+  }
+
+  static Map<_CatalogFilter, int> _deriveCounts(
+    List<VocabularyExpressionEntry> entries,
+  ) {
+    var active = 0;
+    var running = 0;
+    var failed = 0;
+    for (final entry in entries) {
+      switch (entry.explanationStatus) {
+        case ExplanationGenerationStatus.succeeded:
+          active += 1;
+        case ExplanationGenerationStatus.pending:
+        case ExplanationGenerationStatus.running:
+        case ExplanationGenerationStatus.retryScheduled:
+          running += 1;
+        case ExplanationGenerationStatus.timedOut:
+        case ExplanationGenerationStatus.failedFinal:
+        case ExplanationGenerationStatus.deadLettered:
+          failed += 1;
+      }
+    }
+    return <_CatalogFilter, int>{
+      _CatalogFilter.all: entries.length,
+      _CatalogFilter.active: active,
+      _CatalogFilter.running: running,
+      _CatalogFilter.failed: failed,
+    };
+  }
+
+  static List<VocabularyExpressionEntry> _applyFilter(
+    List<VocabularyExpressionEntry> entries,
+    _CatalogFilter filter,
+  ) {
+    return switch (filter) {
+      _CatalogFilter.all => entries,
+      _CatalogFilter.active => entries
+          .where(
+            (e) => e.explanationStatus == ExplanationGenerationStatus.succeeded,
+          )
+          .toList(growable: false),
+      _CatalogFilter.running => entries
+          .where(
+            (e) =>
+                e.explanationStatus == ExplanationGenerationStatus.pending ||
+                e.explanationStatus == ExplanationGenerationStatus.running ||
+                e.explanationStatus ==
+                    ExplanationGenerationStatus.retryScheduled,
+          )
+          .toList(growable: false),
+      _CatalogFilter.failed => entries
+          .where(
+            (e) =>
+                e.explanationStatus == ExplanationGenerationStatus.timedOut ||
+                e.explanationStatus ==
+                    ExplanationGenerationStatus.failedFinal ||
+                e.explanationStatus == ExplanationGenerationStatus.deadLettered,
+          )
+          .toList(growable: false),
+    };
   }
 }
 
@@ -158,27 +298,27 @@ class _CatalogEntryCard extends StatelessWidget {
 
 class _Thumbnail extends StatelessWidget {
   const _Thumbnail({required this.entry});
-
   final VocabularyExpressionEntry entry;
 
   @override
   Widget build(BuildContext context) {
-    Widget child;
+    const size = VsTokens.thumbnailSize;
     if (entry.hasCompletedImage) {
-      child = Center(
-        child: Text(
-          entry.text.length >= 2
+      return SizedBox(
+        width: size,
+        height: size,
+        child: VsIllustrationPanel(
+          seed: entry.identifier.value.length,
+          label: entry.text.length >= 2
               ? entry.text.substring(0, 2)
               : entry.text,
-          style: const TextStyle(
-            fontFamily: VsTokens.serif,
-            fontSize: 20,
-            fontWeight: FontWeight.w600,
-            color: VsTokens.accentDeep,
-          ),
+          height: size,
         ),
       );
-    } else if (entry.imageStatus == ImageGenerationStatus.running ||
+    }
+
+    Widget child;
+    if (entry.imageStatus == ImageGenerationStatus.running ||
         entry.imageStatus == ImageGenerationStatus.retryScheduled) {
       child = const Center(child: VsSpinner(size: 14));
     } else if (entry.imageStatus == ImageGenerationStatus.failedFinal ||
@@ -193,8 +333,8 @@ class _Thumbnail extends StatelessWidget {
     }
 
     return Container(
-      width: VsTokens.thumbnailSize,
-      height: VsTokens.thumbnailSize,
+      width: size,
+      height: size,
       decoration: BoxDecoration(
         color: VsTokens.paperDeep,
         borderRadius: BorderRadius.circular(VsTokens.radiusSm),

--- a/applications/mobile/lib/src/presentation/catalog/vocabulary_registration_screen.dart
+++ b/applications/mobile/lib/src/presentation/catalog/vocabulary_registration_screen.dart
@@ -58,7 +58,10 @@ class _VocabularyRegistrationScreenState
     });
     switch (response) {
       case CommandResponseAccepted():
-        context.go(AppRoutes.catalog);
+        context.go(
+          AppRoutes.registrationGenerating,
+          extra: _textController.text.trim(),
+        );
       case CommandResponseRejected(:final message):
         setState(() {
           _errorText = message.text;

--- a/applications/mobile/lib/src/presentation/catalog/vocabulary_registration_screen.dart
+++ b/applications/mobile/lib/src/presentation/catalog/vocabulary_registration_screen.dart
@@ -8,15 +8,16 @@ import '../../application/envelope/command_response_envelope.dart';
 import '../../domain/identifier/identifier.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_input_field.dart';
+import '../theme/widgets/vs_section_label.dart';
 import '../theme/widgets/vs_spinner.dart';
-import '../theme/widgets/vs_wordmark.dart';
 
 /// Spec 013 canonical `VocabularyRegistration` screen.
 ///
-/// UI state:
-///  - `statusOnly` while the form is idle.
-///  - `loading` while the command is in flight.
-///  - `retryableFailure` when the backend rejects the submission.
+/// Visual reference: `screens.jsx` `VSAddInput`. Top chrome is キャンセル /
+/// 新規登録 / 登録 (register submit). Body is a Mincho 34 single-line field
+/// with a hint, a preset-detail radio card, and an accent-soft info box
+/// describing asynchronous generation.
 class VocabularyRegistrationScreen extends ConsumerStatefulWidget {
   const VocabularyRegistrationScreen({super.key});
 
@@ -25,12 +26,15 @@ class VocabularyRegistrationScreen extends ConsumerStatefulWidget {
       _VocabularyRegistrationScreenState();
 }
 
+enum _DetailPreset { standard, rich, minimal }
+
 class _VocabularyRegistrationScreenState
     extends ConsumerState<VocabularyRegistrationScreen> {
   final TextEditingController _textController = TextEditingController();
   static const Uuid _uuidGenerator = Uuid();
   bool _submitting = false;
   String? _errorText;
+  _DetailPreset _preset = _DetailPreset.standard;
 
   @override
   void dispose() {
@@ -80,79 +84,252 @@ class _VocabularyRegistrationScreenState
                     onPressed: _submitting
                         ? null
                         : () => context.go(AppRoutes.catalog),
+                    style: TextButton.styleFrom(
+                      foregroundColor: VsTokens.inkSoft,
+                    ),
                     child: const Text('キャンセル'),
                   ),
-                  const VsWordmark(),
+                  Text(
+                    '新規登録',
+                    style: theme.textTheme.titleMedium,
+                  ),
                   TextButton(
                     onPressed: _submitting ? null : _submit,
+                    style: TextButton.styleFrom(
+                      foregroundColor: VsTokens.accent,
+                    ),
                     child: const Text('登録'),
                   ),
                 ],
               ),
             ),
-            const Divider(height: 0.5, thickness: 0.5),
+            const Divider(thickness: 0.5, height: 0.5),
             Expanded(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(24, 32, 24, 32),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: <Widget>[
+                  const VsSectionLabel('ENGLISH EXPRESSION'),
+                  const SizedBox(height: 12),
+                  VsInputField(
+                    key: const Key('registration.text-field'),
+                    controller: _textController,
+                    enabled: !_submitting,
+                    autofocus: true,
+                    onChanged: (_) => setState(() {}),
+                    hint: 'serendipity',
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '単語 / 連語どちらも可。小文字・原形での登録を推奨。 '
+                    '重複は学習者ごとの正規化テキストで判定。',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: VsTokens.inkMute,
+                      height: 1.5,
+                    ),
+                  ),
+                  const SizedBox(height: 40),
+                  const VsSectionLabel('AI生成の詳細度'),
+                  const SizedBox(height: 10),
+                  _PresetCard(
+                    selected: _preset,
+                    onChanged: (value) =>
+                        setState(() => _preset = value),
+                  ),
+                  const SizedBox(height: 24),
+                  const _InfoBox(),
+                  if (_errorText != null) ...<Widget>[
+                    const SizedBox(height: 16),
                     Text(
-                      'ENGLISH EXPRESSION',
-                      style: theme.textTheme.labelMedium,
-                    ),
-                    const SizedBox(height: 12),
-                    TextField(
-                      key: const Key('registration.text-field'),
-                      controller: _textController,
-                      enabled: !_submitting,
-                      autofocus: true,
-                      onChanged: (_) => setState(() {}),
-                      style: const TextStyle(
-                        fontFamily: VsTokens.serif,
-                        fontSize: 34,
-                        fontWeight: FontWeight.w600,
-                        color: VsTokens.ink,
-                      ),
-                      decoration: const InputDecoration(
-                        hintText: 'serendipity',
+                      _errorText!,
+                      key: const Key('registration.error-message'),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: VsTokens.err,
                       ),
                     ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '単語 / 連語どちらも可。小文字・原形での登録を推奨。',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: VsTokens.inkMute,
-                      ),
-                    ),
-                    const SizedBox(height: 40),
-                    ElevatedButton(
-                      key: const Key('registration.submit'),
-                      onPressed: _submitting ? null : _submit,
-                      child: _submitting
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: VsSpinner(color: VsTokens.paper),
-                            )
-                          : const Text('この表現を登録'),
-                    ),
-                    if (_errorText != null) ...<Widget>[
-                      const SizedBox(height: 16),
-                      Text(
-                        _errorText!,
-                        key: const Key('registration.error-message'),
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: VsTokens.err,
-                        ),
-                      ),
-                    ],
+                  ],
                   ],
                 ),
               ),
             ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 0, 24, 20),
+              child: ElevatedButton(
+                key: const Key('registration.submit'),
+                onPressed: _submitting ? null : _submit,
+                child: _submitting
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: VsSpinner(color: VsTokens.paper),
+                      )
+                    : const Text('この表現を登録'),
+              ),
+            ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _PresetOption {
+  const _PresetOption({
+    required this.value,
+    required this.label,
+    required this.description,
+  });
+
+  final _DetailPreset value;
+  final String label;
+  final String description;
+}
+
+const List<_PresetOption> _presetOptions = <_PresetOption>[
+  _PresetOption(
+    value: _DetailPreset.standard,
+    label: '標準',
+    description: 'Sense・発音・例文・コロケーション',
+  ),
+  _PresetOption(
+    value: _DetailPreset.rich,
+    label: '詳細',
+    description: '+ 類似表現・語源・使い分け',
+  ),
+  _PresetOption(
+    value: _DetailPreset.minimal,
+    label: '最小',
+    description: '代表 Sense のみ（素早く）',
+  ),
+];
+
+class _PresetCard extends StatelessWidget {
+  const _PresetCard({required this.selected, required this.onChanged});
+
+  final _DetailPreset selected;
+  final ValueChanged<_DetailPreset> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: VsTokens.paperSoft,
+        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+        border: Border.all(color: VsTokens.inkHair),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: <Widget>[
+          for (var index = 0; index < _presetOptions.length; index++)
+            _PresetRow(
+              option: _presetOptions[index],
+              isLast: index == _presetOptions.length - 1,
+              isSelected: _presetOptions[index].value == selected,
+              onTap: () => onChanged(_presetOptions[index].value),
+              theme: theme,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PresetRow extends StatelessWidget {
+  const _PresetRow({
+    required this.option,
+    required this.isLast,
+    required this.isSelected,
+    required this.onTap,
+    required this.theme,
+  });
+
+  final _PresetOption option;
+  final bool isLast;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: isLast ? Colors.transparent : VsTokens.inkHair,
+              width: 0.5,
+            ),
+          ),
+        ),
+        child: Row(
+          children: <Widget>[
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    option.label,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      fontFamily: VsTokens.sans,
+                      fontSize: 14,
+                      fontWeight:
+                          isSelected ? FontWeight.w600 : FontWeight.w400,
+                      color: VsTokens.ink,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    option.description,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontSize: 11,
+                      color: VsTokens.inkMute,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (isSelected)
+              const Icon(Icons.check, size: 16, color: VsTokens.accent),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoBox extends StatelessWidget {
+  const _InfoBox();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: VsTokens.accentSoft,
+        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+      ),
+      child: const Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(Icons.auto_awesome, size: 16, color: VsTokens.accentDeep),
+          SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              '解説生成は非同期で 10〜30 秒ほど。完了時に通知します。',
+              style: TextStyle(
+                fontFamily: VsTokens.sans,
+                fontSize: 11,
+                height: 1.5,
+                color: VsTokens.accentDeep,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/applications/mobile/lib/src/presentation/detail/detail_layout_preference.dart
+++ b/applications/mobile/lib/src/presentation/detail/detail_layout_preference.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Visual layout preference for the Explanation detail screen, mirroring
+/// the three variants from `screens.jsx` (`VSDetailTab`, `VSDetailPage`,
+/// `VSDetailCards`). Persisted only in-memory; a future settings-store
+/// integration can swap this for a hydrated notifier.
+enum DetailLayout { tab, page, cards }
+
+extension DetailLayoutLabel on DetailLayout {
+  String get label {
+    return switch (this) {
+      DetailLayout.tab => 'タブ',
+      DetailLayout.page => 'ページ',
+      DetailLayout.cards => 'カード',
+    };
+  }
+}
+
+class DetailLayoutNotifier extends Notifier<DetailLayout> {
+  @override
+  DetailLayout build() => DetailLayout.tab;
+
+  // Expose a method, not a setter, so the call site reads naturally
+  // (`ref.read(provider.notifier).set(value)`) in places where an explicit
+  // verb is clearer than an assignment.
+  // ignore: use_setters_to_change_properties
+  void set(DetailLayout layout) => state = layout;
+}
+
+final detailLayoutProvider =
+    NotifierProvider<DetailLayoutNotifier, DetailLayout>(
+  DetailLayoutNotifier.new,
+);

--- a/applications/mobile/lib/src/presentation/detail/explanation_detail_screen.dart
+++ b/applications/mobile/lib/src/presentation/detail/explanation_detail_screen.dart
@@ -5,14 +5,17 @@ import 'package:go_router/go_router.dart';
 import '../../app_bindings.dart';
 import '../../domain/identifier/identifier.dart';
 import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_section_label.dart';
 import '../theme/widgets/vs_skeleton.dart';
+import '../theme/widgets/vs_wordmark.dart';
 
 /// Spec 013 canonical `ExplanationDetail` screen.
 ///
-/// `allowsCompletedPayload = true`: renders only completed payload returned
-/// by the reader. A null response means the explanation is no longer
-/// completed (stale read or regeneration in flight), in which case the
-/// screen routes back without ever showing a provisional body.
+/// Visual reference: `screens.jsx` `VSDetail` sense body. The completed
+/// explanation payload is rendered as a dictionary-style page: a Mincho
+/// body paragraph and hairline-separated example sentences in serif italic.
+/// When the reader returns null the screen pops back without flashing
+/// provisional content (spec 013 generation-result-visibility).
 class ExplanationDetailScreen extends ConsumerWidget {
   const ExplanationDetailScreen({required this.identifier, super.key});
 
@@ -25,83 +28,178 @@ class ExplanationDetailScreen extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.chevron_left),
-          onPressed: () => context.pop(),
-        ),
-        title: const Text('解説'),
-      ),
-      body: detailAsync.when(
-        data: (detail) {
-          if (detail == null) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (context.mounted) context.pop();
-            });
-            return const SizedBox.shrink();
-          }
-          return ListView(
-            padding: const EdgeInsets.fromLTRB(24, 8, 24, 32),
-            children: <Widget>[
-              Text(
-                detail.body,
-                key: const Key('explanation-detail.body'),
-                style: theme.textTheme.bodyLarge,
-              ),
-              const SizedBox(height: 24),
-              const Divider(),
-              const SizedBox(height: 16),
-              Text(
-                '例文',
-                style: theme.textTheme.labelMedium,
-              ),
-              const SizedBox(height: 10),
-              for (final sentence in detail.exampleSentences)
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 6),
-                  child: Text(
-                    sentence,
-                    key: const Key('explanation-detail.example'),
-                    style: const TextStyle(
-                      fontFamily: VsTokens.serif,
-                      fontSize: 15,
-                      height: 1.6,
-                      fontStyle: FontStyle.italic,
-                      color: VsTokens.ink,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            _ExplanationHeader(onBack: () => context.pop()),
+            const Divider(thickness: 0.5, height: 0.5),
+            Expanded(
+              child: detailAsync.when(
+                data: (detail) {
+                  if (detail == null) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (context.mounted) context.pop();
+                    });
+                    return const SizedBox.shrink();
+                  }
+                  return ListView(
+                    padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+                    children: <Widget>[
+                      Text(
+                        '解説',
+                        style: theme.textTheme.displaySmall,
+                      ),
+                      const SizedBox(height: 24),
+                      Text(
+                        detail.body,
+                        key: const Key('explanation-detail.body'),
+                        style: const TextStyle(
+                          fontFamily: VsTokens.serif,
+                          fontSize: 17,
+                          height: 1.8,
+                          color: VsTokens.ink,
+                        ),
+                      ),
+                      if (detail.exampleSentences.isNotEmpty) ...<Widget>[
+                        const SizedBox(height: 28),
+                        const Divider(thickness: 0.5, height: 0.5),
+                        const SizedBox(height: 16),
+                        const VsSectionLabel('EXAMPLES'),
+                        const SizedBox(height: 10),
+                        for (var i = 0;
+                            i < detail.exampleSentences.length;
+                            i++)
+                          _ExampleRow(
+                            sentence: detail.exampleSentences[i],
+                            isFirst: i == 0,
+                          ),
+                      ],
+                    ],
+                  );
+                },
+                loading: () => const _LoadingBody(),
+                error: (error, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: VsTokens.accentSoft,
+                        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+                      ),
+                      child: Text(
+                        'エラーが発生しました: $error',
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: VsTokens.err,
+                          height: 1.5,
+                        ),
+                      ),
                     ),
                   ),
                 ),
-            ],
-          );
-        },
-        loading: () => const Padding(
-          key: Key('explanation-detail.loading'),
-          padding: EdgeInsets.fromLTRB(24, 16, 24, 16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              VsSkeleton(height: 20),
-              SizedBox(height: 12),
-              VsSkeleton(),
-              SizedBox(height: 6),
-              VsSkeleton(),
-              SizedBox(height: 6),
-              VsSkeleton(width: 240),
-            ],
-          ),
+              ),
+            ),
+          ],
         ),
-        error: (error, _) => Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: Text(
-              'エラー: $error',
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: VsTokens.err,
+      ),
+    );
+  }
+}
+
+class _ExplanationHeader extends StatelessWidget {
+  const _ExplanationHeader({required this.onBack});
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          TextButton.icon(
+            onPressed: onBack,
+            icon: const Icon(Icons.chevron_left, size: 18),
+            label: const Text('戻る'),
+            style: TextButton.styleFrom(
+              foregroundColor: VsTokens.inkSoft,
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              textStyle: const TextStyle(
+                fontFamily: VsTokens.sans,
+                fontSize: 14,
               ),
             ),
           ),
+          const VsWordmark(size: 13),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: Icon(
+              Icons.star_border,
+              size: 18,
+              color: VsTokens.inkSoft,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExampleRow extends StatelessWidget {
+  const _ExampleRow({required this.sentence, required this.isFirst});
+  final String sentence;
+  final bool isFirst;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: isFirst ? VsTokens.inkHair : Colors.transparent,
+            width: 0.5,
+          ),
+          bottom: const BorderSide(color: VsTokens.inkHair, width: 0.5),
         ),
+      ),
+      child: Text(
+        sentence,
+        key: const Key('explanation-detail.example'),
+        style: const TextStyle(
+          fontFamily: VsTokens.serif,
+          fontSize: 15,
+          fontWeight: FontWeight.w500,
+          fontStyle: FontStyle.italic,
+          height: 1.5,
+          color: VsTokens.ink,
+        ),
+      ),
+    );
+  }
+}
+
+class _LoadingBody extends StatelessWidget {
+  const _LoadingBody();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      key: Key('explanation-detail.loading'),
+      padding: EdgeInsets.fromLTRB(24, 24, 24, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          VsSkeleton(height: 28, width: 120),
+          SizedBox(height: 24),
+          VsSkeleton(),
+          SizedBox(height: 6),
+          VsSkeleton(),
+          SizedBox(height: 6),
+          VsSkeleton(width: 240),
+        ],
       ),
     );
   }

--- a/applications/mobile/lib/src/presentation/detail/explanation_detail_screen.dart
+++ b/applications/mobile/lib/src/presentation/detail/explanation_detail_screen.dart
@@ -3,19 +3,23 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../app_bindings.dart';
+import '../../domain/explanation/explanation_detail.dart';
 import '../../domain/identifier/identifier.dart';
 import '../theme/vs_tokens.dart';
 import '../theme/widgets/vs_section_label.dart';
 import '../theme/widgets/vs_skeleton.dart';
 import '../theme/widgets/vs_wordmark.dart';
+import 'detail_layout_preference.dart';
 
 /// Spec 013 canonical `ExplanationDetail` screen.
 ///
-/// Visual reference: `screens.jsx` `VSDetail` sense body. The completed
-/// explanation payload is rendered as a dictionary-style page: a Mincho
-/// body paragraph and hairline-separated example sentences in serif italic.
-/// When the reader returns null the screen pops back without flashing
-/// provisional content (spec 013 generation-result-visibility).
+/// Visual reference: `screens.jsx` `VSDetail`. The body can be rendered
+/// in three layout variants (Tab / Page / Cards) driven by
+/// `detailLayoutProvider`; the selection lives in Settings. With
+/// `CompletedExplanationDetail` currently carrying a single body and
+/// example list the layouts operate on a single synthetic sense — the
+/// structure is ready for spec 017/021 to populate sense[] without
+/// further churn.
 class ExplanationDetailScreen extends ConsumerWidget {
   const ExplanationDetailScreen({required this.identifier, super.key});
 
@@ -24,6 +28,7 @@ class ExplanationDetailScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final detailAsync = ref.watch(explanationDetailFutureProvider(identifier));
+    final layout = ref.watch(detailLayoutProvider);
     final theme = Theme.of(context);
 
     return Scaffold(
@@ -43,40 +48,11 @@ class ExplanationDetailScreen extends ConsumerWidget {
                     });
                     return const SizedBox.shrink();
                   }
-                  return ListView(
-                    padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
-                    children: <Widget>[
-                      Text(
-                        '解説',
-                        style: theme.textTheme.displaySmall,
-                      ),
-                      const SizedBox(height: 24),
-                      Text(
-                        detail.body,
-                        key: const Key('explanation-detail.body'),
-                        style: const TextStyle(
-                          fontFamily: VsTokens.serif,
-                          fontSize: 17,
-                          height: 1.8,
-                          color: VsTokens.ink,
-                        ),
-                      ),
-                      if (detail.exampleSentences.isNotEmpty) ...<Widget>[
-                        const SizedBox(height: 28),
-                        const Divider(thickness: 0.5, height: 0.5),
-                        const SizedBox(height: 16),
-                        const VsSectionLabel('EXAMPLES'),
-                        const SizedBox(height: 10),
-                        for (var i = 0;
-                            i < detail.exampleSentences.length;
-                            i++)
-                          _ExampleRow(
-                            sentence: detail.exampleSentences[i],
-                            isFirst: i == 0,
-                          ),
-                      ],
-                    ],
-                  );
+                  return switch (layout) {
+                    DetailLayout.tab => _TabLayout(detail: detail),
+                    DetailLayout.page => _PageLayout(detail: detail),
+                    DetailLayout.cards => _CardsLayout(detail: detail),
+                  };
                 },
                 loading: () => const _LoadingBody(),
                 error: (error, _) => Center(
@@ -104,6 +80,330 @@ class ExplanationDetailScreen extends ConsumerWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _TabLayout extends StatelessWidget {
+  const _TabLayout({required this.detail});
+  final CompletedExplanationDetail detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
+      children: <Widget>[
+        Text('解説', style: theme.textTheme.displaySmall),
+        const SizedBox(height: 16),
+        Container(
+          decoration: const BoxDecoration(
+            border: Border(
+              bottom: BorderSide(color: VsTokens.inkHair, width: 0.5),
+            ),
+          ),
+          padding: const EdgeInsets.only(bottom: 12),
+          child: Row(
+            children: <Widget>[
+              Container(
+                padding: const EdgeInsets.only(bottom: 10),
+                decoration: const BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(color: VsTokens.accent, width: 2),
+                  ),
+                ),
+                child: const Row(
+                  children: <Widget>[
+                    _SenseBadge(order: 1, isActive: true),
+                    SizedBox(width: 6),
+                    Text(
+                      'Sense 1',
+                      style: TextStyle(
+                        fontFamily: VsTokens.sans,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: VsTokens.ink,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        _ExplanationBody(detail: detail),
+        const SizedBox(height: 24),
+        const _DeferredFooter(),
+      ],
+    );
+  }
+}
+
+class _PageLayout extends StatelessWidget {
+  const _PageLayout({required this.detail});
+  final CompletedExplanationDetail detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const Text(
+                    'SENSE 01 / 01',
+                    style: TextStyle(
+                      fontFamily: VsTokens.mono,
+                      fontSize: 10,
+                      letterSpacing: 2,
+                      color: VsTokens.inkMute,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '「解説」',
+                    style: theme.textTheme.displaySmall?.copyWith(
+                      fontSize: 24,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const _PageArrow(
+              icon: Icons.chevron_left,
+              onTap: null,
+            ),
+            const SizedBox(width: 8),
+            const _PageArrow(
+              icon: Icons.chevron_right,
+              onTap: null,
+              filled: true,
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: Container(
+                height: 3,
+                color: VsTokens.ink,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 20),
+        _ExplanationBody(detail: detail),
+        const SizedBox(height: 24),
+        const _DeferredFooter(),
+      ],
+    );
+  }
+}
+
+class _CardsLayout extends StatelessWidget {
+  const _CardsLayout({required this.detail});
+  final CompletedExplanationDetail detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 32),
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.fromLTRB(8, 0, 8, 12),
+          child: Text(
+            '解説',
+            style: theme.textTheme.displaySmall,
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.fromLTRB(8, 0, 8, 12),
+          child: VsSectionLabel('Senses · 1 義'),
+        ),
+        Container(
+          decoration: BoxDecoration(
+            color: VsTokens.paperSoft,
+            border: Border.all(color: VsTokens.inkHair),
+            borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            children: <Widget>[
+              const Padding(
+                padding: EdgeInsets.fromLTRB(16, 14, 16, 10),
+                child: Row(
+                  children: <Widget>[
+                    _SenseBadge(order: 1, isActive: true, size: 24),
+                    SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        '「解説」',
+                        style: TextStyle(
+                          fontFamily: VsTokens.serif,
+                          fontSize: 17,
+                          fontWeight: FontWeight.w600,
+                          color: VsTokens.ink,
+                        ),
+                      ),
+                    ),
+                    Icon(Icons.expand_less, size: 16, color: VsTokens.inkMute),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                child: _ExplanationBody(detail: detail),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 24),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8),
+          child: _DeferredFooter(),
+        ),
+      ],
+    );
+  }
+}
+
+class _ExplanationBody extends StatelessWidget {
+  const _ExplanationBody({required this.detail});
+  final CompletedExplanationDetail detail;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        const VsSectionLabel('NUANCE'),
+        const SizedBox(height: 6),
+        Text(
+          detail.body,
+          key: const Key('explanation-detail.body'),
+          style: const TextStyle(
+            fontFamily: VsTokens.serif,
+            fontSize: 16,
+            height: 1.7,
+            color: VsTokens.ink,
+          ),
+        ),
+        if (detail.exampleSentences.isNotEmpty) ...<Widget>[
+          const SizedBox(height: 20),
+          const VsSectionLabel('EXAMPLES'),
+          const SizedBox(height: 10),
+          for (var i = 0; i < detail.exampleSentences.length; i++)
+            _ExampleRow(
+              sentence: detail.exampleSentences[i],
+              isFirst: i == 0,
+            ),
+        ],
+      ],
+    );
+  }
+}
+
+class _SenseBadge extends StatelessWidget {
+  const _SenseBadge({
+    required this.order,
+    required this.isActive,
+    this.size = 18,
+  });
+
+  final int order;
+  final bool isActive;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: isActive ? VsTokens.ink : VsTokens.paperDeep,
+        borderRadius: BorderRadius.circular(size / 2),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '$order',
+        style: TextStyle(
+          fontFamily: VsTokens.sans,
+          fontSize: size < 20 ? 10 : 11,
+          fontWeight: FontWeight.w600,
+          color: isActive ? VsTokens.paper : VsTokens.inkSoft,
+        ),
+      ),
+    );
+  }
+}
+
+class _PageArrow extends StatelessWidget {
+  const _PageArrow({
+    required this.icon,
+    required this.onTap,
+    this.filled = false,
+  });
+
+  final IconData icon;
+  final VoidCallback? onTap;
+  final bool filled;
+
+  @override
+  Widget build(BuildContext context) {
+    final background = filled ? VsTokens.ink : VsTokens.paperSoft;
+    final foreground = filled ? VsTokens.paper : VsTokens.inkSoft;
+    return Opacity(
+      opacity: onTap == null ? 0.3 : 1,
+      child: Material(
+        color: background,
+        shape: CircleBorder(
+          side: filled
+              ? BorderSide.none
+              : const BorderSide(color: VsTokens.inkHair, width: 0.5),
+        ),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: onTap,
+          child: SizedBox(
+            width: 36,
+            height: 36,
+            child: Icon(icon, size: 18, color: foreground),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DeferredFooter extends StatelessWidget {
+  const _DeferredFooter();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Divider(thickness: 0.5, height: 0.5),
+        const SizedBox(height: 16),
+        const VsSectionLabel('類似表現 · 語源 · 習熟度'),
+        const SizedBox(height: 6),
+        Text(
+          'spec 017 / 021 で拡張予定のセクションです。',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: VsTokens.inkMute,
+            fontStyle: FontStyle.italic,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/applications/mobile/lib/src/presentation/detail/image_detail_screen.dart
+++ b/applications/mobile/lib/src/presentation/detail/image_detail_screen.dart
@@ -5,14 +5,15 @@ import 'package:go_router/go_router.dart';
 import '../../app_bindings.dart';
 import '../../domain/identifier/identifier.dart';
 import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_illustration_panel.dart';
 import '../theme/widgets/vs_skeleton.dart';
 
 /// Spec 013 canonical `ImageDetail` screen.
 ///
-/// `allowsCompletedPayload = true`: renders only the completed current image.
-/// Network fetching is deferred to a later phase; for now the screen renders
-/// the asset reference string and description as a stable surface that can be
-/// asserted in widget tests without pulling a real asset.
+/// Visual reference: `screens.jsx` `DetailImagePanel` enlarged. A
+/// full-width illustration panel fills the upper portion of the screen;
+/// description and asset reference follow underneath. Null payloads pop
+/// back without flashing (`allowsCompletedPayload = true`).
 class ImageDetailScreen extends ConsumerWidget {
   const ImageDetailScreen({required this.identifier, super.key});
 
@@ -22,85 +23,116 @@ class ImageDetailScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final detailAsync = ref.watch(imageDetailFutureProvider(identifier));
     final theme = Theme.of(context);
+    final size = MediaQuery.of(context).size;
+    final panelHeight = size.height * 0.55;
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.chevron_left),
-          onPressed: () => context.pop(),
-        ),
-        title: const Text('画像'),
-      ),
-      body: detailAsync.when(
-        data: (detail) {
-          if (detail == null) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (context.mounted) context.pop();
-            });
-            return const SizedBox.shrink();
-          }
-          return ListView(
-            padding: const EdgeInsets.fromLTRB(24, 8, 24, 32),
-            children: <Widget>[
-              Container(
-                key: const Key('image-detail.asset'),
-                height: 260,
-                decoration: BoxDecoration(
-                  color: VsTokens.paperDeep,
-                  borderRadius: BorderRadius.circular(VsTokens.radiusMd),
-                  border: Border.all(color: VsTokens.inkHair),
+      body: SafeArea(
+        child: detailAsync.when(
+          data: (detail) {
+            if (detail == null) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (context.mounted) context.pop();
+              });
+              return const SizedBox.shrink();
+            }
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+              children: <Widget>[
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: IconButton(
+                    icon: const Icon(Icons.chevron_left),
+                    color: VsTokens.inkSoft,
+                    onPressed: () => context.pop(),
+                  ),
                 ),
-                alignment: Alignment.center,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
+                const SizedBox(height: 8),
+                Container(
+                  key: const Key('image-detail.asset'),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(VsTokens.radiusLg),
+                    border: Border.all(color: VsTokens.inkHair),
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: VsIllustrationPanel(
+                    seed: identifier.value.length,
+                    label: '視覚イメージ',
+                    height: panelHeight,
+                    borderRadius: VsTokens.radiusLg,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
                   child: Text(
-                    detail.assetReference,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      fontFamily: VsTokens.mono,
-                      fontSize: 11,
-                      color: VsTokens.inkSoft,
+                    detail.description,
+                    key: const Key('image-detail.description'),
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      height: 1.7,
+                      color: VsTokens.ink,
                     ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 20),
-              Text(
-                detail.description,
-                key: const Key('image-detail.description'),
-                style: theme.textTheme.bodyLarge,
-              ),
-            ],
-          );
-        },
-        loading: () => const Padding(
-          key: Key('image-detail.loading'),
-          padding: EdgeInsets.fromLTRB(24, 16, 24, 16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              VsSkeleton(height: 240),
-              SizedBox(height: 16),
-              VsSkeleton(),
-              SizedBox(height: 6),
-              VsSkeleton(width: 200),
-            ],
-          ),
-        ),
-        error: (error, _) => Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: Text(
-              'エラー: $error',
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: VsTokens.err,
+                const SizedBox(height: 14),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Text(
+                    detail.assetReference,
+                    style: const TextStyle(
+                      fontFamily: VsTokens.mono,
+                      fontSize: 10,
+                      letterSpacing: 0.3,
+                      color: VsTokens.inkMute,
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+          loading: () => const _LoadingBody(),
+          error: (error, _) => Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: VsTokens.accentSoft,
+                  borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+                ),
+                child: Text(
+                  'エラーが発生しました: $error',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: VsTokens.err,
+                    height: 1.5,
+                  ),
+                ),
               ),
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class _LoadingBody extends StatelessWidget {
+  const _LoadingBody();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      key: const Key('image-detail.loading'),
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+      children: const <Widget>[
+        VsSkeleton(height: 280, radius: VsTokens.radiusLg),
+        SizedBox(height: 20),
+        VsSkeleton(),
+        SizedBox(height: 6),
+        VsSkeleton(width: 200),
+      ],
     );
   }
 }

--- a/applications/mobile/lib/src/presentation/detail/vocabulary_expression_detail_screen.dart
+++ b/applications/mobile/lib/src/presentation/detail/vocabulary_expression_detail_screen.dart
@@ -17,13 +17,17 @@ import '../../domain/vocabulary/vocabulary_expression_entry.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
 import '../theme/widgets/vs_chip.dart';
+import '../theme/widgets/vs_illustration_panel.dart';
+import '../theme/widgets/vs_section_label.dart';
 import '../theme/widgets/vs_spinner.dart';
+import '../theme/widgets/vs_wordmark.dart';
 
 /// Spec 013 canonical `VocabularyExpressionDetail` screen.
 ///
-/// `allowsCompletedPayload = false`: the screen only aggregates generation
-/// status and exposes CTAs into the completed-only detail screens. Explanation
-/// body and image payload are NEVER rendered here.
+/// Visual reference: `screens.jsx` `VSDetail` status-only subset (spec 013
+/// `allowsCompletedPayload = false`). Explanation body / image payload are
+/// never rendered here; the screen aggregates generation status and routes
+/// into the completed-only detail screens via CTAs.
 class VocabularyExpressionDetailScreen extends ConsumerWidget {
   const VocabularyExpressionDetailScreen({
     required this.identifier,
@@ -42,100 +46,29 @@ class VocabularyExpressionDetailScreen extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.chevron_left),
-          onPressed: () => context.go(AppRoutes.catalog),
-        ),
-        title: const Text('単語の詳細'),
-      ),
-      body: entry == null
-          ? const Center(
-              child: VsSpinner(
-                key: Key('detail.loading'),
-                size: 20,
+      body: SafeArea(
+        child: entry == null
+            ? const Center(
+                child: VsSpinner(key: Key('detail.loading'), size: 20),
+              )
+            : _DetailBody(
+                entry: entry,
+                onOpenExplanation: () => context.go(
+                  '${AppRoutes.explanationPrefix}/'
+                  '${entry.currentExplanation!.value}',
+                ),
+                onOpenImage: () => context.go(
+                  '${AppRoutes.imagePrefix}/${entry.currentImage!.value}',
+                ),
+                onRequestImage: () => unawaited(_requestImage(context, ref)),
+                onRetryExplanation: () => unawaited(
+                  _retry(ref, GenerationTargetKind.explanation),
+                ),
+                onRetryImage: () =>
+                    unawaited(_retry(ref, GenerationTargetKind.image)),
+                onBack: () => context.go(AppRoutes.catalog),
               ),
-            )
-          : _buildStatusBody(context, ref, entry),
-    );
-  }
-
-  Widget _buildStatusBody(
-    BuildContext context,
-    WidgetRef ref,
-    VocabularyExpressionEntry entry,
-  ) {
-    final theme = Theme.of(context);
-    final canRequestImage =
-        entry.hasCompletedExplanation && !entry.hasCompletedImage;
-    final explanationFailed = _isExplanationFailed(entry.explanationStatus);
-    final imageFailed = _isImageFailed(entry.imageStatus);
-
-    return ListView(
-      padding: const EdgeInsets.fromLTRB(24, 8, 24, 32),
-      children: <Widget>[
-        Text(
-          entry.text,
-          key: const Key('detail.text'),
-          style: theme.textTheme.displayMedium,
-        ),
-        const SizedBox(height: 32),
-        _StatusSection(
-          keyValue: 'detail.explanation-status',
-          title: '解説',
-          label: _explanationLabel(entry.explanationStatus),
-          tone: _explanationChipTone(entry.explanationStatus),
-        ),
-        const SizedBox(height: 12),
-        if (entry.hasCompletedExplanation)
-          ElevatedButton(
-            key: const Key('detail.open-explanation'),
-            onPressed: () => context.go(
-              '${AppRoutes.explanationPrefix}/${entry.currentExplanation!.value}',
-            ),
-            child: const Text('解説を見る'),
-          ),
-        if (explanationFailed)
-          OutlinedButton(
-            key: const Key('detail.retry-explanation'),
-            onPressed: () => unawaited(
-              _retry(ref, GenerationTargetKind.explanation),
-            ),
-            child: const Text('解説生成を再試行'),
-          ),
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 24),
-          child: Divider(),
-        ),
-        _StatusSection(
-          keyValue: 'detail.image-status',
-          title: '画像',
-          label: _imageLabel(entry.imageStatus),
-          tone: _imageChipTone(entry.imageStatus),
-        ),
-        const SizedBox(height: 12),
-        if (entry.hasCompletedImage)
-          ElevatedButton(
-            key: const Key('detail.open-image'),
-            onPressed: () => context.go(
-              '${AppRoutes.imagePrefix}/${entry.currentImage!.value}',
-            ),
-            child: const Text('画像を見る'),
-          ),
-        if (canRequestImage)
-          ElevatedButton(
-            key: const Key('detail.request-image'),
-            onPressed: () => unawaited(_requestImage(context, ref)),
-            child: const Text('画像を生成する'),
-          ),
-        if (imageFailed)
-          OutlinedButton(
-            key: const Key('detail.retry-image'),
-            onPressed: () =>
-                unawaited(_retry(ref, GenerationTargetKind.image)),
-            child: const Text('画像生成を再試行'),
-          ),
-      ],
+      ),
     );
   }
 
@@ -162,90 +95,342 @@ class VocabularyExpressionDetailScreen extends ConsumerWidget {
     );
   }
 
-  Future<void> _retry(
-    WidgetRef ref,
-    GenerationTargetKind target,
-  ) async {
+  Future<void> _retry(WidgetRef ref, GenerationTargetKind target) async {
     final command = ref.read(retryGenerationCommandProvider);
     final response = await command.retry(
       vocabularyExpression: identifier,
       target: target,
       idempotencyKey: IdempotencyKey(_uuidGenerator.v4()),
     );
-    // The UI observes new status through the reader stream; the response
-    // envelope itself is not used to derive completed state (spec 013
-    // command binding rule).
     if (response is CommandResponseRejected) {
       // Silent for now; Phase 7 will surface a SnackBar using the envelope
       // user-facing message.
     }
   }
+}
 
-  bool _isExplanationFailed(ExplanationGenerationStatus status) {
-    return status == ExplanationGenerationStatus.failedFinal ||
-        status == ExplanationGenerationStatus.deadLettered;
-  }
+class _DetailBody extends StatelessWidget {
+  const _DetailBody({
+    required this.entry,
+    required this.onOpenExplanation,
+    required this.onOpenImage,
+    required this.onRequestImage,
+    required this.onRetryExplanation,
+    required this.onRetryImage,
+    required this.onBack,
+  });
 
-  bool _isImageFailed(ImageGenerationStatus status) {
-    return status == ImageGenerationStatus.failedFinal ||
-        status == ImageGenerationStatus.deadLettered;
-  }
+  final VocabularyExpressionEntry entry;
+  final VoidCallback onOpenExplanation;
+  final VoidCallback onOpenImage;
+  final VoidCallback onRequestImage;
+  final VoidCallback onRetryExplanation;
+  final VoidCallback onRetryImage;
+  final VoidCallback onBack;
 
-  String _explanationLabel(ExplanationGenerationStatus status) {
-    return switch (status) {
-      ExplanationGenerationStatus.pending => '解説を準備しています',
-      ExplanationGenerationStatus.running => '解説を生成しています',
-      ExplanationGenerationStatus.retryScheduled => '再試行を待機しています',
-      ExplanationGenerationStatus.timedOut => 'タイムアウトしました',
-      ExplanationGenerationStatus.succeeded => '完了しました',
-      ExplanationGenerationStatus.failedFinal => '生成できませんでした',
-      ExplanationGenerationStatus.deadLettered => '生成できませんでした',
-    };
-  }
-
-  String _imageLabel(ImageGenerationStatus status) {
-    return switch (status) {
-      ImageGenerationStatus.pending => '画像を準備しています',
-      ImageGenerationStatus.running => '画像を生成しています',
-      ImageGenerationStatus.retryScheduled => '再試行を待機しています',
-      ImageGenerationStatus.timedOut => 'タイムアウトしました',
-      ImageGenerationStatus.succeeded => '完了しました',
-      ImageGenerationStatus.failedFinal => '生成できませんでした',
-      ImageGenerationStatus.deadLettered => '生成できませんでした',
-    };
-  }
-
-  VsChipTone _explanationChipTone(ExplanationGenerationStatus status) {
-    return switch (status) {
-      ExplanationGenerationStatus.succeeded => VsChipTone.ok,
-      ExplanationGenerationStatus.pending ||
-      ExplanationGenerationStatus.running ||
-      ExplanationGenerationStatus.retryScheduled =>
-        VsChipTone.accent,
-      ExplanationGenerationStatus.timedOut ||
-      ExplanationGenerationStatus.failedFinal ||
-      ExplanationGenerationStatus.deadLettered =>
-        VsChipTone.err,
-    };
-  }
-
-  VsChipTone _imageChipTone(ImageGenerationStatus status) {
-    return switch (status) {
-      ImageGenerationStatus.succeeded => VsChipTone.ok,
-      ImageGenerationStatus.pending ||
-      ImageGenerationStatus.running ||
-      ImageGenerationStatus.retryScheduled =>
-        VsChipTone.accent,
-      ImageGenerationStatus.timedOut ||
-      ImageGenerationStatus.failedFinal ||
-      ImageGenerationStatus.deadLettered =>
-        VsChipTone.err,
-    };
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _DetailHeader(onBack: onBack),
+        const Divider(thickness: 0.5, height: 0.5),
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+              _VocabularyMeta(entry: entry),
+              const SizedBox(height: 24),
+              _ImagePanelSection(
+                entry: entry,
+                onOpenImage: onOpenImage,
+                onRequestImage: onRequestImage,
+                onRetryImage: onRetryImage,
+              ),
+              const SizedBox(height: 28),
+              _StatusRow(
+                keyValue: 'detail.explanation-status',
+                title: '解説',
+                label: _explanationLabel(entry.explanationStatus),
+                tone: _explanationChipTone(entry.explanationStatus),
+              ),
+              const SizedBox(height: 12),
+              if (entry.hasCompletedExplanation)
+                ElevatedButton(
+                  key: const Key('detail.open-explanation'),
+                  onPressed: onOpenExplanation,
+                  child: const Text('解説を読む'),
+                ),
+              if (_isExplanationFailed(entry.explanationStatus))
+                OutlinedButton(
+                  key: const Key('detail.retry-explanation'),
+                  onPressed: onRetryExplanation,
+                  child: const Text('解説生成を再試行'),
+                ),
+              const SizedBox(height: 28),
+              _StatusRow(
+                keyValue: 'detail.image-status',
+                title: '画像',
+                label: _imageLabel(entry.imageStatus),
+                tone: _imageChipTone(entry.imageStatus),
+              ),
+              const SizedBox(height: 28),
+              const Divider(thickness: 0.5, height: 0.5),
+              const SizedBox(height: 20),
+              const VsSectionLabel('習熟度 · LearningState'),
+              const SizedBox(height: 10),
+              _ProficiencyRow(theme: theme),
+            ],
+            ),
+          ),
+        ),
+      ],
+    );
   }
 }
 
-class _StatusSection extends StatelessWidget {
-  const _StatusSection({
+class _DetailHeader extends StatelessWidget {
+  const _DetailHeader({required this.onBack});
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          TextButton.icon(
+            onPressed: onBack,
+            icon: const Icon(Icons.chevron_left, size: 18),
+            label: const Text('単語帳'),
+            style: TextButton.styleFrom(
+              foregroundColor: VsTokens.inkSoft,
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              textStyle: const TextStyle(
+                fontFamily: VsTokens.sans,
+                fontSize: 14,
+              ),
+            ),
+          ),
+          const VsWordmark(size: 13),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: Icon(
+              Icons.star_border,
+              size: 18,
+              color: VsTokens.inkSoft,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VocabularyMeta extends StatelessWidget {
+  const _VocabularyMeta({required this.entry});
+  final VocabularyExpressionEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: <Widget>[
+        Flexible(
+          child: Text(
+            entry.text,
+            key: const Key('detail.text'),
+            style: const TextStyle(
+              fontFamily: VsTokens.serif,
+              fontSize: 44,
+              fontWeight: FontWeight.w600,
+              letterSpacing: -1,
+              height: 1.05,
+              color: VsTokens.ink,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ImagePanelSection extends StatelessWidget {
+  const _ImagePanelSection({
+    required this.entry,
+    required this.onOpenImage,
+    required this.onRequestImage,
+    required this.onRetryImage,
+  });
+
+  final VocabularyExpressionEntry entry;
+  final VoidCallback onOpenImage;
+  final VoidCallback onRequestImage;
+  final VoidCallback onRetryImage;
+
+  @override
+  Widget build(BuildContext context) {
+    if (entry.hasCompletedImage) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          ClipRRect(
+            borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+            child: VsIllustrationPanel(
+              seed: entry.identifier.value.length,
+              label: entry.text,
+            ),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            key: const Key('detail.open-image'),
+            onPressed: onOpenImage,
+            child: const Text('画像を拡大'),
+          ),
+        ],
+      );
+    }
+    return _ImagePlaceholder(
+      entry: entry,
+      onRequestImage: onRequestImage,
+      onRetryImage: onRetryImage,
+    );
+  }
+}
+
+class _ImagePlaceholder extends StatelessWidget {
+  const _ImagePlaceholder({
+    required this.entry,
+    required this.onRequestImage,
+    required this.onRetryImage,
+  });
+
+  final VocabularyExpressionEntry entry;
+  final VoidCallback onRequestImage;
+  final VoidCallback onRetryImage;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final status = entry.imageStatus;
+    final isRunning = status == ImageGenerationStatus.running ||
+        status == ImageGenerationStatus.retryScheduled;
+    final isFailed = status == ImageGenerationStatus.failedFinal ||
+        status == ImageGenerationStatus.deadLettered ||
+        status == ImageGenerationStatus.timedOut;
+
+    final Widget leading;
+    if (isRunning) {
+      leading = const VsSpinner(size: 18);
+    } else if (isFailed) {
+      leading = const Icon(Icons.close, size: 20, color: VsTokens.err);
+    } else {
+      leading = const Icon(
+        Icons.image_outlined,
+        size: 20,
+        color: VsTokens.inkMute,
+      );
+    }
+
+    final String title;
+    final String description;
+    if (isRunning) {
+      title = '画像を生成中...';
+      description = '中間結果は表示されません';
+    } else if (isFailed) {
+      title = '画像生成に失敗しました';
+      description = '前回の画像がなければ空のまま';
+    } else if (status == ImageGenerationStatus.pending) {
+      title = '画像を準備中';
+      description = '解説完了後に画像を依頼できます';
+    } else {
+      title = '視覚イメージを生成';
+      description = '解説が完了すると画像生成を依頼できます';
+    }
+
+    final canRequest = entry.hasCompletedExplanation && !isRunning;
+    final buttonKey = isFailed
+        ? const Key('detail.retry-image')
+        : const Key('detail.request-image');
+    final buttonText = isFailed ? '再試行' : '生成';
+    final buttonOnPressed =
+        !canRequest && !isFailed ? null : (isFailed ? onRetryImage : onRequestImage);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: VsTokens.paperSoft,
+        border: Border.all(color: VsTokens.inkHair),
+        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+      ),
+      child: Row(
+        children: <Widget>[
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: VsTokens.paperDeep,
+              borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+            ),
+            alignment: Alignment.center,
+            child: leading,
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(title, style: theme.textTheme.titleSmall),
+                const SizedBox(height: 2),
+                Text(
+                  description,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: VsTokens.inkMute,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          if (isRunning)
+            const SizedBox.shrink()
+          else
+            TextButton.icon(
+              key: buttonKey,
+              onPressed: buttonOnPressed,
+              icon: Icon(
+                isFailed ? Icons.refresh : Icons.auto_awesome,
+                size: 14,
+              ),
+              label: Text(buttonText),
+              style: TextButton.styleFrom(
+                backgroundColor: VsTokens.ink,
+                foregroundColor: VsTokens.paper,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(999)),
+                ),
+                textStyle: const TextStyle(
+                  fontFamily: VsTokens.sans,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusRow extends StatelessWidget {
+  const _StatusRow({
     required this.keyValue,
     required this.title,
     required this.label,
@@ -259,19 +444,120 @@ class _StatusSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Column(
+    return Row(
       key: Key(keyValue),
-      crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Row(
-          children: <Widget>[
-            Text(title, style: theme.textTheme.headlineSmall),
-            const SizedBox(width: 10),
-            VsChip(label: label, tone: tone),
-          ],
-        ),
+        Text(title, style: Theme.of(context).textTheme.headlineSmall),
+        const SizedBox(width: 12),
+        VsChip(label: label, tone: tone),
       ],
     );
   }
+}
+
+class _ProficiencyRow extends StatelessWidget {
+  const _ProficiencyRow({required this.theme});
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    const levels = <_ProficiencyLevel>[
+      _ProficiencyLevel(label: '学習中', color: VsTokens.profLearning),
+      _ProficiencyLevel(label: '習得', color: VsTokens.profLearned),
+      _ProficiencyLevel(label: '定着', color: VsTokens.profInternalized),
+      _ProficiencyLevel(label: '自在', color: VsTokens.profFluent),
+    ];
+    return Row(
+      children: <Widget>[
+        for (final level in levels) ...<Widget>[
+          Expanded(
+            child: Opacity(
+              opacity: 0.55,
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                decoration: BoxDecoration(
+                  color: VsTokens.paperSoft,
+                  border: Border.all(color: VsTokens.inkHair),
+                  borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  level.label,
+                  style: TextStyle(
+                    fontFamily: VsTokens.sans,
+                    fontSize: 11,
+                    color: level.color,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (level != levels.last) const SizedBox(width: 4),
+        ],
+      ],
+    );
+  }
+}
+
+@immutable
+class _ProficiencyLevel {
+  const _ProficiencyLevel({required this.label, required this.color});
+  final String label;
+  final Color color;
+}
+
+bool _isExplanationFailed(ExplanationGenerationStatus status) =>
+    status == ExplanationGenerationStatus.failedFinal ||
+    status == ExplanationGenerationStatus.deadLettered;
+
+String _explanationLabel(ExplanationGenerationStatus status) {
+  return switch (status) {
+    ExplanationGenerationStatus.pending => '解説を準備しています',
+    ExplanationGenerationStatus.running => '解説を生成しています',
+    ExplanationGenerationStatus.retryScheduled => '再試行を待機しています',
+    ExplanationGenerationStatus.timedOut => 'タイムアウトしました',
+    ExplanationGenerationStatus.succeeded => '完了しました',
+    ExplanationGenerationStatus.failedFinal => '生成できませんでした',
+    ExplanationGenerationStatus.deadLettered => '生成できませんでした',
+  };
+}
+
+String _imageLabel(ImageGenerationStatus status) {
+  return switch (status) {
+    ImageGenerationStatus.pending => '画像を準備しています',
+    ImageGenerationStatus.running => '画像を生成しています',
+    ImageGenerationStatus.retryScheduled => '再試行を待機しています',
+    ImageGenerationStatus.timedOut => 'タイムアウトしました',
+    ImageGenerationStatus.succeeded => '完了しました',
+    ImageGenerationStatus.failedFinal => '生成できませんでした',
+    ImageGenerationStatus.deadLettered => '生成できませんでした',
+  };
+}
+
+VsChipTone _explanationChipTone(ExplanationGenerationStatus status) {
+  return switch (status) {
+    ExplanationGenerationStatus.succeeded => VsChipTone.ok,
+    ExplanationGenerationStatus.pending ||
+    ExplanationGenerationStatus.running ||
+    ExplanationGenerationStatus.retryScheduled =>
+      VsChipTone.accent,
+    ExplanationGenerationStatus.timedOut ||
+    ExplanationGenerationStatus.failedFinal ||
+    ExplanationGenerationStatus.deadLettered =>
+      VsChipTone.err,
+  };
+}
+
+VsChipTone _imageChipTone(ImageGenerationStatus status) {
+  return switch (status) {
+    ImageGenerationStatus.succeeded => VsChipTone.ok,
+    ImageGenerationStatus.pending ||
+    ImageGenerationStatus.running ||
+    ImageGenerationStatus.retryScheduled =>
+      VsChipTone.accent,
+    ImageGenerationStatus.timedOut ||
+    ImageGenerationStatus.failedFinal ||
+    ImageGenerationStatus.deadLettered =>
+      VsChipTone.err,
+  };
 }

--- a/applications/mobile/lib/src/presentation/paywall/paywall_screen.dart
+++ b/applications/mobile/lib/src/presentation/paywall/paywall_screen.dart
@@ -10,7 +10,6 @@ import '../../domain/identifier/identifier.dart';
 import '../../domain/subscription/plan.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
-import '../theme/widgets/vs_bottom_tab_bar.dart';
 import '../theme/widgets/vs_chip.dart';
 
 /// Spec 013 canonical `Paywall` screen (full-screen route group).
@@ -42,7 +41,6 @@ class _PaywallScreenState extends ConsumerState<PaywallScreen> {
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
-      bottomNavigationBar: const VsBottomTabBar(),
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),

--- a/applications/mobile/lib/src/presentation/paywall/paywall_screen.dart
+++ b/applications/mobile/lib/src/presentation/paywall/paywall_screen.dart
@@ -10,6 +10,7 @@ import '../../domain/identifier/identifier.dart';
 import '../../domain/subscription/plan.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_bottom_tab_bar.dart';
 import '../theme/widgets/vs_chip.dart';
 
 /// Spec 013 canonical `Paywall` screen (full-screen route group).
@@ -41,6 +42,7 @@ class _PaywallScreenState extends ConsumerState<PaywallScreen> {
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
+      bottomNavigationBar: const VsBottomTabBar(),
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),

--- a/applications/mobile/lib/src/presentation/paywall/paywall_screen.dart
+++ b/applications/mobile/lib/src/presentation/paywall/paywall_screen.dart
@@ -11,71 +11,147 @@ import '../../domain/subscription/plan.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
 import '../theme/widgets/vs_chip.dart';
-import '../theme/widgets/vs_screen_scaffold.dart';
 
 /// Spec 013 canonical `Paywall` screen (full-screen route group).
 ///
-/// Lists paid plan options from spec 014 product catalog. Does NOT display
-/// completed payload; purchase state progresses through the underlying
-/// stub. Offers a link to the canonical `SubscriptionStatus` screen so the
-/// learner can review state in detail.
-class PaywallScreen extends ConsumerWidget {
+/// Visual reference: `screens.jsx` `VSPaywall`. Hero has a
+/// `PREMIUM GENERATION` crown chip, a Mincho 28 two-line headline
+/// ("多義の深さに、画像を添えて。") with accent highlight on 画像, and a muted
+/// tagline. The plan list exposes Free / Standard / Pro cards with
+/// selectable state; the selected plan drives the upgrade CTA copy.
+class PaywallScreen extends ConsumerStatefulWidget {
   const PaywallScreen({super.key});
 
+  @override
+  ConsumerState<PaywallScreen> createState() => _PaywallScreenState();
+}
+
+class _PaywallScreenState extends ConsumerState<PaywallScreen> {
   static const Uuid _uuidGenerator = Uuid();
+  PlanCode _selected = PlanCode.proMonthly;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return VsScreenScaffold(
-      eyebrow: 'SUBSCRIPTION',
-      title: 'プランを選ぶ',
-      caption: '生成可能数を増やし、より深く多義を掘り下げる。',
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
+    final currentPlan = ref
+            .watch(subscriptionStatusStreamProvider)
+            .value
+            ?.plan ??
+        PlanCode.free;
+
+    return Scaffold(
+      backgroundColor: VsTokens.paper,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+            const _PaywallHeader(),
+            const SizedBox(height: 24),
+            _PlanCard(
+              key: const Key('paywall.plan.free'),
+              plan: PlanCode.free,
+              label: 'Free',
+              price: '¥0',
+              sub: '基本',
+              quota: '10 語 / 月',
+              features: const <String>[
+                '基本的な解説',
+                '画像生成なし',
+                '月 10 語まで',
+              ],
+              isCurrent: currentPlan == PlanCode.free,
+              isSelected: _selected == PlanCode.free,
+              onTap: () => setState(() => _selected = PlanCode.free),
+            ),
+            const SizedBox(height: 8),
+            _PlanCard(
+              key: const Key('paywall.plan.standard'),
+              plan: PlanCode.standardMonthly,
+              label: 'Standard',
+              price: '¥580',
+              sub: '月額',
+              quota: '100 語 / 月',
+              features: const <String>[
+                'AI解説 完全版',
+                '画像生成: 月 30 枚',
+                '月 100 語まで',
+              ],
+              isCurrent: currentPlan == PlanCode.standardMonthly,
+              isSelected: _selected == PlanCode.standardMonthly,
+              onTap: () =>
+                  setState(() => _selected = PlanCode.standardMonthly),
+            ),
+            const SizedBox(height: 8),
+            _PlanCard(
+              key: const Key('paywall.plan.pro'),
+              plan: PlanCode.proMonthly,
+              label: 'Pro',
+              price: '¥1,280',
+              sub: '月額',
+              quota: '無制限',
+              features: const <String>[
+                'AI解説 完全版',
+                '画像生成: 無制限',
+                '登録数 無制限',
+                '優先キュー',
+              ],
+              isCurrent: currentPlan == PlanCode.proMonthly,
+              isSelected: _selected == PlanCode.proMonthly,
+              onTap: () => setState(() => _selected = PlanCode.proMonthly),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton.icon(
+              onPressed: _selected == PlanCode.free || _selected == currentPlan
+                  ? null
+                  : () => unawaited(_purchase(_selected)),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: VsTokens.accent,
+                foregroundColor: VsTokens.paper,
+                disabledBackgroundColor: VsTokens.paperDeep,
+                disabledForegroundColor: VsTokens.inkMute,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: const RoundedRectangleBorder(
+                  borderRadius:
+                      BorderRadius.all(Radius.circular(VsTokens.radiusMd)),
+                ),
+                textStyle: const TextStyle(
+                  fontFamily: VsTokens.sans,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              icon: const Icon(Icons.bolt, size: 16),
+              label: Text('${_planLabel(_selected)} にアップグレード'),
+            ),
+            const SizedBox(height: 12),
             Text(
-              '月額プランはいつでも解約できます。',
-              style: theme.textTheme.bodyMedium?.copyWith(
+              'purchase state: initiated → submitted → verifying → verified\n'
+              'verified になるまで premium 機能は解放されません。',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontSize: 10,
+                height: 1.5,
                 color: VsTokens.inkMute,
               ),
             ),
             const SizedBox(height: 24),
-            _PlanCard(
-              key: const Key('paywall.plan.standard'),
-              title: 'スタンダード',
-              priceLine: '¥ 480 / 月',
-              features: const <String>['解説 100 / 月', '画像 30 / 月'],
-              accentTag: 'STANDARD',
-              onPurchase: () => unawaited(
-                _purchase(ref, PlanCode.standardMonthly),
+            Center(
+              child: TextButton(
+                key: const Key('paywall.status-link'),
+                onPressed: () => context.go(AppRoutes.subscriptionStatus),
+                child: const Text('サブスクリプション状態を確認'),
               ),
             ),
-            const SizedBox(height: 14),
-            _PlanCard(
-              key: const Key('paywall.plan.pro'),
-              title: 'プロ',
-              priceLine: '¥ 1,280 / 月',
-              features: const <String>['解説 300 / 月', '画像 100 / 月'],
-              accentTag: 'PRO',
-              recommended: true,
-              onPurchase: () => unawaited(_purchase(ref, PlanCode.proMonthly)),
-            ),
-            const SizedBox(height: 24),
-            TextButton(
-              key: const Key('paywall.status-link'),
-              onPressed: () => context.go(AppRoutes.subscriptionStatus),
-              child: const Text('サブスクリプション状態を確認'),
-            ),
           ],
+          ),
         ),
       ),
     );
   }
 
-  Future<void> _purchase(WidgetRef ref, PlanCode plan) async {
+  Future<void> _purchase(PlanCode plan) async {
     final command = ref.read(requestPurchaseCommandProvider);
     await command.purchase(
       plan: plan,
@@ -84,90 +160,192 @@ class PaywallScreen extends ConsumerWidget {
   }
 }
 
-class _PlanCard extends StatelessWidget {
-  const _PlanCard({
-    required this.title,
-    required this.priceLine,
-    required this.features,
-    required this.accentTag,
-    required this.onPurchase,
-    this.recommended = false,
-    super.key,
-  });
-
-  final String title;
-  final String priceLine;
-  final List<String> features;
-  final String accentTag;
-  final bool recommended;
-  final VoidCallback onPurchase;
+class _PaywallHeader extends StatelessWidget {
+  const _PaywallHeader();
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      decoration: BoxDecoration(
-        color: VsTokens.paperSoft,
-        borderRadius: BorderRadius.circular(VsTokens.radiusLg),
-        border: Border.all(
-          color: recommended ? VsTokens.accent : VsTokens.inkHair,
-          width: recommended ? 1.2 : 0.5,
+    return Column(
+      children: <Widget>[
+        const VsChip(
+          label: 'PREMIUM GENERATION',
+          tone: VsChipTone.accent,
+          icon: Icon(Icons.emoji_events),
         ),
-      ),
-      padding: const EdgeInsets.fromLTRB(20, 18, 20, 18),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              VsChip(
-                label: accentTag,
-                tone: recommended ? VsChipTone.accent : VsChipTone.neutral,
-              ),
-              if (recommended) ...<Widget>[
-                const SizedBox(width: 6),
-                const VsChip(label: 'おすすめ', tone: VsChipTone.dark),
-              ],
-            ],
-          ),
-          const SizedBox(height: 10),
-          Text(title, style: theme.textTheme.headlineMedium),
-          const SizedBox(height: 4),
-          Text(
-            priceLine,
-            style: const TextStyle(
-              fontFamily: VsTokens.mono,
-              fontSize: 16,
+        const SizedBox(height: 14),
+        RichText(
+          textAlign: TextAlign.center,
+          text: const TextSpan(
+            style: TextStyle(
+              fontFamily: VsTokens.serif,
+              fontSize: 28,
               fontWeight: FontWeight.w600,
+              letterSpacing: -0.6,
+              height: 1.2,
               color: VsTokens.ink,
             ),
+            children: <InlineSpan>[
+              TextSpan(text: '多義の深さに、\n'),
+              TextSpan(
+                text: '画像',
+                style: TextStyle(color: VsTokens.accent),
+              ),
+              TextSpan(text: 'を添えて。'),
+            ],
           ),
-          const SizedBox(height: 14),
-          for (final feature in features)
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 2),
-              child: Row(
+        ),
+        const SizedBox(height: 10),
+        Text(
+          'AIによる視覚イメージ生成で、英単語の意味が記憶に定着します。',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: VsTokens.inkSoft,
+            height: 1.6,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlanCard extends StatelessWidget {
+  const _PlanCard({
+    required this.plan,
+    required this.label,
+    required this.price,
+    required this.sub,
+    required this.quota,
+    required this.features,
+    required this.isCurrent,
+    required this.isSelected,
+    required this.onTap,
+    super.key,
+  });
+
+  final PlanCode plan;
+  final String label;
+  final String price;
+  final String sub;
+  final String quota;
+  final List<String> features;
+  final bool isCurrent;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final background = isSelected ? VsTokens.ink : VsTokens.paperSoft;
+    final foreground = isSelected ? VsTokens.paper : VsTokens.ink;
+    final borderColor = isSelected ? VsTokens.ink : VsTokens.inkHair;
+    final mutedColor = isSelected ? VsTokens.paperDeep : VsTokens.inkMute;
+    return Material(
+      color: background,
+      borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(18, 16, 18, 18),
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: borderColor,
+              width: isSelected ? 1 : 0.5,
+            ),
+            borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
                 children: <Widget>[
-                  const Icon(
-                    Icons.check,
-                    size: 14,
-                    color: VsTokens.accent,
-                  ),
-                  const SizedBox(width: 8),
                   Text(
-                    feature,
-                    style: theme.textTheme.bodyMedium,
+                    label,
+                    style: TextStyle(
+                      fontFamily: VsTokens.serif,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w600,
+                      color: foreground,
+                    ),
+                  ),
+                  if (isCurrent) ...<Widget>[
+                    const SizedBox(width: 8),
+                    VsChip(
+                      label: '現在のプラン',
+                      tone: isSelected ? VsChipTone.dark : VsChipTone.accent,
+                    ),
+                  ],
+                  const Spacer(),
+                  Text(
+                    price,
+                    style: TextStyle(
+                      fontFamily: VsTokens.serif,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                      color: foreground,
+                    ),
+                  ),
+                  const SizedBox(width: 3),
+                  Text(
+                    sub,
+                    style: TextStyle(
+                      fontFamily: VsTokens.sans,
+                      fontSize: 10,
+                      color: mutedColor,
+                    ),
                   ),
                 ],
               ),
-            ),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: onPurchase,
-            child: const Text('このプランを購入'),
+              const SizedBox(height: 4),
+              Text(
+                'QUOTA · ${quota.toUpperCase()}',
+                style: TextStyle(
+                  fontFamily: VsTokens.mono,
+                  fontSize: 10,
+                  letterSpacing: 0.5,
+                  color: mutedColor,
+                ),
+              ),
+              const SizedBox(height: 12),
+              for (final feature in features)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Row(
+                    children: <Widget>[
+                      Icon(
+                        Icons.check,
+                        size: 12,
+                        color: isSelected ? VsTokens.paper : VsTokens.ok,
+                      ),
+                      const SizedBox(width: 6),
+                      Expanded(
+                        child: Text(
+                          feature,
+                          style: TextStyle(
+                            fontFamily: VsTokens.sans,
+                            fontSize: 11,
+                            color: isSelected
+                                ? VsTokens.paper.withAlpha(230)
+                                : VsTokens.ink.withAlpha(200),
+                            height: 1.5,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
 }
+
+String _planLabel(PlanCode plan) => switch (plan) {
+      PlanCode.free => 'Free',
+      PlanCode.standardMonthly => 'Standard',
+      PlanCode.proMonthly => 'Pro',
+    };

--- a/applications/mobile/lib/src/presentation/proficiency/proficiency_screen.dart
+++ b/applications/mobile/lib/src/presentation/proficiency/proficiency_screen.dart
@@ -7,6 +7,7 @@ import '../../domain/status/proficiency_level.dart';
 import '../../domain/vocabulary/vocabulary_expression_entry.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_bottom_tab_bar.dart';
 import '../theme/widgets/vs_chip.dart';
 import '../theme/widgets/vs_wordmark.dart';
 
@@ -37,41 +38,29 @@ class ProficiencyScreen extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
+      bottomNavigationBar: const VsBottomTabBar(),
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
             Padding(
-              padding: const EdgeInsets.fromLTRB(20, 16, 8, 10),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 10),
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        const VsWordmark(size: 13),
-                        const SizedBox(height: 8),
-                        Text(
-                          '習熟度',
-                          key: const Key('proficiency.title'),
-                          style: theme.textTheme.displaySmall,
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          'LearningState.proficiency を Learner ごとに集計',
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: VsTokens.inkMute,
-                          ),
-                        ),
-                      ],
-                    ),
+                  const VsWordmark(size: 13),
+                  const SizedBox(height: 8),
+                  Text(
+                    '習熟度',
+                    key: const Key('proficiency.title'),
+                    style: theme.textTheme.displaySmall,
                   ),
-                  IconButton(
-                    icon: const Icon(Icons.chevron_left),
-                    color: VsTokens.inkSoft,
-                    onPressed: () => context.go(AppRoutes.catalog),
+                  const SizedBox(height: 4),
+                  Text(
+                    'LearningState.proficiency を Learner ごとに集計',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: VsTokens.inkMute,
+                    ),
                   ),
                 ],
               ),

--- a/applications/mobile/lib/src/presentation/proficiency/proficiency_screen.dart
+++ b/applications/mobile/lib/src/presentation/proficiency/proficiency_screen.dart
@@ -7,7 +7,6 @@ import '../../domain/status/proficiency_level.dart';
 import '../../domain/vocabulary/vocabulary_expression_entry.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
-import '../theme/widgets/vs_bottom_tab_bar.dart';
 import '../theme/widgets/vs_chip.dart';
 import '../theme/widgets/vs_wordmark.dart';
 
@@ -38,7 +37,6 @@ class ProficiencyScreen extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
-      bottomNavigationBar: const VsBottomTabBar(),
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/applications/mobile/lib/src/presentation/proficiency/proficiency_screen.dart
+++ b/applications/mobile/lib/src/presentation/proficiency/proficiency_screen.dart
@@ -1,0 +1,354 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app_bindings.dart';
+import '../../domain/status/proficiency_level.dart';
+import '../../domain/vocabulary/vocabulary_expression_entry.dart';
+import '../router/router.dart';
+import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_chip.dart';
+import '../theme/widgets/vs_wordmark.dart';
+
+/// Proficiency dashboard mirroring `screens.jsx` `VSProficiency`.
+///
+/// Aggregates vocabulary entries by `LearningState.proficiency`. Spec 005
+/// owns the concept; the stub `LearningStateReader` assigns a level so the
+/// layout renders even before the backend reader lands.
+class ProficiencyScreen extends ConsumerWidget {
+  const ProficiencyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final catalogAsync = ref.watch(vocabularyCatalogStreamProvider);
+    final catalog = catalogAsync.value ??
+        VocabularyCatalog(const <VocabularyExpressionEntry>[]);
+    final learningState = ref.watch(learningStateReaderProvider);
+    final theme = Theme.of(context);
+
+    final byLevel = <ProficiencyLevel, List<VocabularyExpressionEntry>>{
+      for (final level in ProficiencyLevel.values) level: <VocabularyExpressionEntry>[],
+    };
+    for (final entry in catalog.entries) {
+      final level = learningState.proficiencyFor(entry.identifier);
+      if (level == null) continue;
+      byLevel[level]!.add(entry);
+    }
+
+    return Scaffold(
+      backgroundColor: VsTokens.paper,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 8, 10),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        const VsWordmark(size: 13),
+                        const SizedBox(height: 8),
+                        Text(
+                          '習熟度',
+                          key: const Key('proficiency.title'),
+                          style: theme.textTheme.displaySmall,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'LearningState.proficiency を Learner ごとに集計',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: VsTokens.inkMute,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.chevron_left),
+                    color: VsTokens.inkSoft,
+                    onPressed: () => context.go(AppRoutes.catalog),
+                  ),
+                ],
+              ),
+            ),
+            _ProficiencyStackedBar(byLevel: byLevel),
+            const SizedBox(height: 6),
+            Expanded(
+              child: catalog.entries.isEmpty
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(32),
+                        child: Text(
+                          'まだ習熟度は記録されていません',
+                          key: const Key('proficiency.empty'),
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: VsTokens.inkMute,
+                          ),
+                        ),
+                      ),
+                    )
+                  : ListView(
+                      key: const Key('proficiency.list'),
+                      padding: const EdgeInsets.fromLTRB(0, 8, 0, 32),
+                      children: <Widget>[
+                        for (final level in ProficiencyLevel.values)
+                          if (byLevel[level]!.isNotEmpty)
+                            _ProficiencySection(
+                              level: level,
+                              entries: byLevel[level]!,
+                            ),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProficiencyStackedBar extends StatelessWidget {
+  const _ProficiencyStackedBar({required this.byLevel});
+  final Map<ProficiencyLevel, List<VocabularyExpressionEntry>> byLevel;
+
+  @override
+  Widget build(BuildContext context) {
+    final totals = <ProficiencyLevel, int>{
+      for (final entry in byLevel.entries) entry.key: entry.value.length,
+    };
+    final totalCount = totals.values.fold<int>(0, (a, b) => a + b);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 4, 24, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: Container(
+              height: 12,
+              decoration: BoxDecoration(
+                border: Border.all(color: VsTokens.inkHair, width: 0.5),
+                borderRadius: BorderRadius.circular(6),
+                color: VsTokens.paperSoft,
+              ),
+              child: totalCount == 0
+                  ? const SizedBox.shrink()
+                  : Row(
+                      children: <Widget>[
+                        for (final level in ProficiencyLevel.values)
+                          if (totals[level]! > 0)
+                            Expanded(
+                              flex: totals[level]!,
+                              child: ColoredBox(color: _colorFor(level)),
+                            ),
+                      ],
+                    ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 12,
+            runSpacing: 6,
+            children: <Widget>[
+              for (final level in ProficiencyLevel.values)
+                _LegendChip(level: level, count: totals[level] ?? 0),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LegendChip extends StatelessWidget {
+  const _LegendChip({required this.level, required this.count});
+  final ProficiencyLevel level;
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(
+            color: _colorFor(level),
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ),
+        const SizedBox(width: 5),
+        Text(
+          _labelJa(level),
+          style: const TextStyle(
+            fontFamily: VsTokens.sans,
+            fontSize: 11,
+            color: VsTokens.inkSoft,
+          ),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          '$count',
+          style: const TextStyle(
+            fontFamily: VsTokens.mono,
+            fontSize: 11,
+            color: VsTokens.inkMute,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ProficiencySection extends StatelessWidget {
+  const _ProficiencySection({required this.level, required this.entries});
+
+  final ProficiencyLevel level;
+  final List<VocabularyExpressionEntry> entries;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 14, 24, 8),
+            child: Row(
+              children: <Widget>[
+                Container(
+                  width: 24,
+                  height: 24,
+                  decoration: BoxDecoration(
+                    color: _colorFor(level),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(
+                    _initialLetter(level),
+                    style: const TextStyle(
+                      fontFamily: VsTokens.serif,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: VsTokens.paper,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Text(
+                  '${_labelJa(level)} · ${_labelEn(level)}',
+                  style: theme.textTheme.headlineSmall,
+                ),
+                const Spacer(),
+                Text(
+                  '${entries.length}',
+                  style: const TextStyle(
+                    fontFamily: VsTokens.mono,
+                    fontSize: 11,
+                    color: VsTokens.inkMute,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                for (final entry in entries)
+                  _ProficiencyEntryRow(entry: entry),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProficiencyEntryRow extends StatelessWidget {
+  const _ProficiencyEntryRow({required this.entry});
+  final VocabularyExpressionEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Material(
+        color: VsTokens.paperSoft,
+        borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+        child: InkWell(
+          key: Key('proficiency.entry.${entry.identifier.value}'),
+          borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+          onTap: () => context.go(
+            '${AppRoutes.vocabularyPrefix}/${entry.identifier.value}',
+          ),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              border: Border.all(color: VsTokens.inkHair, width: 0.5),
+              borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+            ),
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    entry.text,
+                    style: const TextStyle(
+                      fontFamily: VsTokens.serif,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: VsTokens.ink,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (entry.registrationStatus.name.isNotEmpty)
+                  const VsChip(label: 'word'),
+                const SizedBox(width: 8),
+                const Icon(
+                  Icons.chevron_right,
+                  size: 14,
+                  color: VsTokens.inkMute,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Color _colorFor(ProficiencyLevel level) => switch (level) {
+      ProficiencyLevel.learning => VsTokens.profLearning,
+      ProficiencyLevel.learned => VsTokens.profLearned,
+      ProficiencyLevel.internalized => VsTokens.profInternalized,
+      ProficiencyLevel.fluent => VsTokens.profFluent,
+    };
+
+String _labelJa(ProficiencyLevel level) => switch (level) {
+      ProficiencyLevel.learning => '学習中',
+      ProficiencyLevel.learned => '習得',
+      ProficiencyLevel.internalized => '定着',
+      ProficiencyLevel.fluent => '自在',
+    };
+
+String _labelEn(ProficiencyLevel level) => switch (level) {
+      ProficiencyLevel.learning => 'Learning',
+      ProficiencyLevel.learned => 'Learned',
+      ProficiencyLevel.internalized => 'Internalized',
+      ProficiencyLevel.fluent => 'Fluent',
+    };
+
+String _initialLetter(ProficiencyLevel level) => _labelEn(level)[0];

--- a/applications/mobile/lib/src/presentation/restricted/restricted_access_screen.dart
+++ b/applications/mobile/lib/src/presentation/restricted/restricted_access_screen.dart
@@ -9,9 +9,9 @@ import '../theme/widgets/vs_wordmark.dart';
 
 /// Spec 013 canonical `RestrictedAccess` screen (Restricted route group).
 ///
-/// Hard stop — the learner cannot see any AppShell content. Only two
-/// recovery options are exposed: review subscription status, or sign out
-/// and attempt to sign back in.
+/// Visual reference: `screens.jsx` restricted template. Accent-soft badge
+/// with a block icon, Mincho headline, muted sans body, and two recovery
+/// CTAs (status check + sign-out).
 class RestrictedAccessScreen extends ConsumerWidget {
   const RestrictedAccessScreen({super.key});
 
@@ -22,34 +22,37 @@ class RestrictedAccessScreen extends ConsumerWidget {
       backgroundColor: VsTokens.paper,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
+          padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
               const Align(
                 alignment: Alignment.centerLeft,
-                child: VsWordmark(),
+                child: VsWordmark(size: 13),
               ),
               const Spacer(),
-              Container(
-                width: 72,
-                height: 72,
-                decoration: const BoxDecoration(
-                  color: VsTokens.accentSoft,
-                  shape: BoxShape.circle,
-                ),
-                child: const Icon(
-                  Icons.block,
-                  key: Key('restricted.icon'),
-                  size: 32,
-                  color: VsTokens.accentDeep,
+              Center(
+                child: Container(
+                  width: 72,
+                  height: 72,
+                  decoration: const BoxDecoration(
+                    color: VsTokens.accentSoft,
+                    shape: BoxShape.circle,
+                  ),
+                  alignment: Alignment.center,
+                  child: const Icon(
+                    Icons.block,
+                    key: Key('restricted.icon'),
+                    size: 32,
+                    color: VsTokens.accentDeep,
+                  ),
                 ),
               ),
               const SizedBox(height: 20),
               Text(
                 'ご利用になれません',
                 textAlign: TextAlign.center,
-                style: theme.textTheme.headlineLarge,
+                style: theme.textTheme.displaySmall,
               ),
               const SizedBox(height: 10),
               Text(
@@ -58,6 +61,7 @@ class RestrictedAccessScreen extends ConsumerWidget {
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: VsTokens.inkMute,
+                  height: 1.6,
                 ),
               ),
               const Spacer(),
@@ -74,9 +78,12 @@ class RestrictedAccessScreen extends ConsumerWidget {
                   if (!context.mounted) return;
                   context.go(AppRoutes.login);
                 },
+                style: TextButton.styleFrom(
+                  foregroundColor: VsTokens.inkMute,
+                ),
                 child: const Text('サインアウトして再試行'),
               ),
-              const SizedBox(height: 16),
+              const SizedBox(height: 10),
             ],
           ),
         ),

--- a/applications/mobile/lib/src/presentation/router/router.dart
+++ b/applications/mobile/lib/src/presentation/router/router.dart
@@ -8,6 +8,7 @@ import '../../domain/identifier/identifier.dart';
 import '../../domain/status/subscription_state.dart';
 import '../auth/login_screen.dart';
 import '../auth/session_resolving_screen.dart';
+import '../catalog/explanation_generating_screen.dart';
 import '../catalog/vocabulary_catalog_screen.dart';
 import '../catalog/vocabulary_registration_screen.dart';
 import '../detail/explanation_detail_screen.dart';
@@ -16,6 +17,7 @@ import '../detail/vocabulary_expression_detail_screen.dart';
 import '../paywall/paywall_screen.dart';
 import '../proficiency/proficiency_screen.dart';
 import '../restricted/restricted_access_screen.dart';
+import '../settings/settings_screen.dart';
 import '../shell/app_shell.dart';
 import '../subscription/subscription_status_screen.dart';
 
@@ -25,12 +27,14 @@ class AppRoutes {
   static const sessionResolving = '/session-resolving';
   static const catalog = '/catalog';
   static const registration = '/registration';
+  static const registrationGenerating = '/registration/generating';
   static const vocabularyPrefix = '/vocabulary';
   static const explanationPrefix = '/explanation';
   static const imagePrefix = '/image';
   static const subscriptionStatus = '/subscription';
   static const paywall = '/paywall';
   static const proficiency = '/proficiency';
+  static const settings = '/settings';
   static const restricted = '/restricted';
 }
 
@@ -77,6 +81,12 @@ final routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const VocabularyRegistrationScreen(),
       ),
       GoRoute(
+        path: AppRoutes.registrationGenerating,
+        builder: (context, state) => ExplanationGeneratingScreen(
+          text: (state.extra as String?) ?? '',
+        ),
+      ),
+      GoRoute(
         path: '${AppRoutes.vocabularyPrefix}/:identifier',
         builder: (context, state) => VocabularyExpressionDetailScreen(
           identifier: VocabularyExpressionIdentifier(
@@ -99,6 +109,10 @@ final routerProvider = Provider<GoRouter>((ref) {
             state.pathParameters['identifier']!,
           ),
         ),
+      ),
+      GoRoute(
+        path: AppRoutes.subscriptionStatus,
+        builder: (context, state) => const SubscriptionStatusScreen(),
       ),
       GoRoute(
         path: AppRoutes.restricted,
@@ -135,9 +149,8 @@ final routerProvider = Provider<GoRouter>((ref) {
           StatefulShellBranch(
             routes: <RouteBase>[
               GoRoute(
-                path: AppRoutes.subscriptionStatus,
-                builder: (context, state) =>
-                    const SubscriptionStatusScreen(),
+                path: AppRoutes.settings,
+                builder: (context, state) => const SettingsScreen(),
               ),
             ],
           ),
@@ -150,12 +163,14 @@ final routerProvider = Provider<GoRouter>((ref) {
 bool _isAppShellLocation(String location) {
   return location == AppRoutes.catalog ||
       location == AppRoutes.registration ||
+      location == AppRoutes.registrationGenerating ||
       location.startsWith('${AppRoutes.vocabularyPrefix}/') ||
       location.startsWith('${AppRoutes.explanationPrefix}/') ||
       location.startsWith('${AppRoutes.imagePrefix}/') ||
       location == AppRoutes.subscriptionStatus ||
       location == AppRoutes.paywall ||
-      location == AppRoutes.proficiency;
+      location == AppRoutes.proficiency ||
+      location == AppRoutes.settings;
 }
 
 String? _redirect(
@@ -195,6 +210,10 @@ String? _redirect(
 
   if (location == AppRoutes.login ||
       location == AppRoutes.sessionResolving) {
+    return AppRoutes.catalog;
+  }
+  if (location == AppRoutes.subscriptionStatus &&
+      subscription == null) {
     return AppRoutes.catalog;
   }
   return null;

--- a/applications/mobile/lib/src/presentation/router/router.dart
+++ b/applications/mobile/lib/src/presentation/router/router.dart
@@ -14,6 +14,7 @@ import '../detail/explanation_detail_screen.dart';
 import '../detail/image_detail_screen.dart';
 import '../detail/vocabulary_expression_detail_screen.dart';
 import '../paywall/paywall_screen.dart';
+import '../proficiency/proficiency_screen.dart';
 import '../restricted/restricted_access_screen.dart';
 import '../subscription/subscription_status_screen.dart';
 
@@ -28,6 +29,7 @@ class AppRoutes {
   static const imagePrefix = '/image';
   static const subscriptionStatus = '/subscription';
   static const paywall = '/paywall';
+  static const proficiency = '/proficiency';
   static const restricted = '/restricted';
 }
 
@@ -110,6 +112,10 @@ final routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const PaywallScreen(),
       ),
       GoRoute(
+        path: AppRoutes.proficiency,
+        builder: (context, state) => const ProficiencyScreen(),
+      ),
+      GoRoute(
         path: AppRoutes.restricted,
         builder: (context, state) => const RestrictedAccessScreen(),
       ),
@@ -124,7 +130,8 @@ bool _isAppShellLocation(String location) {
       location.startsWith('${AppRoutes.explanationPrefix}/') ||
       location.startsWith('${AppRoutes.imagePrefix}/') ||
       location == AppRoutes.subscriptionStatus ||
-      location == AppRoutes.paywall;
+      location == AppRoutes.paywall ||
+      location == AppRoutes.proficiency;
 }
 
 String? _redirect(

--- a/applications/mobile/lib/src/presentation/router/router.dart
+++ b/applications/mobile/lib/src/presentation/router/router.dart
@@ -16,6 +16,7 @@ import '../detail/vocabulary_expression_detail_screen.dart';
 import '../paywall/paywall_screen.dart';
 import '../proficiency/proficiency_screen.dart';
 import '../restricted/restricted_access_screen.dart';
+import '../shell/app_shell.dart';
 import '../subscription/subscription_status_screen.dart';
 
 /// Canonical route paths (spec 013 navigation-topology-contract).
@@ -62,7 +63,7 @@ final routerProvider = Provider<GoRouter>((ref) {
           ref.read(subscriptionStatusStreamProvider).value?.state;
       return _redirect(handoff, subscription, state.matchedLocation);
     },
-    routes: [
+    routes: <RouteBase>[
       GoRoute(
         path: AppRoutes.login,
         builder: (context, state) => const LoginScreen(),
@@ -70,10 +71,6 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: AppRoutes.sessionResolving,
         builder: (context, state) => const SessionResolvingScreen(),
-      ),
-      GoRoute(
-        path: AppRoutes.catalog,
-        builder: (context, state) => const VocabularyCatalogScreen(),
       ),
       GoRoute(
         path: AppRoutes.registration,
@@ -104,20 +101,47 @@ final routerProvider = Provider<GoRouter>((ref) {
         ),
       ),
       GoRoute(
-        path: AppRoutes.subscriptionStatus,
-        builder: (context, state) => const SubscriptionStatusScreen(),
-      ),
-      GoRoute(
-        path: AppRoutes.paywall,
-        builder: (context, state) => const PaywallScreen(),
-      ),
-      GoRoute(
-        path: AppRoutes.proficiency,
-        builder: (context, state) => const ProficiencyScreen(),
-      ),
-      GoRoute(
         path: AppRoutes.restricted,
         builder: (context, state) => const RestrictedAccessScreen(),
+      ),
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) =>
+            AppShell(navigationShell: navigationShell),
+        branches: <StatefulShellBranch>[
+          StatefulShellBranch(
+            routes: <RouteBase>[
+              GoRoute(
+                path: AppRoutes.catalog,
+                builder: (context, state) => const VocabularyCatalogScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: <RouteBase>[
+              GoRoute(
+                path: AppRoutes.proficiency,
+                builder: (context, state) => const ProficiencyScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: <RouteBase>[
+              GoRoute(
+                path: AppRoutes.paywall,
+                builder: (context, state) => const PaywallScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: <RouteBase>[
+              GoRoute(
+                path: AppRoutes.subscriptionStatus,
+                builder: (context, state) =>
+                    const SubscriptionStatusScreen(),
+              ),
+            ],
+          ),
+        ],
       ),
     ],
   );

--- a/applications/mobile/lib/src/presentation/settings/settings_screen.dart
+++ b/applications/mobile/lib/src/presentation/settings/settings_screen.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app_bindings.dart';
+import '../../domain/subscription/plan.dart';
+import '../detail/detail_layout_preference.dart';
+import '../router/router.dart';
+import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_section_label.dart';
+import '../theme/widgets/vs_settings_row.dart';
+import '../theme/widgets/vs_wordmark.dart';
+
+/// Full Settings screen mirroring `screens.jsx` `VSSettings`.
+///
+/// Replaces `/subscription` as the fourth AppShell branch. Rows group
+/// account, generation preferences, and app configuration; the account
+/// section links into `/subscription` while the generation section owns
+/// the `detailLayoutProvider` picker.
+class SettingsScreen extends ConsumerWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final layout = ref.watch(detailLayoutProvider);
+    final subscription = ref.watch(subscriptionStatusStreamProvider).value;
+
+    return Scaffold(
+      backgroundColor: VsTokens.paper,
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(0, 16, 0, 24),
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const VsWordmark(size: 13),
+                  const SizedBox(height: 8),
+                  Text('設定', style: theme.textTheme.displaySmall),
+                ],
+              ),
+            ),
+            _SectionGroup(
+              title: 'アカウント',
+              child: Column(
+                children: <Widget>[
+                  VsSettingsRow(
+                    key: const Key('settings.row.profile'),
+                    icon: Icons.favorite_border,
+                    label: 'プロフィール',
+                    sub: '学習者',
+                    onTap: () => _showUnsupported(context, 'プロフィール'),
+                  ),
+                  VsSettingsRow(
+                    key: const Key('settings.row.subscription'),
+                    icon: Icons.emoji_events_outlined,
+                    label: 'サブスクリプション',
+                    sub: _subscriptionSubtitle(subscription?.plan),
+                    onTap: () => context.go(AppRoutes.subscriptionStatus),
+                    isLast: true,
+                  ),
+                ],
+              ),
+            ),
+            _SectionGroup(
+              title: '生成設定',
+              child: Column(
+                children: <Widget>[
+                  VsSettingsRow(
+                    key: const Key('settings.row.detail-layout'),
+                    icon: Icons.auto_awesome,
+                    label: 'AI解説のレイアウト',
+                    sub: layout.label,
+                    onTap: () => _pickDetailLayout(context, ref, layout),
+                  ),
+                  VsSettingsRow(
+                    key: const Key('settings.row.image-style'),
+                    icon: Icons.image_outlined,
+                    label: '画像スタイル',
+                    sub: 'イラストレーション',
+                    onTap: () => _showUnsupported(context, '画像スタイル'),
+                  ),
+                  VsSettingsRow(
+                    key: const Key('settings.row.notifications'),
+                    icon: Icons.bolt_outlined,
+                    label: '生成通知',
+                    sub: '完了時にプッシュ',
+                    onTap: () => _showUnsupported(context, '生成通知'),
+                    isLast: true,
+                  ),
+                ],
+              ),
+            ),
+            _SectionGroup(
+              title: 'アプリ',
+              child: Column(
+                children: <Widget>[
+                  VsSettingsRow(
+                    key: const Key('settings.row.export'),
+                    icon: Icons.menu_book_outlined,
+                    label: 'データエクスポート',
+                    onTap: () => _showUnsupported(context, 'データエクスポート'),
+                  ),
+                  VsSettingsRow(
+                    key: const Key('settings.row.locale'),
+                    icon: Icons.settings_outlined,
+                    label: '言語・表記',
+                    sub: '日本語',
+                    onTap: () => _showUnsupported(context, '言語・表記'),
+                    isLast: true,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _subscriptionSubtitle(PlanCode? plan) {
+    switch (plan) {
+      case PlanCode.free:
+      case null:
+        return 'Free プラン';
+      case PlanCode.standardMonthly:
+        return 'Standard (月額)';
+      case PlanCode.proMonthly:
+        return 'Pro (月額)';
+    }
+  }
+
+  void _showUnsupported(BuildContext context, String name) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('$name は未対応です')),
+    );
+  }
+
+  Future<void> _pickDetailLayout(
+    BuildContext context,
+    WidgetRef ref,
+    DetailLayout current,
+  ) async {
+    final selected = await showModalBottomSheet<DetailLayout>(
+      context: context,
+      backgroundColor: VsTokens.paper,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(VsTokens.radiusLg),
+        ),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                const VsSectionLabel('AI解説のレイアウト'),
+                const SizedBox(height: 12),
+                for (final option in DetailLayout.values)
+                  ListTile(
+                    key: Key('settings.layout.${option.name}'),
+                    title: Text(option.label),
+                    trailing: current == option
+                        ? const Icon(Icons.check, color: VsTokens.accent)
+                        : null,
+                    onTap: () => Navigator.of(context).pop(option),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+    if (selected != null) {
+      ref.read(detailLayoutProvider.notifier).set(selected);
+    }
+  }
+}
+
+class _SectionGroup extends StatelessWidget {
+  const _SectionGroup({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
+            child: VsSectionLabel(title),
+          ),
+          Container(
+            margin: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(
+              color: VsTokens.paperSoft,
+              border: Border.all(color: VsTokens.inkHair),
+              borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: child,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/shell/app_shell.dart
+++ b/applications/mobile/lib/src/presentation/shell/app_shell.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_bottom_tab_bar.dart';
+
+/// Persistent chrome that hosts the four main AppShell branches
+/// (catalog / proficiency / paywall / subscription-status).
+///
+/// The `StatefulShellRoute.indexedStack` builder hands in a
+/// [StatefulNavigationShell] whose body must be rendered above the tab
+/// bar. Because the tab bar lives in the shell (not on each screen), it
+/// does not participate in the route-transition animation when the user
+/// switches tabs — matching the `screens.jsx` `VSTabBar` behaviour.
+class AppShell extends StatelessWidget {
+  const AppShell({required this.navigationShell, super.key});
+
+  final StatefulNavigationShell navigationShell;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: VsTokens.paper,
+      body: navigationShell,
+      bottomNavigationBar: VsBottomTabBar(
+        currentIndex: navigationShell.currentIndex,
+        onTap: (index) => navigationShell.goBranch(
+          index,
+          initialLocation: index == navigationShell.currentIndex,
+        ),
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/subscription/subscription_status_screen.dart
+++ b/applications/mobile/lib/src/presentation/subscription/subscription_status_screen.dart
@@ -12,6 +12,7 @@ import '../../domain/subscription/entitlement.dart';
 import '../../domain/subscription/plan.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
+import '../theme/widgets/vs_bottom_tab_bar.dart';
 import '../theme/widgets/vs_chip.dart';
 import '../theme/widgets/vs_section_label.dart';
 import '../theme/widgets/vs_spinner.dart';
@@ -43,6 +44,7 @@ class SubscriptionStatusScreen extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
+      bottomNavigationBar: const VsBottomTabBar(),
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/applications/mobile/lib/src/presentation/subscription/subscription_status_screen.dart
+++ b/applications/mobile/lib/src/presentation/subscription/subscription_status_screen.dart
@@ -12,7 +12,6 @@ import '../../domain/subscription/entitlement.dart';
 import '../../domain/subscription/plan.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
-import '../theme/widgets/vs_bottom_tab_bar.dart';
 import '../theme/widgets/vs_chip.dart';
 import '../theme/widgets/vs_section_label.dart';
 import '../theme/widgets/vs_spinner.dart';
@@ -44,7 +43,6 @@ class SubscriptionStatusScreen extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: VsTokens.paper,
-      bottomNavigationBar: const VsBottomTabBar(),
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/applications/mobile/lib/src/presentation/subscription/subscription_status_screen.dart
+++ b/applications/mobile/lib/src/presentation/subscription/subscription_status_screen.dart
@@ -13,17 +13,17 @@ import '../../domain/subscription/plan.dart';
 import '../router/router.dart';
 import '../theme/vs_tokens.dart';
 import '../theme/widgets/vs_chip.dart';
-import '../theme/widgets/vs_screen_scaffold.dart';
+import '../theme/widgets/vs_section_label.dart';
 import '../theme/widgets/vs_spinner.dart';
+import '../theme/widgets/vs_wordmark.dart';
 
 /// Spec 013 canonical `SubscriptionStatus` screen.
 ///
-/// Renders the four concepts in separate sections per constitution §VI:
-///   - subscription state
-///   - plan code
-///   - entitlement bundle
-///   - usage allowance
-/// plus a recovery section with restore CTA.
+/// Visual reference: `screens.jsx` `VSSettings` row pattern. The four
+/// concepts (state, plan, entitlement, allowance) remain in separate
+/// sections per constitution §VI; each is framed by a `VsSectionLabel` and
+/// rendered as a paperSoft row with an icon box. The recovery section
+/// exposes the restore CTA as an accent ElevatedButton.
 class SubscriptionStatusScreen extends ConsumerWidget {
   const SubscriptionStatusScreen({super.key});
 
@@ -39,66 +39,216 @@ class SubscriptionStatusScreen extends ConsumerWidget {
         body: Center(child: VsSpinner(size: 18)),
       );
     }
+    final theme = Theme.of(context);
 
-    return VsScreenScaffold(
-      eyebrow: 'SUBSCRIPTION',
-      title: 'サブスクリプション',
-      caption: 'プラン・権利・残量を一覧で確認します。',
-      trailing: IconButton(
-        key: const Key('subscription-status.logout'),
-        icon: const Icon(Icons.logout),
-        onPressed: () async {
-          await ref.read(logoutCommandProvider).signOut();
-          if (!context.mounted) return;
-          context.go(AppRoutes.login);
-        },
+    return Scaffold(
+      backgroundColor: VsTokens.paper,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 8, 12),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        const VsWordmark(size: 13),
+                        const SizedBox(height: 10),
+                        Text(
+                          'サブスクリプション',
+                          style: theme.textTheme.displaySmall,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'プラン・権利・残量を一覧で確認します。',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: VsTokens.inkMute,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    key: const Key('subscription-status.logout'),
+                    icon: const Icon(Icons.logout, size: 20),
+                    color: VsTokens.inkSoft,
+                    onPressed: () async {
+                      await ref.read(logoutCommandProvider).signOut();
+                      if (!context.mounted) return;
+                      context.go(AppRoutes.login);
+                    },
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+                children: <Widget>[
+                  const VsSectionLabel('アカウント'),
+                  const SizedBox(height: 8),
+                  _SectionCard(
+                    rows: <_SectionRow>[
+                      _SectionRow(
+                        keyValue: 'subscription-status.state',
+                        icon: Icons.shield_outlined,
+                        label: '状態',
+                        value: _stateLabel(view.state),
+                        tone: _stateTone(view.state),
+                      ),
+                      _SectionRow(
+                        keyValue: 'subscription-status.plan',
+                        icon: Icons.emoji_events_outlined,
+                        label: 'プラン',
+                        value: _planLabel(view.plan),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  const VsSectionLabel('利用可能な機能'),
+                  const SizedBox(height: 8),
+                  _SectionCard(
+                    rows: <_SectionRow>[
+                      _SectionRow(
+                        keyValue: 'subscription-status.entitlement',
+                        icon: Icons.auto_awesome,
+                        label: '権利',
+                        value: _entitlementLabel(view.entitlement),
+                      ),
+                      _SectionRow(
+                        keyValue: 'subscription-status.allowance',
+                        icon: Icons.bolt_outlined,
+                        label: '今月の残量',
+                        value:
+                            '解説 ${view.allowance.remainingExplanationGenerations} / '
+                            '画像 ${view.allowance.remainingImageGenerations}',
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 28),
+                  const VsSectionLabel('購入履歴を復元'),
+                  const SizedBox(height: 10),
+                  ElevatedButton(
+                    key: const Key('subscription-status.restore'),
+                    onPressed: () {
+                      final command =
+                          ref.read(requestRestorePurchaseCommandProvider);
+                      unawaited(
+                        command.restore(
+                          idempotencyKey:
+                              IdempotencyKey(_uuidGenerator.v4()),
+                        ),
+                      );
+                    },
+                    child: const Text('復元する'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
-      body: ListView(
-        padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+    );
+  }
+}
+
+class _SectionRow {
+  const _SectionRow({
+    required this.keyValue,
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.tone,
+  });
+
+  final String keyValue;
+  final IconData icon;
+  final String label;
+  final String value;
+  final VsChipTone? tone;
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({required this.rows});
+  final List<_SectionRow> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: VsTokens.paperSoft,
+        border: Border.all(color: VsTokens.inkHair),
+        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
         children: <Widget>[
-          _SectionCard(
-            keyValue: 'subscription-status.state',
-            label: '状態',
-            value: _stateLabel(view.state),
-            tone: _stateTone(view.state),
+          for (var index = 0; index < rows.length; index++)
+            _SectionRowWidget(
+              row: rows[index],
+              isLast: index == rows.length - 1,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionRowWidget extends StatelessWidget {
+  const _SectionRowWidget({required this.row, required this.isLast});
+
+  final _SectionRow row;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      key: Key(row.keyValue),
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: isLast ? Colors.transparent : VsTokens.inkHair,
+            width: 0.5,
           ),
-          const SizedBox(height: 12),
-          _SectionCard(
-            keyValue: 'subscription-status.plan',
-            label: 'プラン',
-            value: _planLabel(view.plan),
+        ),
+      ),
+      child: Row(
+        children: <Widget>[
+          Container(
+            width: 30,
+            height: 30,
+            decoration: BoxDecoration(
+              color: VsTokens.paperDeep,
+              borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+            ),
+            alignment: Alignment.center,
+            child: Icon(row.icon, size: 15, color: VsTokens.inkSoft),
           ),
-          const SizedBox(height: 12),
-          _SectionCard(
-            keyValue: 'subscription-status.entitlement',
-            label: '利用可能な機能',
-            value: _entitlementLabel(view.entitlement),
-          ),
-          const SizedBox(height: 12),
-          _SectionCard(
-            keyValue: 'subscription-status.allowance',
-            label: '今月の残量',
-            value:
-                '解説 ${view.allowance.remainingExplanationGenerations} / '
-                '画像 ${view.allowance.remainingImageGenerations}',
-          ),
-          const SizedBox(height: 24),
-          Text(
-            '購入履歴を復元',
-            style: Theme.of(context).textTheme.labelMedium,
-          ),
-          const SizedBox(height: 8),
-          ElevatedButton(
-            key: const Key('subscription-status.restore'),
-            onPressed: () {
-              final command = ref.read(requestRestorePurchaseCommandProvider);
-              unawaited(
-                command.restore(
-                  idempotencyKey: IdempotencyKey(_uuidGenerator.v4()),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  row.label,
+                  style: theme.textTheme.titleSmall,
                 ),
-              );
-            },
-            child: const Text('復元する'),
+                const SizedBox(height: 1),
+                Text(
+                  row.value,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: _valueColor(row.tone),
+                  ),
+                ),
+              ],
+            ),
           ),
         ],
       ),
@@ -106,66 +256,15 @@ class SubscriptionStatusScreen extends ConsumerWidget {
   }
 }
 
-class _SectionCard extends StatelessWidget {
-  const _SectionCard({
-    required this.keyValue,
-    required this.label,
-    required this.value,
-    this.tone,
-  });
-
-  final String keyValue;
-  final String label;
-  final String value;
-  final VsChipTone? tone;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      key: Key(keyValue),
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
-      decoration: BoxDecoration(
-        color: VsTokens.paperSoft,
-        borderRadius: BorderRadius.circular(VsTokens.radiusMd),
-        border: Border.all(color: VsTokens.inkHair),
-      ),
-      child: Row(
-        children: <Widget>[
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(label, style: theme.textTheme.labelMedium),
-                const SizedBox(height: 2),
-                Text(
-                  value,
-                  style: theme.textTheme.titleMedium,
-                ),
-              ],
-            ),
-          ),
-          if (tone != null) VsChip(label: _chipLabel(), tone: tone!),
-        ],
-      ),
-    );
-  }
-
-  String _chipLabel() {
-    switch (tone!) {
-      case VsChipTone.ok:
-        return 'ACTIVE';
-      case VsChipTone.accent:
-        return 'SYNC';
-      case VsChipTone.warn:
-        return 'GRACE';
-      case VsChipTone.err:
-        return 'BLOCKED';
-      case VsChipTone.neutral:
-      case VsChipTone.dark:
-        return value;
-    }
-  }
+Color _valueColor(VsChipTone? tone) {
+  if (tone == null) return VsTokens.inkMute;
+  return switch (tone) {
+    VsChipTone.ok => VsTokens.ok,
+    VsChipTone.warn => VsTokens.warn,
+    VsChipTone.accent => VsTokens.accentDeep,
+    VsChipTone.err => VsTokens.err,
+    VsChipTone.neutral || VsChipTone.dark => VsTokens.inkMute,
+  };
 }
 
 String _stateLabel(SubscriptionState state) => switch (state) {

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_bottom_tab_bar.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_bottom_tab_bar.dart
@@ -1,0 +1,158 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../router/router.dart';
+import '../vs_tokens.dart';
+
+/// Bottom tab chrome mirroring `screens.jsx` `VSTabBar`.
+///
+/// Fixed to the bottom of the AppShell screens (Catalog / Proficiency /
+/// Paywall / Subscription Status). Active tab is inferred from the current
+/// [GoRouter] location so each screen simply drops the bar into its
+/// Scaffold's `bottomNavigationBar` slot.
+class VsBottomTabBar extends StatelessWidget {
+  const VsBottomTabBar({super.key});
+
+  static const List<_TabDefinition> _tabs = <_TabDefinition>[
+    _TabDefinition(
+      route: AppRoutes.catalog,
+      label: '単語帳',
+      icon: Icons.menu_book_outlined,
+      activeIcon: Icons.menu_book,
+    ),
+    _TabDefinition(
+      route: AppRoutes.proficiency,
+      label: '習熟',
+      icon: Icons.layers_outlined,
+      activeIcon: Icons.layers,
+    ),
+    _TabDefinition(
+      route: AppRoutes.paywall,
+      label: 'プラン',
+      icon: Icons.emoji_events_outlined,
+      activeIcon: Icons.emoji_events,
+    ),
+    _TabDefinition(
+      route: AppRoutes.subscriptionStatus,
+      label: '設定',
+      icon: Icons.settings_outlined,
+      activeIcon: Icons.settings,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final location = GoRouterState.of(context).matchedLocation;
+    final bottomInset = MediaQuery.of(context).padding.bottom;
+    return ClipRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+        child: DecoratedBox(
+          decoration: const BoxDecoration(
+            color: Color(0xE0F6F1E7),
+            border: Border(
+              top: BorderSide(color: VsTokens.inkHair, width: 0.5),
+            ),
+          ),
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              0,
+              8,
+              0,
+              bottomInset > 0 ? bottomInset : 12,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: <Widget>[
+                for (final tab in _tabs)
+                  _TabButton(
+                    tab: tab,
+                    isActive: _isActive(tab.route, location),
+                    onTap: () => context.go(tab.route),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  static bool _isActive(String tabRoute, String location) {
+    if (tabRoute == location) return true;
+    // Detail screens remain under the catalog tab.
+    if (tabRoute == AppRoutes.catalog) {
+      return location.startsWith('${AppRoutes.vocabularyPrefix}/') ||
+          location.startsWith('${AppRoutes.explanationPrefix}/') ||
+          location.startsWith('${AppRoutes.imagePrefix}/') ||
+          location == AppRoutes.registration;
+    }
+    return false;
+  }
+}
+
+@immutable
+class _TabDefinition {
+  const _TabDefinition({
+    required this.route,
+    required this.label,
+    required this.icon,
+    required this.activeIcon,
+  });
+
+  final String route;
+  final String label;
+  final IconData icon;
+  final IconData activeIcon;
+}
+
+class _TabButton extends StatelessWidget {
+  const _TabButton({
+    required this.tab,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  final _TabDefinition tab;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isActive ? VsTokens.accent : VsTokens.inkMute;
+    return Semantics(
+      button: true,
+      selected: isActive,
+      label: tab.label,
+      child: InkResponse(
+        onTap: onTap,
+        radius: 36,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(
+                isActive ? tab.activeIcon : tab.icon,
+                size: 22,
+                color: color,
+              ),
+              const SizedBox(height: 2),
+              Text(
+                tab.label,
+                style: TextStyle(
+                  fontFamily: VsTokens.sans,
+                  fontSize: 10,
+                  fontWeight: isActive ? FontWeight.w600 : FontWeight.w400,
+                  color: color,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_bottom_tab_bar.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_bottom_tab_bar.dart
@@ -1,41 +1,41 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 
-import '../../router/router.dart';
 import '../vs_tokens.dart';
 
 /// Bottom tab chrome mirroring `screens.jsx` `VSTabBar`.
 ///
-/// Fixed to the bottom of the AppShell screens (Catalog / Proficiency /
-/// Paywall / Subscription Status). Active tab is inferred from the current
-/// [GoRouter] location so each screen simply drops the bar into its
-/// Scaffold's `bottomNavigationBar` slot.
+/// Driven by the parent shell's current branch index. The shell owns the
+/// selection state so tab switches only swap the body subtree — the tab
+/// bar itself stays pinned across navigations.
 class VsBottomTabBar extends StatelessWidget {
-  const VsBottomTabBar({super.key});
+  const VsBottomTabBar({
+    required this.currentIndex,
+    required this.onTap,
+    super.key,
+  });
+
+  final int currentIndex;
+  final ValueChanged<int> onTap;
 
   static const List<_TabDefinition> _tabs = <_TabDefinition>[
     _TabDefinition(
-      route: AppRoutes.catalog,
       label: '単語帳',
       icon: Icons.menu_book_outlined,
       activeIcon: Icons.menu_book,
     ),
     _TabDefinition(
-      route: AppRoutes.proficiency,
       label: '習熟',
       icon: Icons.layers_outlined,
       activeIcon: Icons.layers,
     ),
     _TabDefinition(
-      route: AppRoutes.paywall,
       label: 'プラン',
       icon: Icons.emoji_events_outlined,
       activeIcon: Icons.emoji_events,
     ),
     _TabDefinition(
-      route: AppRoutes.subscriptionStatus,
       label: '設定',
       icon: Icons.settings_outlined,
       activeIcon: Icons.settings,
@@ -44,7 +44,6 @@ class VsBottomTabBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final location = GoRouterState.of(context).matchedLocation;
     final bottomInset = MediaQuery.of(context).padding.bottom;
     return ClipRect(
       child: BackdropFilter(
@@ -66,11 +65,11 @@ class VsBottomTabBar extends StatelessWidget {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: <Widget>[
-                for (final tab in _tabs)
+                for (var index = 0; index < _tabs.length; index++)
                   _TabButton(
-                    tab: tab,
-                    isActive: _isActive(tab.route, location),
-                    onTap: () => context.go(tab.route),
+                    tab: _tabs[index],
+                    isActive: index == currentIndex,
+                    onTap: () => onTap(index),
                   ),
               ],
             ),
@@ -79,30 +78,16 @@ class VsBottomTabBar extends StatelessWidget {
       ),
     );
   }
-
-  static bool _isActive(String tabRoute, String location) {
-    if (tabRoute == location) return true;
-    // Detail screens remain under the catalog tab.
-    if (tabRoute == AppRoutes.catalog) {
-      return location.startsWith('${AppRoutes.vocabularyPrefix}/') ||
-          location.startsWith('${AppRoutes.explanationPrefix}/') ||
-          location.startsWith('${AppRoutes.imagePrefix}/') ||
-          location == AppRoutes.registration;
-    }
-    return false;
-  }
 }
 
 @immutable
 class _TabDefinition {
   const _TabDefinition({
-    required this.route,
     required this.label,
     required this.icon,
     required this.activeIcon,
   });
 
-  final String route;
   final String label;
   final IconData icon;
   final IconData activeIcon;

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_bottom_tab_bar.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_bottom_tab_bar.dart
@@ -37,8 +37,8 @@ class VsBottomTabBar extends StatelessWidget {
     ),
     _TabDefinition(
       label: '設定',
-      icon: Icons.settings_outlined,
-      activeIcon: Icons.settings,
+      icon: Icons.tune,
+      activeIcon: Icons.tune,
     ),
   ];
 

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_brand_mark.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_brand_mark.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+
+/// Brand glyph in paperSoft circle with a serif "V" stroke and an accent
+/// dot at the lower-right — mirrors `VSLoginWelcome`'s hero brand mark.
+class VsBrandMark extends StatelessWidget {
+  const VsBrandMark({this.size = 72, this.accentDotSize = 10, super.key});
+
+  final double size;
+  final double accentDotSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        children: <Widget>[
+          DecoratedBox(
+            decoration: const BoxDecoration(
+              color: VsTokens.paperSoft,
+              shape: BoxShape.circle,
+            ),
+            child: CustomPaint(
+              size: Size(size, size),
+              painter: const _VGlyphPainter(),
+            ),
+          ),
+          Positioned(
+            right: size * 0.14,
+            bottom: size * 0.14,
+            child: Container(
+              width: accentDotSize,
+              height: accentDotSize,
+              decoration: const BoxDecoration(
+                color: VsTokens.accent,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VGlyphPainter extends CustomPainter {
+  const _VGlyphPainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final stroke = Paint()
+      ..color = VsTokens.ink
+      ..strokeWidth = size.width * 0.07
+      ..strokeCap = StrokeCap.round
+      ..style = PaintingStyle.stroke;
+
+    final path = Path()
+      ..moveTo(size.width * 0.28, size.height * 0.32)
+      ..lineTo(size.width * 0.5, size.height * 0.68)
+      ..lineTo(size.width * 0.72, size.height * 0.32);
+
+    canvas.drawPath(path, stroke);
+  }
+
+  @override
+  bool shouldRepaint(covariant _VGlyphPainter oldDelegate) => false;
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_chip.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_chip.dart
@@ -46,12 +46,18 @@ _VsChipColors _tonePalette(VsChipTone tone) {
   }
 }
 
-/// Small pill label mirroring the handoff bundle's `VSChip` component.
+/// Pill label mirroring the handoff bundle's `VSChip`.
+///
+/// Supports an optional leading [icon] (sized to 12 px by default) and an
+/// [outlined] mode that replaces the tone background with a transparent
+/// fill and a 0.8 px border in the tone foreground.
 class VsChip extends StatelessWidget {
   const VsChip({
     required this.label,
     this.tone = VsChipTone.neutral,
     this.icon,
+    this.outlined = false,
+    this.color,
     super.key,
   });
 
@@ -59,21 +65,33 @@ class VsChip extends StatelessWidget {
   final VsChipTone tone;
   final Widget? icon;
 
+  /// Render as an outlined pill with transparent fill. Uses [color] if
+  /// provided, otherwise the tone's foreground.
+  final bool outlined;
+
+  /// Overrides the resolved foreground (useful for proficiency chips where
+  /// the color comes from `VsTokens.prof*`).
+  final Color? color;
+
   @override
   Widget build(BuildContext context) {
     final palette = _tonePalette(tone);
+    final foreground = color ?? palette.foreground;
+    final background = outlined ? Colors.transparent : palette.background;
+    final decoration = BoxDecoration(
+      color: background,
+      borderRadius: BorderRadius.circular(999),
+      border: outlined ? Border.all(color: foreground, width: 0.8) : null,
+    );
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        color: palette.background,
-        borderRadius: BorderRadius.circular(999),
-      ),
+      decoration: decoration,
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           if (icon != null) ...<Widget>[
             IconTheme(
-              data: IconThemeData(color: palette.foreground, size: 12),
+              data: IconThemeData(color: foreground, size: 12),
               child: icon!,
             ),
             const SizedBox(width: 4),
@@ -86,7 +104,7 @@ class VsChip extends StatelessWidget {
               fontWeight: FontWeight.w500,
               letterSpacing: 0.3,
               height: 1.6,
-              color: palette.foreground,
+              color: foreground,
             ),
           ),
         ],
@@ -95,9 +113,11 @@ class VsChip extends StatelessWidget {
   }
 }
 
-/// Outlined chip tinted by [color] — used for proficiency badges where the
-/// fill is paper and the label inherits its semantic hue.
+/// Deprecated wrapper retained for source-level compatibility; delegates to
+/// `VsChip(outlined: true, color: color)`.
+@Deprecated('Use VsChip(outlined: true, color: ...) instead.')
 class VsOutlinedChip extends StatelessWidget {
+  @Deprecated('Use VsChip(outlined: true, color: ...) instead.')
   const VsOutlinedChip({
     required this.label,
     required this.color,
@@ -109,24 +129,6 @@ class VsOutlinedChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        color: Colors.transparent,
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: color, width: 0.8),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontFamily: VsTokens.sans,
-          fontSize: 10,
-          fontWeight: FontWeight.w500,
-          letterSpacing: 0.3,
-          height: 1.6,
-          color: color,
-        ),
-      ),
-    );
+    return VsChip(label: label, outlined: true, color: color);
   }
 }

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_icon_circle.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_icon_circle.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+
+/// Circular icon button in paperSoft — mirrors the search icon chrome used
+/// in `screens.jsx` `VSHome` top-right.
+class VsIconCircle extends StatelessWidget {
+  const VsIconCircle({
+    required this.icon,
+    this.onTap,
+    this.size = 32,
+    this.iconSize = 16,
+    this.background = VsTokens.paperSoft,
+    this.foreground = VsTokens.inkSoft,
+    super.key,
+  });
+
+  final IconData icon;
+  final VoidCallback? onTap;
+  final double size;
+  final double iconSize;
+  final Color background;
+  final Color foreground;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: background,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: size,
+          height: size,
+          child: Icon(icon, size: iconSize, color: foreground),
+        ),
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_illustration_panel.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_illustration_panel.dart
@@ -1,0 +1,108 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+
+/// Striped paper panel mirroring the design bundle's `IllustrationPanel`.
+///
+/// Used as a placeholder for AI-generated imagery: diagonal stripes with a
+/// centered serif label that hints at the content.
+class VsIllustrationPanel extends StatelessWidget {
+  const VsIllustrationPanel({
+    required this.label,
+    this.seed = 0,
+    this.height = 180,
+    this.borderRadius = VsTokens.radiusSm,
+    super.key,
+  });
+
+  final String label;
+  final int seed;
+  final double height;
+  final double borderRadius;
+
+  static const List<Color> _backgrounds = <Color>[
+    Color(0xFFF2E8D2),
+    Color(0xFFEFE2D0),
+    Color(0xFFF3E6CC),
+    Color(0xFFD6E4E6),
+    Color(0xFFEEDFD9),
+    Color(0xFFDEE6D8),
+  ];
+
+  static const List<Color> _textColors = <Color>[
+    Color(0xFF805236),
+    Color(0xFF7A3F2B),
+    Color(0xFF7F5B23),
+    Color(0xFF2E5059),
+    Color(0xFF7A3E34),
+    Color(0xFF3E5E2E),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final index = seed.abs() % _backgrounds.length;
+    final bg = _backgrounds[index];
+    final fg = _textColors[index];
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(borderRadius),
+      child: SizedBox(
+        height: height,
+        width: double.infinity,
+        child: Stack(
+          alignment: Alignment.center,
+          children: <Widget>[
+            Positioned.fill(child: ColoredBox(color: bg)),
+            Positioned.fill(
+              child: CustomPaint(painter: _StripesPainter(fg.withAlpha(30))),
+            ),
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontFamily: VsTokens.serif,
+                    fontSize: height < 80 ? 16 : 24,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: -0.3,
+                    color: fg,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StripesPainter extends CustomPainter {
+  const _StripesPainter(this.color);
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 1;
+    const spacing = 14.0;
+    final diagonal =
+        math.sqrt(size.width * size.width + size.height * size.height);
+    canvas
+      ..save()
+      ..translate(size.width / 2, size.height / 2)
+      ..rotate(35 * math.pi / 180);
+    for (var x = -diagonal; x < diagonal; x += spacing) {
+      canvas.drawLine(Offset(x, -diagonal), Offset(x, diagonal), paint);
+    }
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(covariant _StripesPainter oldDelegate) =>
+      oldDelegate.color != color;
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_input_field.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_input_field.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+
+/// Large serif text field with an ink underline — mirrors `VSAddInput`'s
+/// main entry and `VSField`'s single-line email / password inputs.
+class VsInputField extends StatelessWidget {
+  const VsInputField({
+    required this.controller,
+    this.fontSize = 34,
+    this.fontFamily = VsTokens.serif,
+    this.autofocus = false,
+    this.enabled = true,
+    this.hint,
+    this.onChanged,
+    this.onSubmitted,
+    this.obscureText = false,
+    this.keyboardType,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final double fontSize;
+  final String fontFamily;
+  final bool autofocus;
+  final bool enabled;
+  final String? hint;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      autofocus: autofocus,
+      enabled: enabled,
+      obscureText: obscureText,
+      keyboardType: keyboardType,
+      cursorColor: VsTokens.accent,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      style: TextStyle(
+        fontFamily: fontFamily,
+        fontSize: fontSize,
+        fontWeight: FontWeight.w600,
+        color: VsTokens.ink,
+      ),
+      decoration: InputDecoration(
+        hintText: hint,
+        hintStyle: TextStyle(
+          fontFamily: fontFamily,
+          fontSize: fontSize,
+          fontWeight: FontWeight.w600,
+          color: VsTokens.inkMute,
+        ),
+        isCollapsed: true,
+        contentPadding: const EdgeInsets.symmetric(vertical: 6),
+        enabledBorder: const UnderlineInputBorder(
+          borderSide: BorderSide(color: VsTokens.inkHair),
+        ),
+        focusedBorder: const UnderlineInputBorder(
+          borderSide: BorderSide(color: VsTokens.ink),
+        ),
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_mode_toggle.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_mode_toggle.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+
+/// Pill-shaped two-option toggle used by the login form to switch between
+/// sign-in and sign-up modes (`screens.jsx` `VSLoginEmail` mode toggle).
+class VsModeToggle<T> extends StatelessWidget {
+  const VsModeToggle({
+    required this.options,
+    required this.selected,
+    required this.onChanged,
+    super.key,
+  });
+
+  final List<VsModeOption<T>> options;
+  final T selected;
+  final ValueChanged<T> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: VsTokens.paperSoft,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: VsTokens.inkHair),
+      ),
+      child: Row(
+        children: <Widget>[
+          for (final option in options)
+            Expanded(
+              child: _ModeButton<T>(
+                option: option,
+                isActive: option.value == selected,
+                onTap: () => onChanged(option.value),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+@immutable
+class VsModeOption<T> {
+  const VsModeOption({required this.value, required this.label});
+  final T value;
+  final String label;
+}
+
+class _ModeButton<T> extends StatelessWidget {
+  const _ModeButton({
+    required this.option,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  final VsModeOption<T> option;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: isActive ? VsTokens.ink : Colors.transparent,
+      borderRadius: BorderRadius.circular(999),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(999),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Text(
+            option.label,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontFamily: VsTokens.sans,
+              fontSize: 12,
+              fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+              color: isActive ? VsTokens.paper : VsTokens.inkSoft,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_otp_field.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_otp_field.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../vs_tokens.dart';
+
+/// Six-digit OTP input mirroring `screens.jsx` `VSLoginVerify`. Each digit
+/// is a separate 42x52 paper-framed cell; focus auto-advances on input and
+/// retreats on backspace. Emits the full code via [onCompleted] when all
+/// six digits are filled.
+class VsOtpField extends StatefulWidget {
+  const VsOtpField({
+    required this.onCompleted,
+    this.length = 6,
+    super.key,
+  });
+
+  final void Function(String code) onCompleted;
+  final int length;
+
+  @override
+  State<VsOtpField> createState() => _VsOtpFieldState();
+}
+
+class _VsOtpFieldState extends State<VsOtpField> {
+  late final List<TextEditingController> _controllers;
+  late final List<FocusNode> _focusNodes;
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = List<TextEditingController>.generate(
+      widget.length,
+      (_) => TextEditingController(),
+    );
+    _focusNodes =
+        List<FocusNode>.generate(widget.length, (_) => FocusNode());
+  }
+
+  @override
+  void dispose() {
+    for (final c in _controllers) {
+      c.dispose();
+    }
+    for (final n in _focusNodes) {
+      n.dispose();
+    }
+    super.dispose();
+  }
+
+  void _handleChange(int index, String value) {
+    if (value.length > 1) {
+      _controllers[index].text = value.substring(value.length - 1);
+      _controllers[index].selection = TextSelection.fromPosition(
+        TextPosition(offset: _controllers[index].text.length),
+      );
+    }
+    if (value.isNotEmpty && index < widget.length - 1) {
+      _focusNodes[index + 1].requestFocus();
+    }
+    final code = _controllers.map((c) => c.text).join();
+    if (code.length == widget.length && !code.contains(' ')) {
+      widget.onCompleted(code);
+    }
+    setState(() {});
+  }
+
+  KeyEventResult _handleKey(int index, FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.backspace &&
+        _controllers[index].text.isEmpty &&
+        index > 0) {
+      _focusNodes[index - 1].requestFocus();
+      _controllers[index - 1].text = '';
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        for (var index = 0; index < widget.length; index++)
+          Padding(
+            padding: EdgeInsets.only(
+              right: index == widget.length - 1 ? 0 : 8,
+            ),
+            child: _OtpCell(
+              controller: _controllers[index],
+              focusNode: _focusNodes[index],
+              onChanged: (v) => _handleChange(index, v),
+              onKeyEvent: (n, e) => _handleKey(index, n, e),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _OtpCell extends StatelessWidget {
+  const _OtpCell({
+    required this.controller,
+    required this.focusNode,
+    required this.onChanged,
+    required this.onKeyEvent,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final ValueChanged<String> onChanged;
+  final KeyEventResult Function(FocusNode, KeyEvent) onKeyEvent;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasValue = controller.text.isNotEmpty;
+    return SizedBox(
+      width: 42,
+      height: 52,
+      child: Focus(
+        onKeyEvent: onKeyEvent,
+        child: TextField(
+          controller: controller,
+          focusNode: focusNode,
+          onChanged: onChanged,
+          keyboardType: TextInputType.number,
+          inputFormatters: <TextInputFormatter>[
+            FilteringTextInputFormatter.digitsOnly,
+          ],
+          maxLength: 1,
+          textAlign: TextAlign.center,
+          cursorColor: VsTokens.accent,
+          style: const TextStyle(
+            fontFamily: VsTokens.serif,
+            fontSize: 22,
+            fontWeight: FontWeight.w600,
+            color: VsTokens.ink,
+          ),
+          decoration: InputDecoration(
+            counterText: '',
+            isCollapsed: true,
+            contentPadding: const EdgeInsets.symmetric(vertical: 12),
+            filled: true,
+            fillColor:
+                hasValue ? VsTokens.paperSoft : Colors.transparent,
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+              borderSide: BorderSide(
+                color: hasValue ? VsTokens.ink : VsTokens.inkHair,
+              ),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+              borderSide: const BorderSide(color: VsTokens.ink, width: 1.5),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_pill_tabs.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_pill_tabs.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+
+/// Single entry used by [VsPillTabs].
+@immutable
+class VsPillTab<T> {
+  const VsPillTab({required this.value, required this.label, this.count});
+
+  final T value;
+  final String label;
+  final int? count;
+}
+
+/// Pill-shaped horizontal tab control mirroring `screens.jsx` `VSHome` filter
+/// pills: active pill is filled ink, inactive is transparent.
+class VsPillTabs<T> extends StatelessWidget {
+  const VsPillTabs({
+    required this.tabs,
+    required this.selected,
+    required this.onChanged,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+    super.key,
+  });
+
+  final List<VsPillTab<T>> tabs;
+  final T selected;
+  final ValueChanged<T> onChanged;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: padding,
+      child: Row(
+        children: <Widget>[
+          for (final tab in tabs)
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: _PillButton<T>(
+                tab: tab,
+                isActive: tab.value == selected,
+                onTap: () => onChanged(tab.value),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PillButton<T> extends StatelessWidget {
+  const _PillButton({
+    required this.tab,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  final VsPillTab<T> tab;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final background = isActive ? VsTokens.ink : Colors.transparent;
+    final foreground = isActive ? VsTokens.paper : VsTokens.inkSoft;
+    return Material(
+      color: background,
+      borderRadius: BorderRadius.circular(999),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(999),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                tab.label,
+                style: TextStyle(
+                  fontFamily: VsTokens.sans,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: foreground,
+                ),
+              ),
+              if (tab.count != null) ...<Widget>[
+                const SizedBox(width: 3),
+                Opacity(
+                  opacity: 0.6,
+                  child: Text(
+                    '${tab.count}',
+                    style: TextStyle(
+                      fontFamily: VsTokens.sans,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                      color: foreground,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_section_label.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_section_label.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+
+/// Uppercase eyebrow / section label: sans 11 w500 inkMute, letter-spacing 1.
+///
+/// Mirrors the `label` style used throughout `screens.jsx` for
+/// "ENGLISH EXPRESSION", "EXAMPLES", "NUANCE" etc.
+class VsSectionLabel extends StatelessWidget {
+  const VsSectionLabel(
+    this.text, {
+    this.color = VsTokens.inkMute,
+    this.letterSpacing = 1,
+    super.key,
+  });
+
+  final String text;
+  final Color color;
+  final double letterSpacing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text.toUpperCase(),
+      style: TextStyle(
+        fontFamily: VsTokens.sans,
+        fontSize: 11,
+        fontWeight: FontWeight.w500,
+        letterSpacing: letterSpacing,
+        color: color,
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_settings_row.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_settings_row.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+
+/// Row used by `screens.jsx` `VSSettings` — icon box on the left, label +
+/// optional sub on the right, and a trailing chevron. Sibling rows share a
+/// hairline divider handled by the caller through [isLast].
+class VsSettingsRow extends StatelessWidget {
+  const VsSettingsRow({
+    required this.icon,
+    required this.label,
+    this.sub,
+    this.onTap,
+    this.isLast = false,
+    this.trailing,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final String? sub;
+  final VoidCallback? onTap;
+  final bool isLast;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: isLast ? Colors.transparent : VsTokens.inkHair,
+              width: 0.5,
+            ),
+          ),
+        ),
+        child: Row(
+          children: <Widget>[
+            Container(
+              width: 30,
+              height: 30,
+              decoration: BoxDecoration(
+                color: VsTokens.paperDeep,
+                borderRadius: BorderRadius.circular(VsTokens.radiusSm),
+              ),
+              alignment: Alignment.center,
+              child: Icon(icon, size: 15, color: VsTokens.inkSoft),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    label,
+                    style: theme.textTheme.titleSmall,
+                  ),
+                  if (sub != null) ...<Widget>[
+                    const SizedBox(height: 1),
+                    Text(
+                      sub!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: VsTokens.inkMute,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            if (trailing != null)
+              trailing!
+            else
+              const Icon(
+                Icons.chevron_right,
+                size: 12,
+                color: VsTokens.inkMute,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/applications/mobile/lib/src/presentation/theme/widgets/vs_stage_step.dart
+++ b/applications/mobile/lib/src/presentation/theme/widgets/vs_stage_step.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../vs_tokens.dart';
+import 'vs_spinner.dart';
+
+/// Visual state for a single row in the `VSAddGenerating` stages list.
+enum VsStageState { pending, active, done }
+
+/// One line of the generation progress list — icon (dot / spinner / check)
+/// + label + optional sub-label; opacity drops for pending rows.
+class VsStageStep extends StatelessWidget {
+  const VsStageStep({
+    required this.state,
+    required this.label,
+    this.sub,
+    this.isLast = false,
+    super.key,
+  });
+
+  final VsStageState state;
+  final String label;
+  final String? sub;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final opacity = state == VsStageState.pending ? 0.35 : 1.0;
+    return AnimatedOpacity(
+      duration: const Duration(milliseconds: 300),
+      opacity: opacity,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: isLast ? Colors.transparent : VsTokens.inkHair,
+              width: 0.5,
+            ),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            SizedBox(
+              width: 20,
+              height: 20,
+              child: Center(child: _buildLeading()),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    label,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontSize: 13,
+                    ),
+                  ),
+                  if (sub != null && state == VsStageState.active) ...<Widget>[
+                    const SizedBox(height: 1),
+                    Text(
+                      sub!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        fontSize: 11,
+                        color: VsTokens.inkMute,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLeading() {
+    switch (state) {
+      case VsStageState.done:
+        return const Icon(Icons.check, size: 16, color: VsTokens.ok);
+      case VsStageState.active:
+        return const VsSpinner(size: 14);
+      case VsStageState.pending:
+        return Container(
+          width: 8,
+          height: 8,
+          decoration: const BoxDecoration(
+            color: VsTokens.inkHair,
+            shape: BoxShape.circle,
+          ),
+        );
+    }
+  }
+}

--- a/applications/mobile/test/feature/catalog_registration_flow_test.dart
+++ b/applications/mobile/test/feature/catalog_registration_flow_test.dart
@@ -64,6 +64,9 @@ void main() {
         );
         await tester.tap(find.byKey(const Key('registration.submit')));
         await tester.pumpAndSettle();
+        // Generating animation runs 5 stages x 900ms + 700ms exit.
+        await tester.pump(const Duration(seconds: 6));
+        await tester.pumpAndSettle();
 
         expect(find.byKey(const Key('catalog.list')), findsOneWidget);
         expect(find.text('serendipity'), findsOneWidget);
@@ -97,6 +100,8 @@ void main() {
         'serendipity',
       );
       await tester.tap(find.byKey(const Key('registration.submit')));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
       await tester.pumpAndSettle();
 
       expect(catalog.current.entries.length, equals(1));

--- a/applications/mobile/test/support/login_helpers.dart
+++ b/applications/mobile/test/support/login_helpers.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Runs the Welcome → Sign-in submit flow so tests that want to reach the
+/// authenticated AppShell can write a single call.
+Future<void> loginViaEmail(WidgetTester tester) async {
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('login.provider.basic')));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('login.signin.submit')));
+  await tester.pumpAndSettle();
+}

--- a/applications/mobile/test/unit/presentation/catalog/explanation_generating_screen_test.dart
+++ b/applications/mobile/test/unit/presentation/catalog/explanation_generating_screen_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:vocastock_mobile/src/presentation/catalog/explanation_generating_screen.dart';
+import 'package:vocastock_mobile/src/presentation/router/router.dart';
+
+void main() {
+  testWidgets('ExplanationGeneratingScreen advances through five stages',
+      (WidgetTester tester) async {
+    var reachedCatalog = false;
+    final router = GoRouter(
+      initialLocation: AppRoutes.registrationGenerating,
+      routes: <RouteBase>[
+        GoRoute(
+          path: AppRoutes.registrationGenerating,
+          builder: (context, state) =>
+              const ExplanationGeneratingScreen(text: 'serendipity'),
+        ),
+        GoRoute(
+          path: AppRoutes.catalog,
+          builder: (context, state) {
+            reachedCatalog = true;
+            return const Scaffold(body: Text('catalog landed'));
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pump();
+
+    expect(find.text('serendipity'), findsOneWidget);
+
+    // Let the 5-stage timer run plus the exit delay.
+    await tester.pump(const Duration(seconds: 6));
+    await tester.pumpAndSettle();
+
+    expect(reachedCatalog, isTrue);
+  });
+}

--- a/applications/mobile/test/unit/presentation/detail/detail_layout_preference_test.dart
+++ b/applications/mobile/test/unit/presentation/detail/detail_layout_preference_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/detail/detail_layout_preference.dart';
+
+void main() {
+  test('detailLayoutProvider defaults to tab and mutates via set()', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    expect(container.read(detailLayoutProvider), DetailLayout.tab);
+    container.read(detailLayoutProvider.notifier).set(DetailLayout.cards);
+    expect(container.read(detailLayoutProvider), DetailLayout.cards);
+  });
+}

--- a/applications/mobile/test/unit/presentation/proficiency_screen_test.dart
+++ b/applications/mobile/test/unit/presentation/proficiency_screen_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/app.dart';
+import 'package:vocastock_mobile/src/app_bindings.dart';
+import 'package:vocastock_mobile/src/domain/identifier/identifier.dart';
+import 'package:vocastock_mobile/src/infrastructure/stub/stub_actor_handoff_controller.dart';
+import 'package:vocastock_mobile/src/infrastructure/stub/stub_subscription_state.dart';
+import 'package:vocastock_mobile/src/infrastructure/stub/stub_vocabulary_catalog.dart';
+import 'package:vocastock_mobile/src/presentation/router/router.dart';
+
+void main() {
+  group('ProficiencyScreen', () {
+    testWidgets('renders title and sections after navigating from catalog',
+        (WidgetTester tester) async {
+      final handoff = StubActorHandoffController();
+      final catalog = StubVocabularyCatalog();
+      final subscription = StubSubscriptionState();
+      addTearDown(handoff.dispose);
+      addTearDown(catalog.dispose);
+      addTearDown(subscription.dispose);
+
+      await catalog.register(
+        text: 'serendipity',
+        idempotencyKey: IdempotencyKey('idem-1'),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            stubActorHandoffControllerProvider.overrideWithValue(handoff),
+            stubVocabularyCatalogProvider.overrideWithValue(catalog),
+            stubSubscriptionStateProvider.overrideWithValue(subscription),
+          ],
+          child: const VocastockApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('login.provider.basic')));
+      await tester.pumpAndSettle();
+
+      final element = tester.element(find.byType(MaterialApp));
+      ProviderScope.containerOf(element)
+          .read(routerProvider)
+          .go(AppRoutes.proficiency);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('proficiency.title')), findsOneWidget);
+      expect(find.byKey(const Key('proficiency.list')), findsOneWidget);
+      expect(find.text('serendipity'), findsOneWidget);
+    });
+
+    testWidgets('renders empty state when catalog is empty',
+        (WidgetTester tester) async {
+      final handoff = StubActorHandoffController();
+      final catalog = StubVocabularyCatalog();
+      final subscription = StubSubscriptionState();
+      addTearDown(handoff.dispose);
+      addTearDown(catalog.dispose);
+      addTearDown(subscription.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            stubActorHandoffControllerProvider.overrideWithValue(handoff),
+            stubVocabularyCatalogProvider.overrideWithValue(catalog),
+            stubSubscriptionStateProvider.overrideWithValue(subscription),
+          ],
+          child: const VocastockApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('login.provider.basic')));
+      await tester.pumpAndSettle();
+
+      final element = tester.element(find.byType(MaterialApp));
+      ProviderScope.containerOf(element)
+          .read(routerProvider)
+          .go(AppRoutes.proficiency);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('proficiency.empty')), findsOneWidget);
+    });
+  });
+}

--- a/applications/mobile/test/unit/presentation/settings/settings_screen_test.dart
+++ b/applications/mobile/test/unit/presentation/settings/settings_screen_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/app.dart';
+import 'package:vocastock_mobile/src/app_bindings.dart';
+import 'package:vocastock_mobile/src/infrastructure/stub/stub_actor_handoff_controller.dart';
+import 'package:vocastock_mobile/src/infrastructure/stub/stub_subscription_state.dart';
+import 'package:vocastock_mobile/src/infrastructure/stub/stub_vocabulary_catalog.dart';
+import 'package:vocastock_mobile/src/presentation/router/router.dart';
+
+Future<void> _pumpSettings(WidgetTester tester) async {
+  final handoff = StubActorHandoffController();
+  final catalog = StubVocabularyCatalog();
+  final subscription = StubSubscriptionState();
+  addTearDown(handoff.dispose);
+  addTearDown(catalog.dispose);
+  addTearDown(subscription.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        stubActorHandoffControllerProvider.overrideWithValue(handoff),
+        stubVocabularyCatalogProvider.overrideWithValue(catalog),
+        stubSubscriptionStateProvider.overrideWithValue(subscription),
+      ],
+      child: const VocastockApp(),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('login.provider.basic')));
+  await tester.pumpAndSettle();
+
+  final element = tester.element(find.byType(MaterialApp));
+  ProviderScope.containerOf(element)
+      .read(routerProvider)
+      .go(AppRoutes.settings);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SettingsScreen', () {
+    testWidgets('renders three section groups with labelled rows',
+        (WidgetTester tester) async {
+      await _pumpSettings(tester);
+      expect(find.text('アカウント'), findsOneWidget);
+      expect(find.text('生成設定'), findsOneWidget);
+      expect(find.text('アプリ'), findsOneWidget);
+      expect(find.byKey(const Key('settings.row.profile')), findsOneWidget);
+      expect(
+        find.byKey(const Key('settings.row.subscription')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('settings.row.detail-layout')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'tapping the subscription row navigates to /subscription',
+        (WidgetTester tester) async {
+      await _pumpSettings(tester);
+      await tester.ensureVisible(
+        find.byKey(const Key('settings.row.subscription')),
+      );
+      await tester.tap(find.byKey(const Key('settings.row.subscription')));
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const Key('subscription-status.state')),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_bottom_tab_bar_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_bottom_tab_bar_test.dart
@@ -1,96 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:go_router/go_router.dart';
-import 'package:vocastock_mobile/src/presentation/router/router.dart';
 import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_bottom_tab_bar.dart';
 
 void main() {
-  testWidgets('VsBottomTabBar renders the four main tabs',
-      (WidgetTester tester) async {
-    final router = GoRouter(
-      initialLocation: AppRoutes.catalog,
-      routes: <RouteBase>[
-        GoRoute(
-          path: AppRoutes.catalog,
-          builder: (context, state) => const Scaffold(
-            bottomNavigationBar: VsBottomTabBar(),
-            body: SizedBox.shrink(),
+  testWidgets('VsBottomTabBar renders the four main tabs and marks the '
+      'current index as active', (WidgetTester tester) async {
+    var lastTapped = -1;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: VsBottomTabBar(
+            currentIndex: 1,
+            onTap: (index) => lastTapped = index,
           ),
+          body: const SizedBox.shrink(),
         ),
-        GoRoute(
-          path: AppRoutes.proficiency,
-          builder: (context, state) => const Scaffold(
-            bottomNavigationBar: VsBottomTabBar(),
-            body: SizedBox.shrink(),
-          ),
-        ),
-        GoRoute(
-          path: AppRoutes.paywall,
-          builder: (context, state) => const Scaffold(
-            bottomNavigationBar: VsBottomTabBar(),
-            body: SizedBox.shrink(),
-          ),
-        ),
-        GoRoute(
-          path: AppRoutes.subscriptionStatus,
-          builder: (context, state) => const Scaffold(
-            bottomNavigationBar: VsBottomTabBar(),
-            body: SizedBox.shrink(),
-          ),
-        ),
-      ],
+      ),
     );
-    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
-    await tester.pumpAndSettle();
-
     expect(find.text('単語帳'), findsOneWidget);
     expect(find.text('習熟'), findsOneWidget);
     expect(find.text('プラン'), findsOneWidget);
     expect(find.text('設定'), findsOneWidget);
-  });
 
-  testWidgets('tapping a tab navigates to the target route',
-      (WidgetTester tester) async {
-    final router = GoRouter(
-      initialLocation: AppRoutes.catalog,
-      routes: <RouteBase>[
-        GoRoute(
-          path: AppRoutes.catalog,
-          builder: (context, state) => const Scaffold(
-            bottomNavigationBar: VsBottomTabBar(),
-            body: SizedBox.shrink(),
-          ),
-        ),
-        GoRoute(
-          path: AppRoutes.proficiency,
-          builder: (context, state) => const Scaffold(
-            key: Key('proficiency-target'),
-            bottomNavigationBar: VsBottomTabBar(),
-            body: SizedBox.shrink(),
-          ),
-        ),
-        GoRoute(
-          path: AppRoutes.paywall,
-          builder: (context, state) => const Scaffold(
-            bottomNavigationBar: VsBottomTabBar(),
-            body: SizedBox.shrink(),
-          ),
-        ),
-        GoRoute(
-          path: AppRoutes.subscriptionStatus,
-          builder: (context, state) => const Scaffold(
-            bottomNavigationBar: VsBottomTabBar(),
-            body: SizedBox.shrink(),
-          ),
-        ),
-      ],
-    );
-    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text('習熟'));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('proficiency-target')), findsOneWidget);
+    await tester.tap(find.text('プラン'));
+    expect(lastTapped, 2);
   });
 }

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_bottom_tab_bar_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_bottom_tab_bar_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:vocastock_mobile/src/presentation/router/router.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_bottom_tab_bar.dart';
+
+void main() {
+  testWidgets('VsBottomTabBar renders the four main tabs',
+      (WidgetTester tester) async {
+    final router = GoRouter(
+      initialLocation: AppRoutes.catalog,
+      routes: <RouteBase>[
+        GoRoute(
+          path: AppRoutes.catalog,
+          builder: (context, state) => const Scaffold(
+            bottomNavigationBar: VsBottomTabBar(),
+            body: SizedBox.shrink(),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.proficiency,
+          builder: (context, state) => const Scaffold(
+            bottomNavigationBar: VsBottomTabBar(),
+            body: SizedBox.shrink(),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.paywall,
+          builder: (context, state) => const Scaffold(
+            bottomNavigationBar: VsBottomTabBar(),
+            body: SizedBox.shrink(),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.subscriptionStatus,
+          builder: (context, state) => const Scaffold(
+            bottomNavigationBar: VsBottomTabBar(),
+            body: SizedBox.shrink(),
+          ),
+        ),
+      ],
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    expect(find.text('単語帳'), findsOneWidget);
+    expect(find.text('習熟'), findsOneWidget);
+    expect(find.text('プラン'), findsOneWidget);
+    expect(find.text('設定'), findsOneWidget);
+  });
+
+  testWidgets('tapping a tab navigates to the target route',
+      (WidgetTester tester) async {
+    final router = GoRouter(
+      initialLocation: AppRoutes.catalog,
+      routes: <RouteBase>[
+        GoRoute(
+          path: AppRoutes.catalog,
+          builder: (context, state) => const Scaffold(
+            bottomNavigationBar: VsBottomTabBar(),
+            body: SizedBox.shrink(),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.proficiency,
+          builder: (context, state) => const Scaffold(
+            key: Key('proficiency-target'),
+            bottomNavigationBar: VsBottomTabBar(),
+            body: SizedBox.shrink(),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.paywall,
+          builder: (context, state) => const Scaffold(
+            bottomNavigationBar: VsBottomTabBar(),
+            body: SizedBox.shrink(),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.subscriptionStatus,
+          builder: (context, state) => const Scaffold(
+            bottomNavigationBar: VsBottomTabBar(),
+            body: SizedBox.shrink(),
+          ),
+        ),
+      ],
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('習熟'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('proficiency-target')), findsOneWidget);
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_brand_mark_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_brand_mark_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_brand_mark.dart';
+
+void main() {
+  testWidgets('VsBrandMark renders with the requested size',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: VsBrandMark(size: 48)),
+      ),
+    );
+    final box = tester.getSize(find.byType(VsBrandMark));
+    expect(box.width, 48);
+    expect(box.height, 48);
+    expect(find.byType(CustomPaint), findsWidgets);
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_chip_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_chip_test.dart
@@ -12,7 +12,8 @@ void main() {
       expect(find.text('頻出'), findsOneWidget);
     });
 
-    testWidgets('accent tone paints accent container colors', (WidgetTester tester) async {
+    testWidgets('accent tone paints accent container colors',
+        (WidgetTester tester) async {
       await tester.pumpWidget(
         harness(const VsChip(label: '完了', tone: VsChipTone.accent)),
       );
@@ -21,7 +22,8 @@ void main() {
       expect(decoration.color, VsTokens.accentSoft);
     });
 
-    testWidgets('dark tone paints ink container colors', (WidgetTester tester) async {
+    testWidgets('dark tone paints ink container colors',
+        (WidgetTester tester) async {
       await tester.pumpWidget(
         harness(const VsChip(label: 'ALL', tone: VsChipTone.dark)),
       );
@@ -29,22 +31,36 @@ void main() {
       final decoration = container.decoration! as BoxDecoration;
       expect(decoration.color, VsTokens.ink);
     });
-  });
 
-  group('VsOutlinedChip', () {
-    testWidgets('draws an outlined pill tinted by the given color',
-        (tester) async {
+    testWidgets('outlined mode draws transparent fill with colored border',
+        (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: VsOutlinedChip(
-              label: '学習中',
-              color: VsTokens.profLearning,
-            ),
+        harness(
+          const VsChip(
+            label: '学習中',
+            outlined: true,
+            color: VsTokens.profLearning,
           ),
         ),
       );
-      expect(find.text('学習中'), findsOneWidget);
+      final container = tester.widget<Container>(find.byType(Container).first);
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.color, Colors.transparent);
+      expect(decoration.border, isA<Border>());
+    });
+
+    testWidgets('icon slot renders provided widget',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        harness(
+          const VsChip(
+            label: 'PREMIUM',
+            icon: Icon(Icons.emoji_events),
+            tone: VsChipTone.accent,
+          ),
+        ),
+      );
+      expect(find.byIcon(Icons.emoji_events), findsOneWidget);
     });
   });
 }

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_icon_circle_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_icon_circle_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/vs_tokens.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_icon_circle.dart';
+
+void main() {
+  testWidgets('VsIconCircle renders icon and invokes onTap',
+      (WidgetTester tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: VsIconCircle(
+              icon: Icons.search,
+              onTap: () => taps++,
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.byIcon(Icons.search), findsOneWidget);
+    final icon = tester.widget<Icon>(find.byIcon(Icons.search));
+    expect(icon.color, VsTokens.inkSoft);
+    await tester.tap(find.byType(VsIconCircle));
+    expect(taps, 1);
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_illustration_panel_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_illustration_panel_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_illustration_panel.dart';
+
+void main() {
+  testWidgets('VsIllustrationPanel renders label at requested height',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 300,
+            child: VsIllustrationPanel(label: '走る', seed: 2, height: 120),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('走る'), findsOneWidget);
+    final panel = tester.getSize(find.byType(VsIllustrationPanel));
+    expect(panel.height, 120);
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_input_field_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_input_field_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_input_field.dart';
+
+void main() {
+  testWidgets('VsInputField reports onChanged and updates controller',
+      (WidgetTester tester) async {
+    final controller = TextEditingController();
+    String? latest;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: VsInputField(
+              controller: controller,
+              hint: 'serendipity',
+              onChanged: (value) => latest = value,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(VsInputField), 'meticulous');
+    expect(controller.text, 'meticulous');
+    expect(latest, 'meticulous');
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_mode_toggle_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_mode_toggle_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_mode_toggle.dart';
+
+enum _Mode { signIn, signUp }
+
+void main() {
+  testWidgets('VsModeToggle renders both options and emits onChanged',
+      (WidgetTester tester) async {
+    var current = _Mode.signIn;
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) => MaterialApp(
+          home: Scaffold(
+            body: VsModeToggle<_Mode>(
+              selected: current,
+              onChanged: (value) => setState(() => current = value),
+              options: const <VsModeOption<_Mode>>[
+                VsModeOption<_Mode>(value: _Mode.signIn, label: 'ログイン'),
+                VsModeOption<_Mode>(value: _Mode.signUp, label: '新規登録'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('ログイン'), findsOneWidget);
+    expect(find.text('新規登録'), findsOneWidget);
+
+    await tester.tap(find.text('新規登録'));
+    await tester.pumpAndSettle();
+    expect(current, _Mode.signUp);
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_otp_field_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_otp_field_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_otp_field.dart';
+
+void main() {
+  testWidgets('VsOtpField fires onCompleted when six digits are filled',
+      (WidgetTester tester) async {
+    String? completed;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Padding(
+            padding: const EdgeInsets.all(24),
+            child: VsOtpField(onCompleted: (code) => completed = code),
+          ),
+        ),
+      ),
+    );
+    final fields = find.byType(TextField);
+    expect(fields, findsNWidgets(6));
+
+    for (var i = 0; i < 6; i++) {
+      await tester.enterText(fields.at(i), '${i + 1}');
+    }
+    expect(completed, '123456');
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_pill_tabs_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_pill_tabs_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_pill_tabs.dart';
+
+enum _Filter { all, running }
+
+void main() {
+  testWidgets('VsPillTabs renders each tab label and count',
+      (WidgetTester tester) async {
+    var current = _Filter.all;
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          return MaterialApp(
+            home: Scaffold(
+              body: VsPillTabs<_Filter>(
+                selected: current,
+                onChanged: (value) => setState(() => current = value),
+                tabs: const <VsPillTab<_Filter>>[
+                  VsPillTab<_Filter>(
+                    value: _Filter.all,
+                    label: 'すべて',
+                    count: 7,
+                  ),
+                  VsPillTab<_Filter>(
+                    value: _Filter.running,
+                    label: '生成中',
+                    count: 2,
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    expect(find.text('すべて'), findsOneWidget);
+    expect(find.text('7'), findsOneWidget);
+    expect(find.text('生成中'), findsOneWidget);
+
+    await tester.tap(find.text('生成中'));
+    await tester.pumpAndSettle();
+    // Selected is now running; verify by re-locating text is still present.
+    expect(find.text('生成中'), findsOneWidget);
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_section_label_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_section_label_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/vs_tokens.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_section_label.dart';
+
+void main() {
+  testWidgets('VsSectionLabel uppercases and colors text as inkMute',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: VsSectionLabel('nuance')),
+      ),
+    );
+    expect(find.text('NUANCE'), findsOneWidget);
+    final text = tester.widget<Text>(find.byType(Text));
+    expect(text.style?.color, VsTokens.inkMute);
+    expect(text.style?.fontWeight, FontWeight.w500);
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_settings_row_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_settings_row_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_settings_row.dart';
+
+void main() {
+  testWidgets(
+      'VsSettingsRow renders label / sub and triggers onTap',
+      (WidgetTester tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: VsSettingsRow(
+            icon: Icons.settings,
+            label: 'プロフィール',
+            sub: '田中 健太',
+            onTap: () => tapped = true,
+          ),
+        ),
+      ),
+    );
+    expect(find.text('プロフィール'), findsOneWidget);
+    expect(find.text('田中 健太'), findsOneWidget);
+    await tester.tap(find.byType(VsSettingsRow));
+    expect(tapped, isTrue);
+  });
+}

--- a/applications/mobile/test/unit/presentation/theme/widgets/vs_stage_step_test.dart
+++ b/applications/mobile/test/unit/presentation/theme/widgets/vs_stage_step_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vocastock_mobile/src/presentation/theme/widgets/vs_stage_step.dart';
+
+void main() {
+  testWidgets('VsStageStep renders check icon when done',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: VsStageStep(
+            state: VsStageState.done,
+            label: '正規化',
+          ),
+        ),
+      ),
+    );
+    expect(find.byIcon(Icons.check), findsOneWidget);
+    expect(find.text('正規化'), findsOneWidget);
+  });
+
+  testWidgets('VsStageStep renders sub only when active',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: VsStageStep(
+            state: VsStageState.active,
+            label: '例文生成',
+            sub: 'Sense ごとに例文を構成',
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('Sense ごとに例文を構成'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

PR #17 merged後に追加した **5 コミット** 分の作業を 1 本の PR にまとめます。`screens.jsx` の設計書に沿って、既存 10 画面のピクセル完全模倣と、これまで deferred 扱いだった画面／フローを一気に実装しました。

## Commits

| SHA | Scope |
|---|---|
| `716404c` | 既存 10 画面の layout / typography / copy を `screens.jsx` 準拠に全面再構築 + 共通 Widget 6 種追加 |
| `f4017be` | `/proficiency` 習熟度ダッシュボード + `ProficiencyLevel` enum + `StubLearningStateReader` |
| `a790aa7` | `VsBottomTabBar` と 4 タブ（単語帳 / 習熟 / プラン / 設定） |
| `d2bec11` | `StatefulShellRoute.indexedStack` でタブバーを固定化（タブ切替時に bar がスライドしない） |
| `01ac115` | Login 多段フロー（Welcome → SignIn / SignUp → Verify → Done）/ Generating 画面 / Settings 画面フル実装 / Detail 3 レイアウトバリエーション（Tab / Page / Cards） |

## 対応した `screens.jsx` コンポーネント

- `VSLoginWelcome` / `VSLoginEmail` / `VSLoginVerify` / `VSLoginDone`
- `VSHome` / `VSAddInput` / `VSAddGenerating`
- `VSDetail` (Tab / Page / Cards の 3 バリエーション)
- `VSPaywall` / `VSProficiency` / `VSSettings`
- `DetailHeader` / `DetailMeta` / `DetailImagePanel` / `DetailFooter`

## 新規共通 Widget

`lib/src/presentation/theme/widgets/` 配下:
- `VsPillTabs<T>`, `VsBrandMark`, `VsSectionLabel`, `VsIllustrationPanel`, `VsIconCircle`, `VsInputField`
- `VsBottomTabBar`, `VsOtpField`, `VsModeToggle`, `VsSettingsRow`, `VsStageStep`
- `VsChip` に `icon` スロット + `outlined` モード統合

`lib/src/presentation/shell/app_shell.dart`:
- `StatefulNavigationShell` をホストしてタブバーを永続化

## 新規ドメイン / アプリケーション

- `ProficiencyLevel` enum（`lib/src/domain/status/proficiency_level.dart`）
- `LearningStateReader` + `StubLearningStateReader`（`lib/src/application/reader/learning_state_reader.dart`） — spec 005 LearningState 未到来までのスタブ。identifier hash から決定論的に level を導出
- `DetailLayoutNotifier` + `detailLayoutProvider`（`lib/src/presentation/detail/detail_layout_preference.dart`）

## 新規画面 / ルート

| Route | Screen |
|---|---|
| `/proficiency` | `ProficiencyScreen` |
| `/registration/generating` | `ExplanationGeneratingScreen` |
| `/settings` | `SettingsScreen`（Shell 4 番目 branch） |

- `/subscription` は top-level に残し、Settings の「サブスクリプション」行から遷移
- Login flow は `/login` 内部 state machine（ルート追加なし）

## 保持する spec 契約

- `spec 013 allowsCompletedPayload=false` — `VocabularyExpressionDetailScreen` は相変わらず解説本文 / pronunciation / frequency を表示しない
- `spec 024 CI 成功条件` — analyze 0 / coverage 90%+ / apple-build + ci green を全 commit で維持

## Test plan

- [x] `rm -rf _build/ && bash scripts/ci/run_quality_checks.sh` → Static analysis passed / Tests passed
- [x] `bash scripts/ci/run_flutter_coverage_gate.sh` → 91.8% ≥ 90%
- [x] `flutter test` → 212 tests pass（新規 10+ 件）
- [x] iOS 26.4 シミュレータ（iPhone 17）で golden path 目視確認：Welcome → Catalog → Proficiency → Paywall → Settings → Subscription
- [x] タブ切替時にタブバーが固定（本文のみ遷移）を実機確認
- [x] Registration submit → Generating 5 段階 → Catalog を実機確認
- [x] CI workflow: `ci` (8 jobs all green) / `apple-build` green

## 残課題（本 PR スコープ外）

- Sense 配列 / pronunciation / similarities / etymology の domain モデル拡張（spec 017 / 021 続編）— 現状は `DetailLayout` の 3 レイアウトが単一 "Sense 1" で動作
- Playful (Duolingo 風) バリアント — 別 PR
- プロフィール / 画像スタイル / 生成通知 / データエクスポート / 言語・表記 の設定画面 — Settings から SnackBar「未対応」表示中
- OAuth (Apple / Google) の実 backend 連携 — stub で即完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)