### PR TITLE
feat(dev): add local AI provider stub for offline backend dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ docker/applications/env/.env
 docker/applications/env/.env.local
 docker/applications/*.override.yaml
 .claude/settings.local.json
+
+# Local AI provider stub (per-run env file written by scripts/dev/start_stub_providers.sh)
+.env.stub

--- a/docs/development/local-stub.md
+++ b/docs/development/local-stub.md
@@ -1,0 +1,95 @@
+# Local AI provider stub
+
+Run the backend workers locally without paid Anthropic / Stability API keys. The stub mirrors the wire format of both providers so the real worker → Pub/Sub → Firestore round-trip exercises real adapters end-to-end.
+
+## Quick start
+
+Three independent commands (run each in its own terminal):
+
+```bash
+# 1. Firebase emulators (Firestore + Auth + Storage + Pub/Sub)
+bash scripts/firebase/start_emulators.sh
+
+# 2. AI provider stub (writes .env.stub at repo root)
+bash scripts/dev/start_stub_providers.sh
+
+# 3. Backend services pointing at the stub
+docker compose --env-file .env.stub -f docker/applications/compose.yaml up
+```
+
+After step 2 the launcher prints the chosen port, the env-file path, the PID, and the log paths. Tear down in any order:
+
+```bash
+docker compose -f docker/applications/compose.yaml down
+bash scripts/dev/stop_stub_providers.sh
+bash scripts/firebase/stop_emulators.sh
+```
+
+## What the stub returns
+
+The script under `scripts/ci/e2e_stub_providers.mjs` (shared with the e2e CI smoke) serves three endpoints:
+
+| Method + path | Response |
+| --- | --- |
+| `GET /readyz` | 200 `OK` |
+| `POST /v1/messages` | 200 JSON in Anthropic Messages API shape; the `content[0].text` is a JSON string with the required `CompletedExplanationPayload` fields (`summary`, `senses[]`, `frequency`, `sophistication`, `pronunciation`, `etymology`, `similar_expressions`). |
+| `POST /v1/generation/{engineId}/text-to-image` | 200 JSON in Stability shape; `artifacts[0].base64` is a 1×1 transparent PNG (≈100 bytes). The image-worker base64-decodes it and uploads the bytes to the Cloud Storage emulator. |
+| anything else | 404 |
+
+Both successful responses are deterministic — the same explanation payload and the same PNG land for every request. That is intentional (see "Limitations" below).
+
+## Customisation
+
+Override these env vars before running `start_stub_providers.sh`:
+
+| Var | Default | Notes |
+| --- | --- | --- |
+| `VOCAS_STUB_PROVIDERS_PORT` | auto-pick free port | If you pin one, avoid colliding with compose-published ports (graphql-gateway 18180 / command-api 18181 / query-api 18182). |
+| `VOCAS_STUB_LOG_DIR` | `${TMPDIR:-/tmp}/vocastock-stub` | Houses `stub.log`, `access.log`, `pid`. |
+| `VOCAS_STUB_ENV_FILE` | `${REPO_ROOT}/.env.stub` | Path the launcher writes; pass to compose with `--env-file`. Gitignored. |
+
+The launcher refuses to start a second instance while another one is running (PID file check). Use `stop_stub_providers.sh` to stop, or `kill` the printed PID.
+
+## Verification
+
+After step 2 in "Quick start", probe the stub directly:
+
+```bash
+PORT=$(awk -F: '/ANTHROPIC_API_BASE_URL/ {split($NF,a,"/"); print a[3]}' .env.stub)
+
+curl -fsS "http://127.0.0.1:${PORT}/readyz"
+# OK
+
+curl -fsS -X POST "http://127.0.0.1:${PORT}/v1/messages" \
+  -H 'content-type: application/json' \
+  -d '{"model":"claude-3-haiku","max_tokens":1024,"messages":[]}'
+# JSON with content[0].text containing the explanation payload
+
+curl -fsS -X POST "http://127.0.0.1:${PORT}/v1/generation/stable-diffusion-v1-6/text-to-image" \
+  -H 'content-type: application/json' \
+  -d '{"text_prompts":[{"text":"test","weight":1}],"cfg_scale":7,"height":512,"width":512,"samples":1,"steps":30}' \
+  | jq -r '.artifacts[0].base64' | base64 --decode | file -
+# /dev/stdin: PNG image data, 1 x 1, ...
+```
+
+After step 3, drive the GraphQL gateway (`http://127.0.0.1:18180/graphql`) with `registerVocabularyExpression` / `requestExplanationGeneration` / `requestImageGeneration` mutations from your usual harness. Tail `${VOCAS_STUB_LOG_DIR:-/tmp/vocastock-stub}/access.log` to confirm the workers reach the stub:
+
+```
+2026-04-25T05:42:01.012Z POST /v1/messages
+2026-04-25T05:42:03.456Z POST /v1/generation/stable-diffusion-v1-6/text-to-image
+```
+
+The completed explanation document and the uploaded image should appear under the actor's `vocabularyExpressions` / `images` collections in the Firestore emulator UI at `http://127.0.0.1:4000`.
+
+## Limitations
+
+- **Deterministic output.** Every request gets the same explanation body / same 1×1 PNG. No prompt-driven variance; not suitable for visual review or fixture diversity.
+- **No streaming.** Anthropic streaming responses (`message_delta` chunks) are not modelled — the stub returns the final body in a single response. Adapters that rely on streaming would need to be tested against the live API.
+- **No error injection.** The stub never returns 4xx/5xx (other than the 404 fallthrough); rate-limit / quota-exhausted / network-blip behaviour is unmodelled.
+- **No latency simulation.** Responses are instant. The projection-lag window between command acceptance and Firestore write is exercised by the workers' real Pub/Sub poll interval (`VOCAS_WORKER_POLL_INTERVAL_SECONDS`), not by stub latency.
+- **OpenAI is not stubbed.** The codebase declares `OPENAI_API_KEY` and `LLM_PROVIDER` env vars but no worker reads them today. If an OpenAI adapter ships later, this stub will need a corresponding endpoint.
+- **Path-suffix Stability match.** The stub matches any `POST /v1/generation/*/text-to-image`, regardless of engine id. A future `image-to-image` call would 404; widen the match if/when it lands.
+
+## CI usage (for reference)
+
+`scripts/ci/run_e2e_round_trip_smoke.sh` boots the same stub on every PR run via the e2e CI smoke job. It writes its own access log under `.artifacts/ci/logs/`, exports `ANTHROPIC_API_BASE_URL` / `STABILITY_API_BASE_URL` to the chosen port, and tears the stub down via the script's `trap cleanup EXIT`. Local dev borrows the same Node script but layers a launcher / stopper around it so multi-terminal workflows are ergonomic.

--- a/scripts/ci/e2e_stub_providers.mjs
+++ b/scripts/ci/e2e_stub_providers.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
-// Test-scope HTTP stub that pretends to be the Anthropic Messages API so
-// the E2E round-trip smoke can exercise the real worker -> provider
-// transport path without hitting the live endpoint. Used only from
-// `scripts/ci/run_e2e_round_trip_smoke.sh` and kept under `scripts/ci/`
-// so production binaries never link or reference it.
+// Test-scope HTTP stub that pretends to be the Anthropic Messages API
+// **and** the Stability text-to-image API so workers can talk to a
+// deterministic fake instead of paid live endpoints. Two callers:
+//   * `scripts/ci/run_e2e_round_trip_smoke.sh`  — CI smoke harness.
+//   * `scripts/dev/start_stub_providers.sh`     — local-dev launcher
+//     (see `docs/development/local-stub.md`).
+// The stub stays under `scripts/ci/` so production binaries never link
+// or reference it; the dev launcher just `node`-invokes the same file.
 //
 // Usage:
 //   node scripts/ci/e2e_stub_providers.mjs [--port <port>] \
@@ -14,9 +17,14 @@
 // - Each incoming request is appended to the access log file (if the
 //   `--access-log` flag is provided) in the form `ISO8601 METHOD PATH`.
 // - Responds to:
-//     GET  /readyz             -> 200 `OK`
-//     POST /v1/messages        -> 200 JSON (Anthropic success body)
-//     *                        -> 404
+//     GET  /readyz                                       -> 200 `OK`
+//     POST /v1/messages                                  -> 200 JSON
+//                                                          (Anthropic success)
+//     POST /v1/generation/{engineId}/text-to-image       -> 200 JSON
+//                                                          (Stability success
+//                                                           with a 1x1
+//                                                           transparent PNG)
+//     *                                                  -> 404
 //
 // Shutdown: SIGTERM / SIGINT close the server cleanly so the driver's
 // trap can proceed with the rest of the cleanup steps.
@@ -86,6 +94,22 @@ const anthropicSuccessBody = JSON.stringify({
   ],
 });
 
+// 1x1 transparent PNG, base64-encoded. ImageWorker.StabilityAdapter
+// reads `artifacts[0].base64`, base64-decodes it, and uploads the bytes
+// verbatim to Cloud Storage; the value must be a real, decodable PNG.
+const stabilityPngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAeImBZsAAAAASUVORK5CYII=";
+
+const stabilitySuccessBody = JSON.stringify({
+  artifacts: [
+    {
+      base64: stabilityPngBase64,
+      finishReason: "SUCCESS",
+      seed: 0,
+    },
+  ],
+});
+
 async function appendAccessLog(accessLogPath, method, path) {
   if (!accessLogPath) {
     return;
@@ -120,6 +144,19 @@ async function handleRequest(accessLogPath, request, response) {
   if (method === "POST" && path === "/v1/messages") {
     response.writeHead(200, { "content-type": "application/json" });
     response.end(anthropicSuccessBody);
+    return;
+  }
+
+  // Stability `text-to-image`: the engine id segment is variable
+  // (`StabilityAdapter.hs` hardcodes `stable-diffusion-v1-6` today, but
+  // that constant could change). Match by suffix to stay forward-compat.
+  if (
+    method === "POST" &&
+    path.startsWith("/v1/generation/") &&
+    path.endsWith("/text-to-image")
+  ) {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(stabilitySuccessBody);
     return;
   }
 

--- a/scripts/dev/start_stub_providers.sh
+++ b/scripts/dev/start_stub_providers.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Boots the AI provider stub for local development. The stub
+# (`scripts/ci/e2e_stub_providers.mjs`) is shared with the CI e2e
+# smoke; this launcher wraps it with a developer-friendly env-file
+# write and PID tracking. See `docs/development/local-stub.md`.
+#
+# Usage:
+#   bash scripts/dev/start_stub_providers.sh
+#
+# Env knobs:
+#   VOCAS_STUB_PROVIDERS_PORT  Pin the port (default: auto-pick free).
+#   VOCAS_STUB_LOG_DIR         Override log/PID dir (default: $TMPDIR/vocastock-stub).
+#   VOCAS_STUB_ENV_FILE        Override env-file output (default: $REPO_ROOT/.env.stub).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="${REPO_ROOT}/scripts/ci"
+LOG_DIR="${VOCAS_STUB_LOG_DIR:-${TMPDIR:-/tmp}/vocastock-stub}"
+LOG_FILE="${LOG_DIR}/stub.log"
+ACCESS_LOG="${LOG_DIR}/access.log"
+PID_FILE="${LOG_DIR}/pid"
+ENV_FILE="${VOCAS_STUB_ENV_FILE:-${REPO_ROOT}/.env.stub}"
+
+mkdir -p "$LOG_DIR"
+
+if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  printf "stub already running (pid=%s); run scripts/dev/stop_stub_providers.sh first\n" \
+    "$(cat "$PID_FILE")" >&2
+  exit 1
+fi
+
+PORT_ARG=()
+if [[ -n "${VOCAS_STUB_PROVIDERS_PORT:-}" ]]; then
+  PORT_ARG=(--port "$VOCAS_STUB_PROVIDERS_PORT")
+fi
+
+: > "$LOG_FILE"
+nohup node "$SCRIPT_DIR/e2e_stub_providers.mjs" \
+  "${PORT_ARG[@]}" \
+  --access-log "$ACCESS_LOG" \
+  > "$LOG_FILE" 2>&1 &
+STUB_PID=$!
+disown "$STUB_PID" 2>/dev/null || true
+echo "$STUB_PID" > "$PID_FILE"
+
+DEADLINE=$(( $(date +%s) + 15 ))
+PORT=""
+while (( $(date +%s) < DEADLINE )); do
+  if ! kill -0 "$STUB_PID" 2>/dev/null; then
+    printf "stub exited before binding; see %s\n" "$LOG_FILE" >&2
+    rm -f "$PID_FILE"
+    exit 1
+  fi
+  if grep -Eq '^listening on [0-9]+' "$LOG_FILE" 2>/dev/null; then
+    PORT="$(grep -Eo 'listening on [0-9]+' "$LOG_FILE" | head -n1 | awk '{print $3}')"
+    break
+  fi
+  sleep 0.2
+done
+
+if [[ -z "$PORT" ]]; then
+  printf "stub did not bind within 15s; see %s\n" "$LOG_FILE" >&2
+  kill "$STUB_PID" 2>/dev/null || true
+  rm -f "$PID_FILE"
+  exit 1
+fi
+
+if ! curl -fsS "http://127.0.0.1:${PORT}/readyz" >/dev/null; then
+  printf "stub readiness probe failed at http://127.0.0.1:%s/readyz\n" "$PORT" >&2
+  kill "$STUB_PID" 2>/dev/null || true
+  rm -f "$PID_FILE"
+  exit 1
+fi
+
+cat > "$ENV_FILE" <<EOF
+ANTHROPIC_API_KEY=stub-anthropic-key
+ANTHROPIC_API_BASE_URL=http://host.docker.internal:${PORT}
+STABILITY_API_KEY=stub-stability-key
+STABILITY_API_BASE_URL=http://host.docker.internal:${PORT}
+EOF
+
+cat <<EOF
+stub-providers listening:
+  pid:        ${STUB_PID}
+  port:       ${PORT}
+  log:        ${LOG_FILE}
+  access log: ${ACCESS_LOG}
+  env file:   ${ENV_FILE}
+
+bring up workers:
+  docker compose --env-file ${ENV_FILE} -f docker/applications/compose.yaml up
+
+or source these env vars into your shell:
+  export ANTHROPIC_API_KEY=stub-anthropic-key
+  export ANTHROPIC_API_BASE_URL=http://host.docker.internal:${PORT}
+  export STABILITY_API_KEY=stub-stability-key
+  export STABILITY_API_BASE_URL=http://host.docker.internal:${PORT}
+
+stop with:
+  bash scripts/dev/stop_stub_providers.sh
+  (or: kill ${STUB_PID})
+EOF

--- a/scripts/dev/stop_stub_providers.sh
+++ b/scripts/dev/stop_stub_providers.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Stops the local AI provider stub started by
+# `scripts/dev/start_stub_providers.sh`. Idempotent — silent no-op if
+# no PID file is present or the process is already dead.
+
+set -euo pipefail
+
+LOG_DIR="${VOCAS_STUB_LOG_DIR:-${TMPDIR:-/tmp}/vocastock-stub}"
+PID_FILE="${LOG_DIR}/pid"
+
+if [[ ! -f "$PID_FILE" ]]; then
+  exit 0
+fi
+
+PID="$(cat "$PID_FILE")"
+if ! kill -0 "$PID" 2>/dev/null; then
+  rm -f "$PID_FILE"
+  exit 0
+fi
+
+kill "$PID" 2>/dev/null || true
+DEADLINE=$(( $(date +%s) + 5 ))
+while kill -0 "$PID" 2>/dev/null; do
+  if (( $(date +%s) >= DEADLINE )); then
+    kill -9 "$PID" 2>/dev/null || true
+    break
+  fi
+  sleep 0.2
+done
+
+rm -f "$PID_FILE"
+printf "stopped stub-providers (pid=%s)\n" "$PID"


### PR DESCRIPTION
## Summary

Lets a developer run the backend locally without paid Anthropic / Stability API keys. Adds a Stability endpoint to the existing CI stub plus a developer-facing launcher.

The intended flow:
\`\`\`bash
bash scripts/firebase/start_emulators.sh    # terminal 1
bash scripts/dev/start_stub_providers.sh    # terminal 2 — writes .env.stub
docker compose --env-file .env.stub -f docker/applications/compose.yaml up
\`\`\`

## Changes

| File | Change |
| --- | --- |
| \`scripts/ci/e2e_stub_providers.mjs\` | Add \`POST /v1/generation/{engineId}/text-to-image\` returning a 1×1 transparent PNG in \`artifacts[0].base64\`. Path-suffix match (not hardcoded engine id) so it survives \`STABILITY_ENGINE_ID\` changes. Header comment documents dual CI + local use. |
| \`scripts/dev/start_stub_providers.sh\` | Backgrounds the existing stub, polls for the \`listening on <port>\` line (15s deadline, same shape as \`run_e2e_round_trip_smoke.sh\`), hits \`/readyz\`, writes \`.env.stub\`. PID-file guard refuses re-launch. Env knobs: \`VOCAS_STUB_PROVIDERS_PORT\`, \`VOCAS_STUB_LOG_DIR\`, \`VOCAS_STUB_ENV_FILE\`. |
| \`scripts/dev/stop_stub_providers.sh\` | SIGTERM (then SIGKILL after 5s), removes PID file. Idempotent. |
| \`docs/development/local-stub.md\` | Quick-start, customisation, verification, limitations, CI cross-reference. |
| \`.gitignore\` | \`.env.stub\` (per-run state, port differs each launch). |

## CI compatibility

The augmentation is purely additive:
- Existing \`POST /v1/messages\` and \`GET /readyz\` routes untouched.
- \`^listening on <port>$\` log format byte-for-byte identical (\`run_e2e_round_trip_smoke.sh:236\` greps for it).
- \`scripts/ci/run_e2e_round_trip_smoke.sh:255\` already exports \`STABILITY_API_BASE_URL\` to the stub port, so adding the Stability endpoint plugs an existing latent gap (Stability calls during CI silently went from 404 to 200 with a real PNG).
- No CI workflow / compose change needed.

## Verification

Locally verified:

\`\`\`bash
$ printf 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAeImBZsAAAAASUVORK5CYII=' | base64 --decode | file -
/dev/stdin: PNG image data, 1 x 1, 8-bit gray+alpha, non-interlaced

$ bash scripts/dev/start_stub_providers.sh
stub-providers listening:
  pid:        63089
  port:       54441
  ...

$ curl -fsS "http://127.0.0.1:54441/readyz"
OK

$ curl -fsS -X POST "http://127.0.0.1:54441/v1/messages" ... | head -c 200
{\"id\":\"msg_e2e_round_trip\",\"content\":[{\"type\":\"text\",\"text\":\"{\"summary\":\"E2E smoke explanation\",...

$ curl -fsS -X POST "http://127.0.0.1:54441/v1/generation/stable-diffusion-v1-6/text-to-image" ... | jq -r '.artifacts[0].base64' | base64 --decode | file -
/dev/stdin: PNG image data, 1 x 1, 8-bit gray+alpha, non-interlaced

$ bash scripts/dev/start_stub_providers.sh
stub already running (pid=63089); run scripts/dev/stop_stub_providers.sh first

$ bash scripts/dev/stop_stub_providers.sh
stopped stub-providers (pid=63089)

$ bash scripts/dev/stop_stub_providers.sh
$ # idempotent — silent
\`\`\`

## Out of scope

- OpenAI mocking (no adapter exists in workers).
- Prompt-driven response variance / latency simulation / error injection.
- Compose-overlay / containerised stub.
- One-command full-stack launcher.

## Test plan

- [x] PNG base64 decodes to a valid 1×1 PNG (verified via \`file -\`).
- [x] start / stop / re-launch guards work locally.
- [x] All 3 endpoints respond as expected.
- [x] Existing CI smoke (\`scripts/ci/run_e2e_round_trip_smoke.sh\`) untouched at the call-site level.
- [ ] CI green