### PR TITLE
ci: raise e2e-round-trip-smoke timeout to 40 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
     needs: toolchain-validate
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Validate application container contract
         run: bash scripts/bootstrap/validate_application_containers.sh
       - name: Run application container smoke
@@ -104,6 +105,7 @@ jobs:
     needs: toolchain-validate
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Run E2E command -> worker -> query round-trip smoke
         run: bash scripts/ci/run_e2e_round_trip_smoke.sh
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
   e2e-round-trip-smoke:
     name: e2e-round-trip-smoke
     runs-on: ubuntu-24.04
-    timeout-minutes: 12
+    timeout-minutes: 40
     needs: toolchain-validate
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/applications/backend/explanation-worker/src/ExplanationWorker/FirestoreWriter.hs
+++ b/applications/backend/explanation-worker/src/ExplanationWorker/FirestoreWriter.hs
@@ -54,26 +54,36 @@ writeCompletedExplanation client actor explanationId vocabularyExpressionId summ
 
 -- | Patches the vocabulary-expression document so `currentExplanation`
 -- points at the freshly-written explanation and `explanationStatus`
--- flips to `succeeded`. Atomic-ish because Firestore applies per-field
--- patches server-side in a single transaction.
+-- flips to `succeeded`. Also writes `id` + `text` because Firestore
+-- PATCH on a missing document creates it with only the masked fields,
+-- and the catalog read model (query-api) treats those two as required.
+-- Re-writing them on update is harmless: vocabulary id derives from
+-- normalized text, so both stay invariant for a given identifier.
 switchCurrentExplanation ::
   FirestoreClient ->
+  -- | actor UID
   Text ->
+  -- | vocabulary expression identifier (e.g. "vocabulary:slug")
   Text ->
+  -- | normalized text the identifier was derived from
+  Text ->
+  -- | explanation document id
   Text ->
   IO (Either FirestoreError ())
-switchCurrentExplanation client actor vocabularyExpressionId explanationId = do
+switchCurrentExplanation client actor vocabularyExpressionId normalizedText explanationId = do
   let documentPath =
         T.concat ["actors/", actor, "/vocabularyExpressions/", vocabularyExpressionId]
   let fieldsObject =
         encodeFieldsObject
-          [ ("currentExplanation", encodeStringField explanationId),
+          [ ("id", encodeStringField vocabularyExpressionId),
+            ("text", encodeStringField normalizedText),
+            ("currentExplanation", encodeStringField explanationId),
             ("explanationStatus", encodeStringField "succeeded")
           ]
   result <-
     patchDocument
       client
       documentPath
-      ["currentExplanation", "explanationStatus"]
+      ["id", "text", "currentExplanation", "explanationStatus"]
       fieldsObject
   pure (fmap (const ()) result)

--- a/applications/backend/explanation-worker/src/ExplanationWorker/PullLoop.hs
+++ b/applications/backend/explanation-worker/src/ExplanationWorker/PullLoop.hs
@@ -218,6 +218,8 @@ commitSucceededGeneration ::
 commitSucceededGeneration firestore envelope outcome payload = do
   let actor = envelopeActor envelope
   let vocabularyExpressionId = envelopeVocabularyExpression envelope
+  let normalizedText =
+        fromMaybe vocabularyExpressionId (envelopeNormalizedText envelope)
   let explanationId =
         T.pack
           ( "exp-"
@@ -235,7 +237,7 @@ commitSucceededGeneration firestore envelope outcome payload = do
     Left err -> pure (JobRetryableFailure ("firestore-write-failed: " <> show err))
     Right () -> do
       handoffResult <-
-        switchCurrentExplanation firestore actor vocabularyExpressionId explanationId
+        switchCurrentExplanation firestore actor vocabularyExpressionId normalizedText explanationId
       case handoffResult of
         Left err ->
           pure (JobRetryableFailure ("firestore-patch-failed: " <> show err))

--- a/docker/applications/billing-worker/Dockerfile
+++ b/docker/applications/billing-worker/Dockerfile
@@ -1,16 +1,29 @@
+# syntax=docker/dockerfile:1.7
 FROM haskell:9.2.8 AS builder
 
 WORKDIR /workspace/applications/backend/billing-worker
 
+# Stage 1: copy cabal manifests only so the cabal update layer is cached
+# until any cabal file changes.
 COPY applications/backend/billing-worker/cabal.project cabal.project
 COPY applications/backend/billing-worker/billing-worker.cabal billing-worker.cabal
+COPY packages/haskell/vocas-worker-core/vocas-worker-core.cabal /workspace/packages/haskell/vocas-worker-core/vocas-worker-core.cabal
+
+# CABAL_DIR points at a BuildKit cache mount whose id is shared across the
+# 3 worker Dockerfiles, so the package store is reused between them and
+# (when --cache-to=type=gha,mode=max is configured) across CI runs.
+RUN --mount=type=cache,target=/tmp/cabal,sharing=locked,id=vocas-cabal-store \
+    env CABAL_DIR=/tmp/cabal cabal update
+
+# Stage 2: copy the source files.
 COPY applications/backend/billing-worker/app app
 COPY applications/backend/billing-worker/src src
 COPY applications/backend/billing-worker/tests tests
 COPY packages/haskell/vocas-worker-core /workspace/packages/haskell/vocas-worker-core
 
-RUN env CABAL_DIR=/tmp/cabal cabal update
-RUN env CABAL_DIR=/tmp/cabal cabal install exe:billing-worker \
+RUN --mount=type=cache,target=/tmp/cabal,sharing=locked,id=vocas-cabal-store \
+    --mount=type=cache,target=/workspace/applications/backend/billing-worker/dist-newstyle,id=vocas-cabal-dist-billing \
+    env CABAL_DIR=/tmp/cabal cabal install exe:billing-worker \
     --disable-tests \
     --install-method=copy \
     --installdir=/out \

--- a/docker/applications/compose.yaml
+++ b/docker/applications/compose.yaml
@@ -113,6 +113,10 @@ services:
     build:
       context: ../..
       dockerfile: docker/applications/explanation-worker/Dockerfile
+      cache_from:
+        - type=gha,scope=vocas-explanation-worker
+      cache_to:
+        - type=gha,mode=max,scope=vocas-explanation-worker
     <<: *host-gateway
     environment:
       <<: *worker-environment
@@ -124,6 +128,10 @@ services:
     build:
       context: ../..
       dockerfile: docker/applications/image-worker/Dockerfile
+      cache_from:
+        - type=gha,scope=vocas-image-worker
+      cache_to:
+        - type=gha,mode=max,scope=vocas-image-worker
     <<: *host-gateway
     environment:
       <<: *worker-environment
@@ -135,6 +143,10 @@ services:
     build:
       context: ../..
       dockerfile: docker/applications/billing-worker/Dockerfile
+      cache_from:
+        - type=gha,scope=vocas-billing-worker
+      cache_to:
+        - type=gha,mode=max,scope=vocas-billing-worker
     <<: *host-gateway
     environment:
       <<: *worker-environment

--- a/docker/applications/compose.yaml
+++ b/docker/applications/compose.yaml
@@ -110,13 +110,10 @@ services:
       - applications
 
   explanation-worker:
+    image: vocastock-applications-explanation-worker:${VOCAS_HASKELL_WORKER_IMAGE_TAG:-ci}
     build:
       context: ../..
       dockerfile: docker/applications/explanation-worker/Dockerfile
-      cache_from:
-        - type=gha,scope=vocas-explanation-worker
-      cache_to:
-        - type=gha,mode=max,scope=vocas-explanation-worker
     <<: *host-gateway
     environment:
       <<: *worker-environment
@@ -125,13 +122,10 @@ services:
       - applications
 
   image-worker:
+    image: vocastock-applications-image-worker:${VOCAS_HASKELL_WORKER_IMAGE_TAG:-ci}
     build:
       context: ../..
       dockerfile: docker/applications/image-worker/Dockerfile
-      cache_from:
-        - type=gha,scope=vocas-image-worker
-      cache_to:
-        - type=gha,mode=max,scope=vocas-image-worker
     <<: *host-gateway
     environment:
       <<: *worker-environment
@@ -140,13 +134,10 @@ services:
       - applications
 
   billing-worker:
+    image: vocastock-applications-billing-worker:${VOCAS_HASKELL_WORKER_IMAGE_TAG:-ci}
     build:
       context: ../..
       dockerfile: docker/applications/billing-worker/Dockerfile
-      cache_from:
-        - type=gha,scope=vocas-billing-worker
-      cache_to:
-        - type=gha,mode=max,scope=vocas-billing-worker
     <<: *host-gateway
     environment:
       <<: *worker-environment

--- a/docker/applications/explanation-worker/Dockerfile
+++ b/docker/applications/explanation-worker/Dockerfile
@@ -1,16 +1,29 @@
+# syntax=docker/dockerfile:1.7
 FROM haskell:9.2.8 AS builder
 
 WORKDIR /workspace/applications/backend/explanation-worker
 
+# Stage 1: copy cabal manifests only so the cabal update layer is cached
+# until any cabal file changes.
 COPY applications/backend/explanation-worker/cabal.project cabal.project
 COPY applications/backend/explanation-worker/explanation-worker.cabal explanation-worker.cabal
+COPY packages/haskell/vocas-worker-core/vocas-worker-core.cabal /workspace/packages/haskell/vocas-worker-core/vocas-worker-core.cabal
+
+# CABAL_DIR points at a BuildKit cache mount whose id is shared across the
+# 3 worker Dockerfiles, so the package store is reused between them and
+# (when --cache-to=type=gha,mode=max is configured) across CI runs.
+RUN --mount=type=cache,target=/tmp/cabal,sharing=locked,id=vocas-cabal-store \
+    env CABAL_DIR=/tmp/cabal cabal update
+
+# Stage 2: copy the source files.
 COPY applications/backend/explanation-worker/app app
 COPY applications/backend/explanation-worker/src src
 COPY applications/backend/explanation-worker/tests tests
 COPY packages/haskell/vocas-worker-core /workspace/packages/haskell/vocas-worker-core
 
-RUN env CABAL_DIR=/tmp/cabal cabal update
-RUN env CABAL_DIR=/tmp/cabal cabal install exe:explanation-worker \
+RUN --mount=type=cache,target=/tmp/cabal,sharing=locked,id=vocas-cabal-store \
+    --mount=type=cache,target=/workspace/applications/backend/explanation-worker/dist-newstyle,id=vocas-cabal-dist-explanation \
+    env CABAL_DIR=/tmp/cabal cabal install exe:explanation-worker \
     --disable-tests \
     --install-method=copy \
     --installdir=/out \

--- a/docker/applications/image-worker/Dockerfile
+++ b/docker/applications/image-worker/Dockerfile
@@ -1,16 +1,29 @@
+# syntax=docker/dockerfile:1.7
 FROM haskell:9.2.8 AS builder
 
 WORKDIR /workspace/applications/backend/image-worker
 
+# Stage 1: copy cabal manifests only so the cabal update layer is cached
+# until any cabal file changes.
 COPY applications/backend/image-worker/cabal.project cabal.project
 COPY applications/backend/image-worker/image-worker.cabal image-worker.cabal
+COPY packages/haskell/vocas-worker-core/vocas-worker-core.cabal /workspace/packages/haskell/vocas-worker-core/vocas-worker-core.cabal
+
+# CABAL_DIR points at a BuildKit cache mount whose id is shared across the
+# 3 worker Dockerfiles, so the package store is reused between them and
+# (when --cache-to=type=gha,mode=max is configured) across CI runs.
+RUN --mount=type=cache,target=/tmp/cabal,sharing=locked,id=vocas-cabal-store \
+    env CABAL_DIR=/tmp/cabal cabal update
+
+# Stage 2: copy the source files.
 COPY applications/backend/image-worker/app app
 COPY applications/backend/image-worker/src src
 COPY applications/backend/image-worker/tests tests
 COPY packages/haskell/vocas-worker-core /workspace/packages/haskell/vocas-worker-core
 
-RUN env CABAL_DIR=/tmp/cabal cabal update
-RUN env CABAL_DIR=/tmp/cabal cabal install exe:image-worker \
+RUN --mount=type=cache,target=/tmp/cabal,sharing=locked,id=vocas-cabal-store \
+    --mount=type=cache,target=/workspace/applications/backend/image-worker/dist-newstyle,id=vocas-cabal-dist-image \
+    env CABAL_DIR=/tmp/cabal cabal install exe:image-worker \
     --disable-tests \
     --install-method=copy \
     --installdir=/out \

--- a/scripts/ci/build_haskell_worker_images.sh
+++ b/scripts/ci/build_haskell_worker_images.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Pre-builds the Haskell worker Docker images with explicit `docker buildx
+# build --cache-to=type=gha,mode=max --load` so the BuildKit cache mounts
+# (cabal store + per-worker dist-newstyle) survive across CI runs.
+#
+# Compose's `cache_from`/`cache_to` are silently dropped when the build
+# is invoked through `docker compose --build` on ubuntu-24.04 runners
+# (verified via runs 24919496475 / 24920082015 — no `exporting cache`
+# log lines, post-job cache state stayed "not set"). Pre-building each
+# image directly with buildx — the same pattern that
+# `scripts/ci/prepare_emulator_image.sh` already uses successfully —
+# routes the cache flags through the channel that actually honors them.
+#
+# After this script runs, each worker image is loaded into the local
+# Docker daemon under the tag the compose service references via its
+# `image:` field, so a subsequent `docker compose up` (without `--build`)
+# picks them up without re-running the build.
+#
+# Usage:
+#   bash scripts/ci/build_haskell_worker_images.sh
+#
+# Environment knobs:
+#   GITHUB_ACTIONS=true|ACT=1 — enable `type=gha` cache flags (mirrors
+#     the pattern in prepare_emulator_image.sh:95-100).
+#   VOCAS_HASKELL_WORKER_IMAGE_TAG — overrides the tag suffix; defaults
+#     to "ci".
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/vocastock_env.sh"
+
+vocas_require_command docker
+
+build_context="$(vocas_repo_root)"
+image_tag="${VOCAS_HASKELL_WORKER_IMAGE_TAG:-ci}"
+
+cache_args=()
+if [[ "${GITHUB_ACTIONS:-}" == "true" || -n "${ACT:-}" ]]; then
+  in_gha="yes"
+else
+  in_gha="no"
+fi
+
+while IFS= read -r worker; do
+  image_reference="vocastock-applications-${worker}:${image_tag}"
+  dockerfile="$build_context/docker/applications/${worker}/Dockerfile"
+
+  build_args=(
+    buildx build
+    --file "$dockerfile"
+    --tag "$image_reference"
+  )
+  if [[ "$in_gha" == "yes" ]]; then
+    cache_args=(
+      --cache-from "type=gha,scope=vocas-${worker}"
+      --cache-to "type=gha,scope=vocas-${worker},mode=max"
+    )
+    build_args+=("${cache_args[@]}")
+  fi
+  build_args+=(--load "$build_context")
+
+  vocas_log "building haskell worker image ${image_reference} (gha-cache=${in_gha})"
+  docker "${build_args[@]}"
+done < <(vocas_application_worker_services)

--- a/scripts/ci/e2e_stub_providers.mjs
+++ b/scripts/ci/e2e_stub_providers.mjs
@@ -155,7 +155,10 @@ async function main() {
     });
   }
 
-  server.listen(port, "127.0.0.1");
+  // Bind to all interfaces so that compose containers can reach the stub
+  // via `host.docker.internal:host-gateway` (the bridge gateway IP, not
+  // the host loopback). Local dev still reaches it via 127.0.0.1.
+  server.listen(port, "0.0.0.0");
 }
 
 main().catch((error) => {

--- a/scripts/ci/run_application_container_smoke.sh
+++ b/scripts/ci/run_application_container_smoke.sh
@@ -112,10 +112,16 @@ cleanup() {
 trap cleanup EXIT
 
 if (( reuse_running == 0 )); then
-  up_args=(--env-file "$env_file" -f "$compose_file" up -d)
   if (( skip_build == 0 )); then
-    up_args+=(--build)
+    # Pre-build Haskell worker images via explicit `docker buildx build`
+    # so the GHA cache backend actually receives the cache_to flag.
+    # `docker compose --build` silently drops cache_from/cache_to with
+    # the docker-container builder set up by setup-buildx-action; see
+    # scripts/ci/build_haskell_worker_images.sh for the working pattern.
+    bash "$SCRIPT_DIR/build_haskell_worker_images.sh"
   fi
+
+  up_args=(--env-file "$env_file" -f "$compose_file" up -d)
   up_args+=("${services[@]}")
 
   vocas_log "starting application container smoke for services: ${services[*]}"

--- a/scripts/ci/run_e2e_round_trip_smoke.sh
+++ b/scripts/ci/run_e2e_round_trip_smoke.sh
@@ -287,10 +287,16 @@ done < <(vocas_application_service_names)
 failure_stage="compose-up"
 vocas_log "compose up for services: ${services[*]}"
 if (( reuse_running == 0 )); then
-  up_args=(--env-file "$e2e_env_file" -f "$compose_file" up -d)
   if (( skip_build == 0 )); then
-    up_args+=(--build)
+    # Pre-build Haskell worker images via explicit `docker buildx build`
+    # so the GHA cache backend actually receives the cache_to flag.
+    # `docker compose --build` silently drops cache_from/cache_to with
+    # the docker-container builder set up by setup-buildx-action; see
+    # scripts/ci/build_haskell_worker_images.sh for the working pattern.
+    bash "$SCRIPT_DIR/build_haskell_worker_images.sh"
   fi
+
+  up_args=(--env-file "$e2e_env_file" -f "$compose_file" up -d)
   up_args+=("${services[@]}")
   docker compose "${up_args[@]}"
 fi


### PR DESCRIPTION
## Summary

PR を `fix/ci-e2e-smoke-timeout` (timeout 引き上げ) で開いたが、`e2e-round-trip-smoke` の失敗は CI 時間の問題ではなく複数の独立したバグだったため、ブランチ上で順次修正してこのPRに集約。

| Commit | 修正対象 | 効果 |
| --- | --- | --- |
| `2aad49d` ci: raise timeout 12→40 min | CI ジョブ timeout | 余裕を持たせる (元の修正) |
| `d216ce8` cache Haskell worker builds (compose) | Haskell worker Docker build キャッシュ | (compose の cache_from/to は実際には forward されず無効、後続 commit で本格対応) |
| `71f8acb` bind e2e stub to 0.0.0.0 | `e2e_stub_providers.mjs` が `127.0.0.1` のみで listen していたため worker container から `host.docker.internal:port` で届かず `Connection refused` | worker が Anthropic stub に到達できるように |
| `7070a69` worker writes id/text on patch | `switchCurrentExplanation` が `currentExplanation` + `explanationStatus` の 2 フィールドしか書かず、`vocabularyExpressions/{id}` の必須フィールド (`id`, `text`) が無いため query-api detail が null を返していた | round-trip 完走 |
| `7671b57` pre-build via `docker buildx build` | `docker compose --build` が compose の `cache_from`/`cache_to` を docker-container builder に forward していなかった (run 24919496475/24920082015 で確認: `exporting cache` ログ無し、cache state `not set`)。新規 helper script で各 Haskell worker を直接 `docker buildx build --cache-from/--cache-to=type=gha,mode=max --load` で事前ビルドし、compose は `image:` フィールドで pre-built image を参照 | 同一 CI run 内で 3 worker が `id=vocas-cabal-store` cache mount を共有し、後続 worker が ~18 秒で完了 |

## CI 状態 (run 24920801928)

- ✅ `e2e-round-trip-smoke` — success (10.7 分)
- ✅ `application-container-smoke` — success (10.7 分)
- ✅ `haskell-quality` — success (1.4 分)
- ✅ その他全ジョブ success
- mergeable: MERGEABLE / mergeStateStatus: CLEAN

## ビルド時間の比較

修正前 (parallel rebuild via compose):
- 3 worker が並列で同じ依存をフルビルド、wall-clock ~18 分

修正後 (helper による pre-build, in-run cache mount sharing):
- explanation-worker (最初): cabal install ~6.5 分
- image-worker, billing-worker (cache hit): ~18 秒ずつ
- 合計 wall-clock ~7 分

## 既知の改善余地 (別 issue で対応想定)

- **クロス CI run キャッシュ**: 現状の `--cache-to=type=gha,mode=max` は GHA cache に書き出されていない (確認: 24920801928 後に `gh api /repos/.../actions/caches` で `vocas-*` 該当エントリ無し)。`scripts/ci/prepare_emulator_image.sh` も同じパターンを使うが GHA cache 出力が動作しない可能性あり。`actions/cache@v4` + `type=local` cache backend に切り替えると cabal 依存の **クロス CI 再利用** が可能。explanation-worker の初回 6.5 分も ~1 分まで短縮見込み。

## Test plan

- [x] `.github/workflows/ci.yml` の YAML syntax 検証
- [x] 他ジョブの `timeout-minutes` と整合性確認
- [x] CI 再実行で `e2e-round-trip-smoke` が success
- [x] `ci-runtime-budget` ジョブの aggregate 予算超過なし
- [x] `application-container-smoke` も success (同じ image をシェア)
- [x] in-run cache mount sharing の動作確認 (image-worker/billing-worker が ~18 秒で完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)