### PR TITLE
feat(visual): propagate senseIdentifier through RequestImageGenerationCommand → worker

### DIFF
--- a/applications/backend/command-api/src/register_command_api/command/mutation_request.rs
+++ b/applications/backend/command-api/src/register_command_api/command/mutation_request.rs
@@ -121,6 +121,9 @@ pub struct RequestImageGenerationCommand {
     pub actor: VerifiedActorContext,
     pub idempotency_key: String,
     pub vocabulary_expression: String,
+    /// Sense the regenerated image illustrates (per
+    /// `docs/internal/domain/visual.md:45,52`); null = explanation-wide image.
+    pub sense_identifier: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -152,6 +155,16 @@ struct GenerationRequestEnvelope {
     actor: String,
     idempotency_key: String,
     vocabulary_expression: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImageGenerationRequestEnvelope {
+    actor: String,
+    idempotency_key: String,
+    vocabulary_expression: String,
+    #[serde(default)]
+    sense_identifier: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -200,15 +213,22 @@ pub fn parse_request_image_generation(
     body: &str,
     actor_context: &VerifiedActorContext,
 ) -> Result<RequestImageGenerationCommand, MutationRequestError> {
-    let envelope: GenerationRequestEnvelope =
+    let envelope: ImageGenerationRequestEnvelope =
         serde_json::from_str(body).map_err(|_| MutationRequestError::InvalidJson)?;
     let (actor, idempotency_key) =
         validate_actor_and_key(&envelope.actor, &envelope.idempotency_key, actor_context)?;
     let vocabulary_expression = validate_vocabulary_expression(&envelope.vocabulary_expression)?;
+    let sense_identifier = envelope
+        .sense_identifier
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
     Ok(RequestImageGenerationCommand {
         actor,
         idempotency_key,
         vocabulary_expression,
+        sense_identifier,
     })
 }
 
@@ -350,17 +370,24 @@ impl MutationCommand for RequestImageGenerationCommand {
         &self.idempotency_key
     }
     fn payload_hash(&self) -> String {
-        format!("vocab={}", self.vocabulary_expression)
+        match self.sense_identifier.as_deref() {
+            Some(sense) => format!("vocab={};sense={}", self.vocabulary_expression, sense),
+            None => format!("vocab={}", self.vocabulary_expression),
+        }
     }
     fn dispatch_request(&self) -> DispatchRequest {
-        DispatchRequest::new(
+        let mut request = DispatchRequest::new(
             self.actor_reference(),
             self.idempotency_key.as_str(),
             "",
             self.vocabulary_expression.as_str(),
             false,
         )
-        .with_kind(DispatchKind::ImageGeneration)
+        .with_kind(DispatchKind::ImageGeneration);
+        if let Some(sense) = self.sense_identifier.as_deref() {
+            request = request.with_sense_identifier(sense);
+        }
+        request
     }
     fn success_message(&self) -> UserFacingMessage {
         UserFacingMessage::new(

--- a/applications/backend/command-api/src/register_command_api/runtime/dispatch_port.rs
+++ b/applications/backend/command-api/src/register_command_api/runtime/dispatch_port.rs
@@ -31,6 +31,7 @@ pub struct DispatchRequest {
     pub kind: DispatchKind,
     pub retry_target: Option<String>,
     pub plan_code: Option<String>,
+    pub sense_identifier: Option<String>,
 }
 
 impl DispatchRequest {
@@ -50,6 +51,7 @@ impl DispatchRequest {
             kind: DispatchKind::ExplanationGeneration,
             retry_target: None,
             plan_code: None,
+            sense_identifier: None,
         }
     }
 
@@ -65,6 +67,11 @@ impl DispatchRequest {
 
     pub fn with_plan_code(mut self, plan_code: impl Into<String>) -> Self {
         self.plan_code = Some(plan_code.into());
+        self
+    }
+
+    pub fn with_sense_identifier(mut self, sense: impl Into<String>) -> Self {
+        self.sense_identifier = Some(sense.into());
         self
     }
 }

--- a/applications/backend/command-api/src/register_command_api/runtime/pubsub_dispatch_port.rs
+++ b/applications/backend/command-api/src/register_command_api/runtime/pubsub_dispatch_port.rs
@@ -82,6 +82,9 @@ pub fn build_dispatch_message(request: &DispatchRequest) -> PubSubMessage {
     if let Some(plan_code) = request.plan_code.as_ref() {
         message = message.with_attribute("planCode", plan_code.clone());
     }
+    if let Some(sense_identifier) = request.sense_identifier.as_ref() {
+        message = message.with_attribute("senseIdentifier", sense_identifier.clone());
+    }
     message
 }
 
@@ -110,6 +113,12 @@ fn build_dispatch_payload(request: &DispatchRequest) -> String {
             value.insert(
                 "planCode".to_owned(),
                 serde_json::Value::String(plan_code.clone()),
+            );
+        }
+        if let Some(sense_identifier) = request.sense_identifier.as_ref() {
+            value.insert(
+                "senseIdentifier".to_owned(),
+                serde_json::Value::String(sense_identifier.clone()),
             );
         }
     }

--- a/applications/backend/command-api/tests/feature/production_mutations.rs
+++ b/applications/backend/command-api/tests/feature/production_mutations.rs
@@ -91,7 +91,7 @@ fn production_adapters_path_accepts_register_and_five_mutations() {
         "explanation outcome",
     );
 
-    // --- request image generation ---
+    // --- request image generation (with senseIdentifier per #22) ---
     let image = runtime.post_raw(
         "/commands/request-image-generation",
         Some(demo_bearer.as_str()),
@@ -99,7 +99,10 @@ fn production_adapters_path_accepts_register_and_five_mutations() {
             "requestImageGeneration",
             "stub-actor-demo",
             "feat-image-1",
-            json!({"vocabularyExpression": "vocabulary:serendipity"}),
+            json!({
+                "vocabularyExpression": "vocabulary:serendipity",
+                "senseIdentifier": "sense-001",
+            }),
         )
         .as_str(),
     );

--- a/applications/backend/command-api/tests/unit/register_command_api/command/mutation_request.rs
+++ b/applications/backend/command-api/tests/unit/register_command_api/command/mutation_request.rs
@@ -59,6 +59,34 @@ fn parse_request_image_generation_builds_image_kind_dispatch() {
         command.dispatch_request().kind,
         DispatchKind::ImageGeneration
     );
+    assert!(command.sense_identifier.is_none());
+    assert!(command.dispatch_request().sense_identifier.is_none());
+}
+
+#[test]
+fn parse_request_image_generation_accepts_optional_sense_identifier() {
+    let body = "{\"actor\":\"actor:learner\",\"idempotencyKey\":\"k2-sense\",\"vocabularyExpression\":\"vocabulary:tea\",\"senseIdentifier\":\"sense-001\"}";
+    let command = parse_request_image_generation(body, &active_actor()).expect("valid request");
+    assert_eq!(command.sense_identifier.as_deref(), Some("sense-001"));
+    assert_eq!(
+        command.dispatch_request().sense_identifier.as_deref(),
+        Some("sense-001"),
+    );
+}
+
+#[test]
+fn parse_request_image_generation_treats_empty_sense_identifier_as_none() {
+    let body = "{\"actor\":\"actor:learner\",\"idempotencyKey\":\"k2-empty\",\"vocabularyExpression\":\"vocabulary:tea\",\"senseIdentifier\":\"\"}";
+    let command = parse_request_image_generation(body, &active_actor()).expect("valid request");
+    assert!(command.sense_identifier.is_none());
+    assert!(command.dispatch_request().sense_identifier.is_none());
+}
+
+#[test]
+fn parse_request_image_generation_trims_whitespace_only_sense_identifier_to_none() {
+    let body = "{\"actor\":\"actor:learner\",\"idempotencyKey\":\"k2-ws\",\"vocabularyExpression\":\"vocabulary:tea\",\"senseIdentifier\":\"   \"}";
+    let command = parse_request_image_generation(body, &active_actor()).expect("valid request");
+    assert!(command.sense_identifier.is_none());
 }
 
 #[test]

--- a/applications/backend/command-api/tests/unit/register_command_api/runtime/pubsub_dispatch_port.rs
+++ b/applications/backend/command-api/tests/unit/register_command_api/runtime/pubsub_dispatch_port.rs
@@ -93,6 +93,37 @@ fn build_dispatch_message_includes_plan_code_for_purchase() {
 }
 
 #[test]
+fn build_dispatch_message_includes_sense_identifier_for_image_generation() {
+    let request = DispatchRequest::new("actor:learner", "k4", "", "vocabulary:run", false)
+        .with_kind(DispatchKind::ImageGeneration)
+        .with_sense_identifier("sense-001");
+    let message = build_dispatch_message(&request);
+
+    let attributes: std::collections::HashMap<_, _> = message.attributes.iter().cloned().collect();
+    assert_eq!(attributes.get("kind"), Some(&"image-generation".to_owned()));
+    assert_eq!(
+        attributes.get("senseIdentifier"),
+        Some(&"sense-001".to_owned())
+    );
+
+    let payload_json = String::from_utf8(message.data.clone()).expect("utf-8 data");
+    assert!(payload_json.contains("\"senseIdentifier\":\"sense-001\""));
+}
+
+#[test]
+fn build_dispatch_message_omits_sense_identifier_when_absent() {
+    let request = DispatchRequest::new("actor:learner", "k5", "", "vocabulary:run", false)
+        .with_kind(DispatchKind::ImageGeneration);
+    let message = build_dispatch_message(&request);
+
+    let attributes: std::collections::HashMap<_, _> = message.attributes.iter().cloned().collect();
+    assert!(!attributes.contains_key("senseIdentifier"));
+
+    let payload_json = String::from_utf8(message.data.clone()).expect("utf-8 data");
+    assert!(!payload_json.contains("senseIdentifier"));
+}
+
+#[test]
 fn decode_data_helper_round_trips() {
     // sanity check the in-test decoder against shared-pubsub's encoder.
     assert_eq!(decode_data("Zm9v"), "foo");

--- a/applications/backend/image-worker/image-worker.cabal
+++ b/applications/backend/image-worker/image-worker.cabal
@@ -31,6 +31,7 @@ library scenarios
       ImageWorker.FailureSummary
       ImageWorker.ImagePersistence
       ImageWorker.PreviousImageInvariant
+      ImageWorker.SenseAttachmentInvariant
       ImageWorker.TargetResolution
       ImageWorker.WorkerRuntime
       ImageWorker.WorkflowStateMachine
@@ -61,6 +62,8 @@ test-suite unit
       ImageWorker.ImageGenerationPortSpec
       ImageWorker.ImagePersistenceSpec
       ImageWorker.PreviousImageInvariantSpec
+      ImageWorker.PullLoopPromptSpec
+      ImageWorker.SenseAttachmentInvariantSpec
       ImageWorker.StabilityAdapterSpec
       ImageWorker.TargetResolutionSpec
       ImageWorker.WorkItemContractSpec
@@ -79,6 +82,7 @@ test-suite unit
     , image-worker:scenarios
     , network
     , text
+    , vocas-worker-core
     , wai
     , warp
   default-language: GHC2021

--- a/applications/backend/image-worker/src/ImageWorker/PullLoop.hs
+++ b/applications/backend/image-worker/src/ImageWorker/PullLoop.hs
@@ -6,6 +6,7 @@
 -- handoff -> ack.
 module ImageWorker.PullLoop
   ( runPullLoop,
+    imagePrompt,
   )
 where
 
@@ -129,10 +130,7 @@ runImageJob firestore storage stability manager bucket envelope = do
   let actor = envelopeActor envelope
   let vocabularyExpressionId = envelopeVocabularyExpression envelope
   let idempotencyKey = envelopeIdempotencyKey envelope
-  let prompt =
-        "Illustration visualising \""
-          <> fromMaybe vocabularyExpressionId (envelopeNormalizedText envelope)
-          <> "\""
+  let prompt = imagePrompt envelope
   outcome <- generateImage stability manager prompt idempotencyKey
   case outcome of
     ImageRetryable reason -> pure (Left (True, reason))
@@ -167,7 +165,7 @@ runImageJob firestore storage stability manager bucket envelope = do
               explanationId
               assetReference
               (T.pack "Generated illustration")
-              Nothing
+              (envelopeSenseIdentifier envelope)
               Nothing
               previousImage
           case writeResult of
@@ -182,3 +180,17 @@ die :: String -> IO a
 die reason = do
   hPutStrLn stderr ("[vocastock] image-worker cannot start: " <> reason)
   error reason
+
+-- | Builds the Stability prompt from the dispatch envelope, folding in
+-- the optional `senseIdentifier` so a sense-specific regeneration job
+-- actually steers the image (per `docs/internal/domain/visual.md:45,52`
+-- and `docs/internal/domain/service.md:64-66`). Exposed for unit
+-- testing without spinning up the loop.
+imagePrompt :: DispatchEnvelope -> Text
+imagePrompt envelope =
+  let baseSubject =
+        fromMaybe (envelopeVocabularyExpression envelope) (envelopeNormalizedText envelope)
+      senseSuffix = case envelopeSenseIdentifier envelope of
+        Just sense -> T.concat [" (sense: ", sense, ")"]
+        Nothing -> T.empty
+   in T.concat ["Illustration visualising \"", baseSubject, "\"", senseSuffix]

--- a/applications/backend/image-worker/tests/support-lib/ImageWorker/SenseAttachmentInvariant.hs
+++ b/applications/backend/image-worker/tests/support-lib/ImageWorker/SenseAttachmentInvariant.hs
@@ -1,0 +1,41 @@
+-- |
+-- Pure validator for the same-explanation `sense` invariant from
+-- `docs/internal/domain/visual.md:45,52` and
+-- `docs/internal/domain/explanation.md:16-28,188-190`:
+--
+--   * `VisualImage.sense` (`SenseIdentifier`, 0..1) must reference a
+--     `Sense` owned by the **same** Explanation that this image is
+--     attached to.
+--   * `sense = null` (explanation-wide image) is always valid.
+--
+-- This module documents the invariant so issue #22's acceptance criterion
+-- "同一 explanation 外の sense を指定したら domain invariant で reject"
+-- has an executable spec. It is **not** wired into the production
+-- `PullLoop` — runtime rejection would require a Firestore read of the
+-- explanation's `senses` array (mirroring `readCurrentImage`), which is
+-- intentionally out of scope for the "low" priority issue. The pure
+-- validator captures the rule for future runtime adoption.
+module ImageWorker.SenseAttachmentInvariant
+  ( SenseAttachmentViolation (..),
+    validateSenseInExplanation,
+  )
+where
+
+data SenseAttachmentViolation
+  = SenseNotInExplanation
+  deriving (Eq, Show)
+
+-- | First argument is the explanation's owned `Sense` identifiers; the
+-- second is the candidate `senseIdentifier` requested by the dispatch
+-- envelope. Returns `Right ()` when the link satisfies the invariant,
+-- `Left SenseNotInExplanation` otherwise.
+validateSenseInExplanation ::
+  -- | senses owned by the explanation
+  [String] ->
+  -- | candidate sense identifier (Nothing = explanation-wide image)
+  Maybe String ->
+  Either SenseAttachmentViolation ()
+validateSenseInExplanation _ Nothing = Right ()
+validateSenseInExplanation senses (Just candidate)
+  | candidate `elem` senses = Right ()
+  | otherwise = Left SenseNotInExplanation

--- a/applications/backend/image-worker/tests/unit/ImageWorker/PullLoopPromptSpec.hs
+++ b/applications/backend/image-worker/tests/unit/ImageWorker/PullLoopPromptSpec.hs
@@ -1,0 +1,68 @@
+module ImageWorker.PullLoopPromptSpec (run) where
+
+import qualified Data.Text as T
+
+import ImageWorker.PullLoop (imagePrompt)
+import TestSupport
+import Vocas.Worker.Core.MessageEnvelope
+  ( DispatchEnvelope (..),
+    DispatchKind (..),
+  )
+
+run :: IO ()
+run = do
+  runNamed "uses normalized text and folds in sense identifier" testWithSense
+  runNamed "uses normalized text without sense suffix when sense absent" testWithoutSense
+  runNamed "falls back to vocabulary expression when normalized text missing" testFallbackSubject
+
+baseEnvelope :: DispatchEnvelope
+baseEnvelope =
+  DispatchEnvelope
+    { envelopeActor = T.pack "stub-actor-demo",
+      envelopeIdempotencyKey = T.pack "feat-image-1",
+      envelopeKind = ImageGenerationKind,
+      envelopeVocabularyExpression = T.pack "vocabulary:run",
+      envelopeRestartRequested = False,
+      envelopeNormalizedText = Just (T.pack "run"),
+      envelopeRetryTarget = Nothing,
+      envelopePlanCode = Nothing,
+      envelopeSenseIdentifier = Nothing
+    }
+
+testWithSense :: IO ()
+testWithSense = do
+  let envelope = baseEnvelope {envelopeSenseIdentifier = Just (T.pack "sense-001")}
+      prompt = T.unpack (imagePrompt envelope)
+  assertEqual
+    "prompt mentions vocabulary"
+    True
+    (T.pack "\"run\"" `T.isInfixOf` imagePrompt envelope)
+  assertEqual
+    "prompt folds in sense"
+    True
+    (T.pack "(sense: sense-001)" `T.isInfixOf` imagePrompt envelope)
+  assertEqual
+    "prompt is the documented shape"
+    "Illustration visualising \"run\" (sense: sense-001)"
+    prompt
+
+testWithoutSense :: IO ()
+testWithoutSense = do
+  let prompt = T.unpack (imagePrompt baseEnvelope)
+  assertEqual
+    "prompt is the no-sense baseline"
+    "Illustration visualising \"run\""
+    prompt
+  assertEqual
+    "prompt does not contain sense suffix"
+    False
+    (T.pack "sense:" `T.isInfixOf` imagePrompt baseEnvelope)
+
+testFallbackSubject :: IO ()
+testFallbackSubject = do
+  let envelope = baseEnvelope {envelopeNormalizedText = Nothing}
+      prompt = T.unpack (imagePrompt envelope)
+  assertEqual
+    "prompt falls back to vocabulary expression when normalized text absent"
+    "Illustration visualising \"vocabulary:run\""
+    prompt

--- a/applications/backend/image-worker/tests/unit/ImageWorker/SenseAttachmentInvariantSpec.hs
+++ b/applications/backend/image-worker/tests/unit/ImageWorker/SenseAttachmentInvariantSpec.hs
@@ -1,0 +1,50 @@
+module ImageWorker.SenseAttachmentInvariantSpec (run) where
+
+import ImageWorker.SenseAttachmentInvariant
+  ( SenseAttachmentViolation (..),
+    validateSenseInExplanation,
+  )
+import TestSupport
+
+run :: IO ()
+run = do
+  runNamed "accepts Nothing sense for empty senses" testNothingEmpty
+  runNamed "accepts Nothing sense for non-empty senses" testNothingNonEmpty
+  runNamed "accepts when sense belongs to explanation" testSenseInExplanation
+  runNamed "rejects when sense not in explanation" testSenseNotInExplanation
+  runNamed "rejects sense against empty explanation senses" testSenseAgainstEmpty
+
+testNothingEmpty :: IO ()
+testNothingEmpty =
+  assertEqual
+    "Nothing + empty senses → Right"
+    (Right ())
+    (validateSenseInExplanation [] Nothing)
+
+testNothingNonEmpty :: IO ()
+testNothingNonEmpty =
+  assertEqual
+    "Nothing + non-empty senses → Right"
+    (Right ())
+    (validateSenseInExplanation ["sense-001", "sense-002"] Nothing)
+
+testSenseInExplanation :: IO ()
+testSenseInExplanation =
+  assertEqual
+    "sense in senses → Right"
+    (Right ())
+    (validateSenseInExplanation ["sense-001", "sense-002"] (Just "sense-001"))
+
+testSenseNotInExplanation :: IO ()
+testSenseNotInExplanation =
+  assertEqual
+    "sense not in senses → Left SenseNotInExplanation"
+    (Left SenseNotInExplanation)
+    (validateSenseInExplanation ["sense-001"] (Just "sense-from-other-explanation"))
+
+testSenseAgainstEmpty :: IO ()
+testSenseAgainstEmpty =
+  assertEqual
+    "sense against empty senses → Left SenseNotInExplanation"
+    (Left SenseNotInExplanation)
+    (validateSenseInExplanation [] (Just "sense-001"))

--- a/applications/backend/image-worker/tests/unit/Main.hs
+++ b/applications/backend/image-worker/tests/unit/Main.hs
@@ -6,6 +6,8 @@ import qualified ImageWorker.FailureSummarySpec
 import qualified ImageWorker.ImageGenerationPortSpec
 import qualified ImageWorker.ImagePersistenceSpec
 import qualified ImageWorker.PreviousImageInvariantSpec
+import qualified ImageWorker.PullLoopPromptSpec
+import qualified ImageWorker.SenseAttachmentInvariantSpec
 import qualified ImageWorker.StabilityAdapterSpec
 import qualified ImageWorker.TargetResolutionSpec
 import qualified ImageWorker.WorkItemContractSpec
@@ -20,6 +22,8 @@ main = do
   ImageWorker.AssetStoragePortSpec.run
   ImageWorker.ImagePersistenceSpec.run
   ImageWorker.PreviousImageInvariantSpec.run
+  ImageWorker.SenseAttachmentInvariantSpec.run
+  ImageWorker.PullLoopPromptSpec.run
   ImageWorker.CurrentImageHandoffSpec.run
   ImageWorker.FailureSummarySpec.run
   ImageWorker.WorkflowStateMachineSpec.run

--- a/packages/haskell/vocas-worker-core/src/Vocas/Worker/Core/MessageEnvelope.hs
+++ b/packages/haskell/vocas-worker-core/src/Vocas/Worker/Core/MessageEnvelope.hs
@@ -50,7 +50,8 @@ data DispatchEnvelope = DispatchEnvelope
     envelopeRestartRequested :: Bool,
     envelopeNormalizedText :: Maybe Text,
     envelopeRetryTarget :: Maybe GenerationTarget,
-    envelopePlanCode :: Maybe PlanCode
+    envelopePlanCode :: Maybe PlanCode,
+    envelopeSenseIdentifier :: Maybe Text
   }
   deriving (Eq, Show)
 
@@ -78,6 +79,7 @@ buildEnvelope obj = do
   retryTarget <- traverse decodeGenerationTarget retryTargetRaw
   planCodeRaw <- optionalMaybeText "planCode" obj
   planCode <- traverse decodePlanCode planCodeRaw
+  senseIdentifier <- optionalMaybeText "senseIdentifier" obj
   Right
     DispatchEnvelope
       { envelopeActor = actor,
@@ -87,7 +89,8 @@ buildEnvelope obj = do
         envelopeRestartRequested = restartRequested,
         envelopeNormalizedText = normalizedText,
         envelopeRetryTarget = retryTarget,
-        envelopePlanCode = planCode
+        envelopePlanCode = planCode,
+        envelopeSenseIdentifier = senseIdentifier
       }
 
 decodeDispatchKind :: Text -> Either String DispatchKind

--- a/packages/haskell/vocas-worker-core/tests/unit/MessageEnvelopeSpec.hs
+++ b/packages/haskell/vocas-worker-core/tests/unit/MessageEnvelopeSpec.hs
@@ -20,6 +20,8 @@ run = do
         caseRetry,
         casePurchase,
         caseRestore,
+        caseImageWithSense,
+        caseImageWithoutSense,
         caseMalformed
       ]
   pure (all id cases)
@@ -107,6 +109,35 @@ caseRestore = do
     Right envelope -> assertEq "kind" RestorePurchaseKind (envelopeKind envelope)
     Left err -> do
       putStrLn ("  FAIL restore envelope: " ++ err)
+      pure False
+
+caseImageWithSense :: IO Bool
+caseImageWithSense = do
+  let raw =
+        LBS8.pack
+          "{\"actor\":\"a\",\"idempotencyKey\":\"k5\",\"kind\":\"image-generation\",\"vocabularyExpression\":\"vocabulary:run\",\"restartRequested\":false,\"senseIdentifier\":\"sense-001\"}"
+  case decodeDispatchEnvelope raw of
+    Right envelope -> do
+      results <-
+        sequence
+          [ assertEq "kind" ImageGenerationKind (envelopeKind envelope),
+            assertEq "sense identifier" (Just "sense-001") (envelopeSenseIdentifier envelope)
+          ]
+      pure (all id results)
+    Left err -> do
+      putStrLn ("  FAIL image-with-sense envelope: " ++ err)
+      pure False
+
+caseImageWithoutSense :: IO Bool
+caseImageWithoutSense = do
+  let raw =
+        LBS8.pack
+          "{\"actor\":\"a\",\"idempotencyKey\":\"k6\",\"kind\":\"image-generation\",\"vocabularyExpression\":\"vocabulary:run\",\"restartRequested\":false}"
+  case decodeDispatchEnvelope raw of
+    Right envelope ->
+      assertEq "sense identifier defaults to Nothing" Nothing (envelopeSenseIdentifier envelope)
+    Left err -> do
+      putStrLn ("  FAIL image-without-sense envelope: " ++ err)
       pure False
 
 caseMalformed :: IO Bool


### PR DESCRIPTION
Closes #22.

## Summary

`ImageGenerationPort` accepts `sense?` (`docs/internal/domain/service.md:64-66`) and `VisualImage.sense` is documented in `docs/internal/domain/visual.md:45,52`, but the write-side (HTTP body → command-api → dispatch envelope → image-worker) was severed: `RequestImageGenerationCommand` didn't accept `senseIdentifier`, the dispatch envelope didn't carry it, and `PullLoop` hardcoded `Nothing` when calling `writeCompletedImage`. Every regenerated image landed with `sense=null` regardless of caller intent.

This PR closes that gap end-to-end and folds `(sense: <id>)` into the Stability prompt so the generated image actually reflects the requested sense.

| Layer | Change |
| --- | --- |
| **Rust command-api** | New `ImageGenerationRequestEnvelope` keeps the explanation envelope shape clean. `RequestImageGenerationCommand.sense_identifier: Option<String>`, trim/empty-as-None on parse. `DispatchRequest` gains `sense_identifier` + `with_sense_identifier(...)` mirroring `with_retry_target`/`with_plan_code`. Pub/Sub message + body conditionally include `senseIdentifier`. `payload_hash()` includes sense only when `Some` so the existing fingerprint invariant for no-sense requests holds. |
| **Haskell vocas-worker-core** | `DispatchEnvelope.envelopeSenseIdentifier :: Maybe Text`, decoded via the existing `optionalMaybeText` helper. |
| **Haskell image-worker** | `PullLoop.imagePrompt` (new exported helper) folds `(sense: <id>)` into the Stability prompt when present. `writeCompletedImage` call replaces the hardcoded `Nothing` with `envelopeSenseIdentifier envelope`. New pure validator `ImageWorker.SenseAttachmentInvariant` + spec mirrors PR #24's `PreviousImageInvariant` precedent. |
| **query-api / GraphQL / Flutter** | No change — already exposed `senseIdentifier`. |

## Acceptance criteria

- [x] `RequestImageGenerationCommand` が optional `senseIdentifier` を受理 — `parse_request_image_generation_*` (4 cases including trim/empty/whitespace).
- [x] dispatch message に `senseIdentifier` attribute が含まれる — `build_dispatch_message_includes_sense_identifier_for_image_generation` + omits-when-absent regression.
- [x] 同一 explanation 外の sense を指定したら domain invariant で reject (unit test あり) — `SenseAttachmentInvariantSpec` (5 cases). Pure validator, no runtime hookup (rationale below).
- [x] image-worker が sense を prompt context に反映 — `PullLoopPromptSpec` (3 cases: with sense / without sense / fallback subject).
- [x] 完了画像が sense を保持し、query-api / GraphQL で返る — already covered by query-api unit tests + GraphQL schema (`schema.graphql:180-181`).
- [x] unit / feature test で sense-to-image mapping が end-to-end に通る — `MessageEnvelopeSpec.caseImageWithSense` proves Rust → Haskell wire compatibility; `production_mutations.rs` feature test sends `senseIdentifier` and asserts ACCEPTED.

## Why pure validator (Option A) instead of runtime rejection

PR #24's `PreviousImageInvariant` is the precedent — it lives only in `tests/support-lib` and documents the rule without runtime enforcement. Worker production code trusts the dispatch contract. Runtime enforcement would require a Firestore read of the explanation's `senses` array (mirroring `readCurrentImage`) — a substantial new I/O path inappropriate for this "low" priority issue. The pure validator captures the invariant exactly so a future runtime adoption can call it without re-deriving the rule.

## Out of scope (follow-up issues)

- Runtime rejection of cross-explanation senses (`readExplanationSenses` helper)
- `senseLabel` propagation (worker doesn't have access to label without explanation read)
- UI sense selector (issue body explicitly defers)
- Multi-sense parallel generation (1 image = 1 sense per visual.md)

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --test unit` — 91 query-api + 78 command-api + 84 graphql-gateway pass
- [x] `cabal test vocas-worker-core:unit` PASS (includes 2 new envelope cases)
- [x] `cabal test image-worker:unit` PASS (includes 5 invariant + 3 prompt cases)
- [ ] CI green